### PR TITLE
Parser speedup

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -108,10 +108,12 @@ Writer<std::unique_ptr<AST>> Parser::parse_declaration() {
 
 	Writer<Token const*> type;
 
-	if (handle_error(result, require(token_type::DECLARE_ASSIGN))) {
+	auto p0 = peek();
 
-		if (handle_error(result, require(token_type::DECLARE)))
-			return result;
+	if (p0->m_type == token_type::DECLARE_ASSIGN) {
+		m_lexer->advance();
+	} else if (p0->m_type == token_type::DECLARE) {
+		m_lexer->advance();
 
 		type = require(token_type::IDENTIFIER);
 		if (handle_error(result, type))
@@ -119,6 +121,9 @@ Writer<std::unique_ptr<AST>> Parser::parse_declaration() {
 
 		if (handle_error(result, require(token_type::ASSIGN)))
 			return result;
+	} else {
+		result.m_error.m_sub_errors.push_back(
+		    make_expected_error("':' or ':='", p0));
 	}
 
 	auto value = parse_expression();


### PR DESCRIPTION
un pequeño retoque en `parse_declaration` nos da un speedup de ~4.5%

Mi metodología de benchmark (correr el parser 10k veces sobre el mismo código de 30 líneas) no fue super limpia, pero es suficiente para que quede claro que ahora es más rápido.

Esto es lo que medi:
```
Before:

real    0m5,035s
user    0m4,870s
sys     0m0,164s

real    0m5,014s
user    0m4,845s
sys     0m0,168s

real    0m5,042s
user    0m4,865s
sys     0m0,176s

avg. real 5.030s

After:

real    0m4,808s
user    0m4,644s
sys     0m0,164s

real    0m4,780s
user    0m4,640s
sys     0m0,140s

real    0m4,822s
user    0m4,682s
sys     0m0,140s

avg. real 4.803s

4.51% runtime decrease
```

PS: tire un ```AST::print``` del input entero antes y después del cambio y me dio exactamente lo mismo. estoy 99.9% seguro que es equivalente.