### PR TITLE
Lexer: consume line comments

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -177,6 +177,9 @@ void Lexer::consume_token() {
 
 	case '/':
 		switch (next_char()) {
+		case '/':
+			assert(consume_comment());
+			break;
 		case '=':
 			push_token(token_type::DIV_TO, 2);
 			break;
@@ -421,6 +424,31 @@ void Lexer::consume_token() {
 			m_source_index += 1;
 		}
 	}
+}
+
+bool Lexer::consume_comment () {
+	if(current_char() != '/')
+		return false;
+	m_source_index += 1;
+	m_current_column += 1;
+
+	if(current_char() != '/') 
+		return false;
+	m_source_index += 1;
+	m_current_column += 1;
+
+	while ((not done()) && current_char() != '\n') {
+		m_source_index += 1;
+		m_current_column += 1;
+	}
+
+	if(current_char() == '\n'){
+		m_source_index += 1;
+		m_current_line += 1;
+		m_current_column = 0;
+	}
+
+	return true;
 }
 
 void Lexer::advance() {

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -30,6 +30,7 @@ struct Lexer {
 
 	bool done() { return current_char() == '\0'; }
 
+	bool consume_comment();
 	void consume_token();
 	bool consume_keyword();
 	void push_token(token_type, int);


### PR DESCRIPTION
> We just detect and ignore comments. I have considered preserving
comments throughout the interpreter, for better debugging capabilities
but it seems like too much of a hassle for little gain.

Bueno, eso. Agrega comentarios de linea