### PR TITLE
CI: Make CircleCI run the program

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: gcc:latest
     steps:
       - checkout
-      - run: (cd src; make -j)
+      - run: (cd src; make -j && ../bin/iseeaparse)
 workflows:
   version: 2.1
   build:


### PR DESCRIPTION
Since the program returns a failure exit code when it fails to parse,
it should work as a rudimentary test.

Now CI will fail if the parser fails to parse the sample code :^)

(lo que dice arriba)