### PR TITLE
return a failure exit state when we fail to parse

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ int main() {
 	auto parse_result = p.parse_top_level();
 	if (not parse_result.ok()) {
 		parse_result.m_error.print();
+		return 1;
 	} else {
 		parse_result.m_result->print();
 	}


### PR DESCRIPTION
Me había faltado esto antes. Ahora circleCI nos va a avisar si el código de ejemplo no parsea.

La misma idea puede aplicar a runtime errors, etc en el futuro.