### PR TITLE
Bugfix function call

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -26,16 +26,20 @@ Value* Scope::access(const Identifier& i) {
 
 
 
+Scope* Environment::new_nested_scope() {
+	m_scope = new Scope{m_scope, m_scope};
+	return m_scope;
+}
+
 Scope* Environment::new_scope() {
-	Scope* parent = m_scope;
-	m_scope = new Scope(parent);
+	m_scope = new Scope{m_global_scope, m_scope};
 	return m_scope;
 }
 
 void Environment::end_scope() {
-	Scope* parent = m_scope->m_parent;
+	Scope* prev = m_scope->m_prev;
 	delete m_scope;
-	m_scope = parent;
+	m_scope = prev;
 }
 
 void Environment::save_return_value(Type::Value* v) {

--- a/src/environment.hpp
+++ b/src/environment.hpp
@@ -13,10 +13,8 @@ namespace Type {
 
 struct Scope {
 	Scope* m_parent {nullptr};
+	Scope* m_prev {nullptr};
 	ObjectType m_declarations;
-
-	Scope() = default;
-	Scope(Scope* parent) : m_parent(parent) {}
 
 	void declare(const Identifier& i, Value* v);
 	Value* access(const Identifier& i);
@@ -25,9 +23,11 @@ struct Scope {
 struct Environment {
 	GarbageCollector::GC* m_gc;
 	Scope* m_scope;
+	Scope* m_global_scope;
 	Value* m_return_value {nullptr};
 
 	Scope* new_scope();
+	Scope* new_nested_scope();
 	void end_scope();
 
 	void save_return_value(Type::Value*);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -89,7 +89,7 @@ Type::Value* eval(ASTIdentifier* ast, Type::Environment& e) {
 
 Type::Value* eval(ASTBlock* ast, Type::Environment& e) {
 
-	e.new_scope();
+	e.new_nested_scope();
 
 	for(auto &stmt : ast->m_body){
 		eval(stmt.get(), e);
@@ -197,9 +197,11 @@ Type::Value* eval(ASTIndexExpression* ast, Type::Environment& e) {
 	// TODO: proper error handling
 
 	auto* callee = eval(ast->m_callee.get(), e);
+	assert(callee);
 	assert(callee->type() == value_type::List);
 
 	auto* index = eval(ast->m_index.get(), e);
+	assert(index);
 	assert(index->type() == value_type::Integer);
 
 	auto* array_callee = static_cast<Type::List*>(callee);

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -23,7 +23,7 @@ int execute(std::string const& source, bool dump_ast, Runner* runner) {
 
 	GarbageCollector::GC gc;
 	Type::Scope scope;
-	Type::Environment env = { &gc, &scope };
+	Type::Environment env = { &gc, &scope, &scope};
 
 	auto* top_level = parse_result.m_result.get();
 	if (top_level->type() != ast_type::DeclarationList)


### PR DESCRIPTION
El bug que mencione ayer era que si tenias una variable llamada `x`, e intentas llamar a una función que tiene un argumento llamado `x`, dependiendo del orden de los argumentos, los otros valores que pasas que mencionan la variable `x` terminan apuntando al argumento `x`.

Ejemplo:
```rust
f := fn(x,y){
  return y
};
g := fn(){
  x := 20;
  return f(10, x+1); // devuelve 11, en vez de 21
};
```
-----------

Otro bug:

Como todos los scopes que se creaban apuntaban al anterior como padre, terminaba pasando que podrás capturar cosas que venían del call stack del caller.
Este comportamiento es interesante, es macro-like, lo cual puede ser algo que queramos implementar como feature eventualmente.
```rust
g := fn(){
  return fn() => x;
}
f := fn(){
  x := 5;
  a := g();
  return a(); // devuelve 5, en vez de ser un error
};
```

--------------

Aparte, implemente `<`, porque querie codear un BST y me hacia falta.