### PR TITLE
[WIP] Add a simpler variant of the AST for easier type checking and eval

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,6 +15,7 @@ OBJNAMES := \
 	match_identifiers.o \
 	parser.o \
 	parse.o \
+	simple_ast.o \
 	string_view.o \
 	tester.o \
 	token.o \

--- a/src/simple_ast.cpp
+++ b/src/simple_ast.cpp
@@ -1,0 +1,3 @@
+#include "simple_ast.hpp"
+
+

--- a/src/simple_ast.hpp
+++ b/src/simple_ast.hpp
@@ -10,6 +10,7 @@ enum class rtast_type {
 	FunctionCall,
 	ConstructorCall,
 	Sequence,
+	Return,
 
 	IntegerLiteral,
 	RealLiteral,
@@ -90,6 +91,11 @@ struct FunctionLiteral final : public RTAST {
 struct Sequence final : public RTAST {
 	std::vector<std::unique_ptr<RTAST>> m_values;
 	Sequence() : RTAST { rtast_type::Sequence } {}
+};
+
+struct Return final : public RTAST {
+	std::unique_ptr<RTAST> m_value;
+	Return() : RTAST { rtast_type::Return } {}
 };
 
 }

--- a/src/simple_ast.hpp
+++ b/src/simple_ast.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace RTAST {
+
+enum class rtast_type {
+	FunctionCall,
+	ConstructorCall,
+	Sequence,
+
+	NumberLiteral,
+	StringLiteral,
+	FunctionLiteral,
+
+	LetBlock, // TODO: is this really needed?
+	RecBlock,
+};
+
+struct RTAST {
+	int m_monotype;
+};
+
+struct MonomorphicDeclaration {
+	std::string m_name;
+	std::unique_ptr<RTAST> m_value;
+	int m_monotype;
+};
+
+struct PolymorphicDeclaration {
+	std::string m_name;
+	std::unique_ptr<RTAST> m_value;
+	int m_polytype;
+};
+
+struct RecBlock final : public RTAST {
+	std::vector<MonomorphicDeclaration> m_declaration_block;
+	std::unique_ptr<RTAST> m_in_block;
+};
+
+struct LetBlock final : public RTAST {
+	MonomorphicDeclaration m_declaration_block;
+	std::unique_ptr<RTAST> m_in_block;
+};
+
+struct FunctionCall final : public RTAST {
+	std::unique_ptr<RTAST> m_callee;
+};
+
+struct ConstructorCall final : public RTAST {
+	int m_monotype_callee;
+	std::vector<std::unique_ptr<RTAST>> m_callee;
+};
+
+struct RealLiteral final : public RTAST {
+	double m_value;
+};
+
+struct IntegerLiteral final : public RTAST {
+	int m_value;
+};
+
+struct StringLiteral final : public RTAST {
+	std::string m_value;
+};
+
+struct FunctionLiteral final : public RTAST {
+	std::vector<MonomorphicDeclaration> m_arguments;
+	std::unique_ptr<RTAST> m_body;
+};
+
+}

--- a/src/simple_ast.hpp
+++ b/src/simple_ast.hpp
@@ -20,6 +20,9 @@ enum class rtast_type {
 };
 
 struct RTAST {
+	rtast_type m_type;
+
+	// Everything is an expression, so everything has a monotype
 	int m_monotype;
 };
 
@@ -41,7 +44,7 @@ struct RecBlock final : public RTAST {
 };
 
 struct LetBlock final : public RTAST {
-	MonomorphicDeclaration m_declaration_block;
+	PolymorphicDeclaration m_declaration_block;
 	std::unique_ptr<RTAST> m_in_block;
 };
 
@@ -50,7 +53,9 @@ struct FunctionCall final : public RTAST {
 };
 
 struct ConstructorCall final : public RTAST {
+	// TODO: what if we are not given a fully instanced type?
 	int m_monotype_callee;
+
 	std::vector<std::unique_ptr<RTAST>> m_callee;
 };
 
@@ -69,6 +74,10 @@ struct StringLiteral final : public RTAST {
 struct FunctionLiteral final : public RTAST {
 	std::vector<MonomorphicDeclaration> m_arguments;
 	std::unique_ptr<RTAST> m_body;
+};
+
+struct Sequence final : public RTAST {
+	std::vector<std::unique_ptr<RTAST>> m_values;
 };
 
 }

--- a/src/simple_ast.hpp
+++ b/src/simple_ast.hpp
@@ -11,7 +11,8 @@ enum class rtast_type {
 	ConstructorCall,
 	Sequence,
 
-	NumberLiteral,
+	IntegerLiteral,
+	RealLiteral,
 	StringLiteral,
 	FunctionLiteral,
 
@@ -24,6 +25,8 @@ struct RTAST {
 
 	// Everything is an expression, so everything has a monotype
 	int m_monotype;
+
+	RTAST(rtast_type type) : m_type { type } {}
 };
 
 struct MonomorphicDeclaration {
@@ -41,15 +44,18 @@ struct PolymorphicDeclaration {
 struct RecBlock final : public RTAST {
 	std::vector<MonomorphicDeclaration> m_declaration_block;
 	std::unique_ptr<RTAST> m_in_block;
+	RecBlock() : RTAST { rtast_type::RecBlock } {}
 };
 
 struct LetBlock final : public RTAST {
 	PolymorphicDeclaration m_declaration_block;
 	std::unique_ptr<RTAST> m_in_block;
+	LetBlock() : RTAST { rtast_type::LetBlock } {}
 };
 
 struct FunctionCall final : public RTAST {
 	std::unique_ptr<RTAST> m_callee;
+	FunctionCall() : RTAST { rtast_type::FunctionCall } {}
 };
 
 struct ConstructorCall final : public RTAST {
@@ -57,27 +63,33 @@ struct ConstructorCall final : public RTAST {
 	int m_monotype_callee;
 
 	std::vector<std::unique_ptr<RTAST>> m_callee;
+	ConstructorCall() : RTAST { rtast_type::ConstructorCall } {}
 };
 
 struct RealLiteral final : public RTAST {
 	double m_value;
+	RealLiteral() : RTAST { rtast_type::RealLiteral } {}
 };
 
 struct IntegerLiteral final : public RTAST {
 	int m_value;
+	IntegerLiteral() : RTAST { rtast_type::IntegerLiteral } {}
 };
 
 struct StringLiteral final : public RTAST {
 	std::string m_value;
+	StringLiteral() : RTAST { rtast_type::StringLiteral } {}
 };
 
 struct FunctionLiteral final : public RTAST {
 	std::vector<MonomorphicDeclaration> m_arguments;
 	std::unique_ptr<RTAST> m_body;
+	FunctionLiteral() : RTAST { rtast_type::FunctionLiteral } {}
 };
 
 struct Sequence final : public RTAST {
 	std::vector<std::unique_ptr<RTAST>> m_values;
+	Sequence() : RTAST { rtast_type::Sequence } {}
 };
 
 }


### PR DESCRIPTION
Esto de alejarse de un proyecto por un tiempo y después volver realmente te deja ver todo mas claramente.

Creo que el objetivo que deberíamos perseguir es reemplazar `TypedAST` con esto. Es mucho más chico y solo tiene cosas esenciales, todo lo demás se puede hacer con funciones nativas.

No se si va a tener sentido mergear este PR eventualmente (probably no), pero quiero ponerlo aca para poder charlar si le falta o le sobra algo.

La idea es tener una versión del AST que se parezca más al cálculo lambda de Hindley-Milner, asi es mas facil de tipar. Aparte, con este diseño, moveriamos la implementación de for, if, etc. a funciones nativas, y no haría falta tener que manejarlos especialmente en el type checker, y en eval.

E:

me olvide de poner un nodo para eso pero una `Sequence` es simplemente una secuencia de expresiones, que se evalúan en orden. Básicamente modela los bloques de código (`{ if(x) return y; z = z + 1; f(); }`).