### PR TITLE
CI: build and run on separate steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,18 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 jobs:
-  build_gcc_latest:
+  build_and_run_gcc_latest:
     docker:
       - image: gcc:latest
     steps:
       - checkout
-      - run: (cd src; make -j && ../bin/iseeaparse)
+      - run:
+          name: Build
+          command: make -C ./src -j
+      - run:
+          name: Run
+          command: ./bin/iseeaparse
 workflows:
   version: 2.1
-  build:
+  build_and_run:
     jobs:
-      - build_gcc_latest
+      - build_and_run_gcc_latest


### PR DESCRIPTION
Estuve leyendo un poco la documentación de circleCI y encontré que dentro de un `job` se ponen los `steps` que se tienen que realizar secuencialmente en la misma máquina.

Básicamente puse eso en practica.

Medio una verga que no te diga cual step es el que falla directo en github pero por lo menos ya no hay que leer el build log para ver si es que no compila o si está mal en cuanto a funcionalidad. (UPDATE: Acabo de activar el github checks de circleci en este repo pero por ahora no hace nada)