### PR TITLE
Clean up `execute`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,6 +6,7 @@ OBJDIR := ../build
 OBJNAMES := \
 	ast.o \
 	captures.o \
+	compile_time_environment.o \
 	desugar.o \
 	environment.o \
 	error.o \

--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -1,0 +1,70 @@
+#include "compile_time_environment.hpp"
+
+#include "typed_ast.hpp"
+
+namespace Frontend {
+
+CompileTimeEnvironment::CompileTimeEnvironment() {
+	// TODO: put this in a better place
+	// HACK: this is an ugly hack. bear with me...
+	TypedAST::Declaration dummy;
+	declare("size", &dummy);
+	declare("print", &dummy);
+	declare("array_append", &dummy);
+	declare("array_extend", &dummy);
+	declare("array_join", &dummy);
+
+	declare("+", &dummy);
+	declare("-", &dummy);
+	declare("*", &dummy);
+	declare("/", &dummy);
+	declare("<", &dummy);
+	declare("=", &dummy);
+	declare("==", &dummy);
+	declare(".", &dummy);
+};
+
+Scope& CompileTimeEnvironment::current_scope() {
+	if (m_scopes.empty())
+		return m_global_scope;
+	else
+		return m_scopes.back();
+}
+
+void CompileTimeEnvironment::declare(std::string const& name, TypedAST::Declaration* decl) {
+	current_scope().m_vars[name] = decl;
+}
+
+TypedAST::Declaration* CompileTimeEnvironment::access(std::string const& name) {
+	auto scan_scope
+	    = [](Scope& scope, std::string const& name) -> TypedAST::Declaration* {
+		auto it = scope.m_vars.find(name);
+		if (it != scope.m_vars.end())
+			return it->second;
+		return nullptr;
+	};
+
+	// scan nested scopes from the inside out
+	for(int i = m_scopes.size(); i--;){
+		auto ptr = scan_scope(m_scopes[i], name);
+		if (ptr) return ptr;
+		if (!m_scopes[i].m_nested) break;
+	}
+
+	// fall back to global scope lookup
+	return scan_scope(m_global_scope, name);
+}
+
+void CompileTimeEnvironment::new_scope() {
+	m_scopes.push_back({ false });
+}
+
+void CompileTimeEnvironment::new_nested_scope() {
+	m_scopes.push_back({ true });
+}
+
+void CompileTimeEnvironment::end_scope() {
+	m_scopes.pop_back();
+}
+
+} // namespace Frontend

--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -25,10 +25,7 @@ CompileTimeEnvironment::CompileTimeEnvironment() {
 };
 
 Scope& CompileTimeEnvironment::current_scope() {
-	if (m_scopes.empty())
-		return m_global_scope;
-	else
-		return m_scopes.back();
+	return m_scopes.empty() ? m_global_scope : m_scopes.back();
 }
 
 void CompileTimeEnvironment::declare(std::string const& name, TypedAST::Declaration* decl) {

--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace TypedAST {
+
+struct Declaration;
+
+}
+
+namespace Frontend {
+
+struct Scope {
+	bool m_nested { false };
+	std::unordered_map<std::string, TypedAST::Declaration*> m_vars;
+};
+
+struct CompileTimeEnvironment {
+	Scope m_global_scope;
+	std::vector<Scope> m_scopes;
+
+	CompileTimeEnvironment();
+
+	Scope& current_scope();
+
+	void declare(std::string const&, TypedAST::Declaration*);
+	TypedAST::Declaration* access(std::string const&);
+
+	void new_scope();
+	void new_nested_scope();
+	void end_scope();
+};
+
+} // namespace Frontend

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -34,7 +34,7 @@ Scope* Environment::new_nested_scope() {
 }
 
 Scope* Environment::new_scope() {
-	m_scope = new Scope{m_global_scope, m_scope};
+	m_scope = new Scope{&m_global_scope, m_scope};
 	return m_scope;
 }
 

--- a/src/environment.hpp
+++ b/src/environment.hpp
@@ -23,9 +23,13 @@ struct Scope {
 
 struct Environment {
 	GarbageCollector::GC* m_gc;
+	Scope m_global_scope;
+
 	Scope* m_scope;
-	Scope* m_global_scope;
 	Value* m_return_value {nullptr};
+
+	Environment(GarbageCollector::GC* gc)
+	    : m_gc { gc }, m_scope { &m_global_scope } {}
 
 	Scope* new_scope();
 	Scope* new_nested_scope();

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -1,6 +1,7 @@
 #include "execute.hpp"
 
 #include "captures.hpp"
+#include "compile_time_environment.hpp"
 #include "desugar.hpp"
 #include "environment.hpp"
 #include "eval.hpp"
@@ -32,7 +33,9 @@ exit_status_type execute(std::string const& source, bool dump_ast, Runner* runne
 
 	auto desugared_ast = AST::desugar(std::move(top_level_ast));
 	auto top_level = TypedAST::get_unique(desugared_ast);
-	TypeChecker::match_identifiers(top_level.get());
+	Frontend::CompileTimeEnvironment ct_env;
+
+	TypeChecker::match_identifiers(top_level.get(), ct_env);
 	gather_captures(top_level.get());
 
 	GarbageCollector::GC gc;

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -36,8 +36,7 @@ exit_status_type execute(std::string const& source, bool dump_ast, Runner* runne
 	gather_captures(top_level.get());
 
 	GarbageCollector::GC gc;
-	Type::Scope scope;
-	Type::Environment env = { &gc, &scope, &scope };
+	Type::Environment env = { &gc };
 	declare_native_functions(env);
 	eval(top_level.get(), env);
 

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -3,214 +3,105 @@
 #include <unordered_map>
 
 #include "typed_ast.hpp"
+#include "compile_time_environment.hpp"
 
 #include <cassert>
 
 namespace TypeChecker {
 
-struct Scope {
-	bool m_nested { false };
-	std::unordered_map<std::string, TypedAST::Declaration*> m_vars;
-};
-
-struct FakeEnvironment {
-	std::vector<Scope> m_scopes;
-
-	FakeEnvironment();
-
-	void new_scope();
-	void new_nested_scope();
-	void end_scope();
-
-	void declare_name(std::string const&, TypedAST::Declaration*);
-	TypedAST::Declaration* access_name(std::string const&);
-
-	void match_identifiers(TypedAST::TypedAST*);
-	void match_identifiers(TypedAST::Declaration*);
-	void match_identifiers(TypedAST::Identifier*);
-	void match_identifiers(TypedAST::Block* ast);
-	void match_identifiers(TypedAST::IfStatement* ast);
-	void match_identifiers(TypedAST::ForStatement* ast);
-	void match_identifiers(TypedAST::FunctionLiteral* ast);
-	void match_identifiers(TypedAST::CallExpression* ast);
-	void match_identifiers(TypedAST::ReturnStatement* ast);
-	void match_identifiers(TypedAST::IndexExpression* ast);
-	void match_identifiers(TypedAST::DeclarationList* ast);
-};
-
-void match_identifiers(TypedAST::TypedAST* ast) {
-	FakeEnvironment env;
-
-	// TODO: put this in a better place
-	// HACK: this is an ugly hack. bear with me...
-	TypedAST::Declaration dummy;
-
-	env.declare_name("size", &dummy);
-	env.declare_name("print", &dummy);
-	env.declare_name("array_append", &dummy);
-	env.declare_name("array_extend", &dummy);
-	env.declare_name("array_join", &dummy);
-
-	env.declare_name("+", &dummy);
-	env.declare_name("-", &dummy);
-	env.declare_name("*", &dummy);
-	env.declare_name("/", &dummy);
-	env.declare_name("<", &dummy);
-	env.declare_name("=", &dummy);
-	env.declare_name("==", &dummy);
-	env.declare_name(".", &dummy);
-	
-	return env.match_identifiers(ast);
-}
-
-FakeEnvironment::FakeEnvironment() {
-	m_scopes.push_back({ false });
-}
-
-TypedAST::Declaration* FakeEnvironment::access_name(std::string const& name) {
-	auto scan_scope
-	    = [](Scope& scope, std::string const& name) -> TypedAST::Declaration* {
-		auto it = scope.m_vars.find(name);
-		if (it != scope.m_vars.end())
-			return it->second;
-		return nullptr;
-	};
-
-	// iterate until we are no longer nested, excluding the global scope
-	for (int i = m_scopes.size() - 1; i > 0; --i) {
-		auto ptr = scan_scope(m_scopes[i], name);
-		if (ptr)
-			return ptr;
-
-		// break if we are not nested
-		if (!m_scopes[i].m_nested)
-			break;
-	}
-
-	// now scan the global scope
-	auto ptr = scan_scope(m_scopes[0], name);
-	if (ptr)
-		return ptr;
-
-	return nullptr;
-}
-
-void FakeEnvironment::declare_name(std::string const& name, TypedAST::Declaration* decl) {
-	auto& scope = m_scopes.back();
-	scope.m_vars[name] = decl;
-}
-
-void FakeEnvironment::new_scope() {
-	m_scopes.push_back({ false });
-}
-
-void FakeEnvironment::new_nested_scope() {
-	m_scopes.push_back({ true });
-}
-
-void FakeEnvironment::end_scope() {
-	m_scopes.pop_back();
-}
-
-void FakeEnvironment::match_identifiers(TypedAST::Declaration* ast) {
-	declare_name(ast->identifier_text(), ast);
+void match_identifiers(TypedAST::Declaration* ast, Frontend::CompileTimeEnvironment& env) {
+	env.declare(ast->identifier_text(), ast);
 	if (ast->m_value) {
-		match_identifiers(ast->m_value.get());
+		match_identifiers(ast->m_value.get(), env);
 	}
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::Identifier* ast) {
-	TypedAST::Declaration* declaration = access_name(ast->text());
+void match_identifiers(TypedAST::Identifier* ast, Frontend::CompileTimeEnvironment& env) {
+	TypedAST::Declaration* declaration = env.access(ast->text());
 	assert(declaration);
 	ast->m_declaration = declaration;
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::Block* ast) {
-	new_nested_scope();
+void match_identifiers(TypedAST::Block* ast, Frontend::CompileTimeEnvironment& env) {
+	env.new_nested_scope();
 	for (auto& child : ast->m_body)
-		match_identifiers(child.get());
-	end_scope();
+		match_identifiers(child.get(), env);
+	env.end_scope();
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::IfStatement* ast) {
-	match_identifiers(ast->m_condition.get());
-	match_identifiers(ast->m_body.get());
+void match_identifiers(TypedAST::IfStatement* ast, Frontend::CompileTimeEnvironment& env) {
+	match_identifiers(ast->m_condition.get(), env);
+	match_identifiers(ast->m_body.get(), env);
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::CallExpression* ast) {
-	match_identifiers(ast->m_callee.get());
+void match_identifiers(TypedAST::CallExpression* ast, Frontend::CompileTimeEnvironment& env) {
+	match_identifiers(ast->m_callee.get(), env);
 	for (auto& arg : ast->m_args)
-		match_identifiers(arg.get());
+		match_identifiers(arg.get(), env);
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::FunctionLiteral* ast) {
+void match_identifiers(TypedAST::FunctionLiteral* ast, Frontend::CompileTimeEnvironment& env) {
 	// TODO: captures
-	new_nested_scope();
+	env.new_nested_scope();
 	// declare arguments
 	for (auto& decl : ast->m_args)
-		match_identifiers(decl.get());
+		match_identifiers(decl.get(), env);
 	// scan body
 	assert(ast->m_body->type() == ast_type::Block);
 	auto body = static_cast<TypedAST::Block*>(ast->m_body.get());
 	for (auto& child : body->m_body)
-		match_identifiers(child.get());
-	end_scope();
+		match_identifiers(child.get(), env);
+	env.end_scope();
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::ForStatement* ast) {
-	new_nested_scope();
-	match_identifiers(ast->m_declaration.get());
-	match_identifiers(ast->m_condition.get());
-	match_identifiers(ast->m_action.get());
-	match_identifiers(ast->m_body.get());
-	end_scope();
+void match_identifiers(TypedAST::ForStatement* ast, Frontend::CompileTimeEnvironment& env) {
+	env.new_nested_scope();
+	match_identifiers(ast->m_declaration.get(), env);
+	match_identifiers(ast->m_condition.get(), env);
+	match_identifiers(ast->m_action.get(), env);
+	match_identifiers(ast->m_body.get(), env);
+	env.end_scope();
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::ReturnStatement* ast) {
-	match_identifiers(ast->m_value.get());
+void match_identifiers(TypedAST::ReturnStatement* ast, Frontend::CompileTimeEnvironment& env) {
+	match_identifiers(ast->m_value.get(), env);
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::IndexExpression* ast) {
-	match_identifiers(ast->m_callee.get());
-	match_identifiers(ast->m_index.get());
+void match_identifiers(TypedAST::IndexExpression* ast, Frontend::CompileTimeEnvironment& env) {
+	match_identifiers(ast->m_callee.get(), env);
+	match_identifiers(ast->m_index.get(), env);
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::DeclarationList* ast) {
+void match_identifiers(TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment& env) {
 	for (auto& decl : ast->m_declarations) {
 		auto d = static_cast<TypedAST::Declaration*>(decl.get());
-		declare_name(d->identifier_text(), d);
+		env.declare(d->identifier_text(), d);
 	}
 
 	for (auto& decl : ast->m_declarations) {
 		auto d = static_cast<TypedAST::Declaration*>(decl.get());
 		if (d->m_value)
-			match_identifiers(d->m_value.get());
+			match_identifiers(d->m_value.get(), env);
 	}
 }
 
-void FakeEnvironment::match_identifiers(TypedAST::TypedAST* ast) {
+void match_identifiers(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment& env) {
+#define DISPATCH(type)                                                         \
+	case ast_type::type:                                                       \
+		return match_identifiers(static_cast<TypedAST::type*>(ast), env);
+
 	// TODO: Compound literals
 	switch (ast->type()) {
-	case ast_type::Declaration:
-		return match_identifiers(static_cast<TypedAST::Declaration*>(ast));
-	case ast_type::Identifier:
-		return match_identifiers(static_cast<TypedAST::Identifier*>(ast));
-	case ast_type::Block:
-		return match_identifiers(static_cast<TypedAST::Block*>(ast));
-	case ast_type::ForStatement:
-		return match_identifiers(static_cast<TypedAST::ForStatement*>(ast));
-	case ast_type::IfStatement:
-		return match_identifiers(static_cast<TypedAST::IfStatement*>(ast));
-	case ast_type::FunctionLiteral:
-		return match_identifiers(static_cast<TypedAST::FunctionLiteral*>(ast));
-	case ast_type::CallExpression:
-		return match_identifiers(static_cast<TypedAST::CallExpression*>(ast));
-	case ast_type::ReturnStatement:
-		return match_identifiers(static_cast<TypedAST::ReturnStatement*>(ast));
-	case ast_type::IndexExpression:
-		return match_identifiers(static_cast<TypedAST::IndexExpression*>(ast));
-	case ast_type::DeclarationList:
-		return match_identifiers(static_cast<TypedAST::DeclarationList*>(ast));
+		DISPATCH(Declaration);
+		DISPATCH(Identifier);
+		DISPATCH(Block);
+		DISPATCH(ForStatement);
+		DISPATCH(IfStatement);
+		DISPATCH(FunctionLiteral);
+		DISPATCH(CallExpression);
+		DISPATCH(ReturnStatement);
+		DISPATCH(IndexExpression);
+		DISPATCH(DeclarationList);
 	case ast_type::BinaryExpression:
 		assert(0);
 	case ast_type::StringLiteral:
@@ -219,6 +110,8 @@ void FakeEnvironment::match_identifiers(TypedAST::TypedAST* ast) {
 	case ast_type::BooleanLiteral:
 		return;
 	}
+
+#undef DISPATCH
 }
 
 } // namespace TypeChecker

--- a/src/match_identifiers.hpp
+++ b/src/match_identifiers.hpp
@@ -3,8 +3,12 @@ namespace TypedAST {
 struct TypedAST;
 }
 
+namespace Frontend {
+struct CompileTimeEnvironment;
+}
+
 namespace TypeChecker {
 
-void match_identifiers(TypedAST::TypedAST* ast);
+void match_identifiers(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment&);
 
 }


### PR DESCRIPTION
La función `execute` fue quedando iterativamente más fea. Me gustaría emprolijarla un poco.

El ideal seria que tenga esta pinta (pseudo codigo):

```cpp
ExitStatus execute (std::string const& source, Runner* runner) {
    AST raw_ast = parse_program(source);
    AST clean_ast = desugar(std::move(raw_ast));

    CompileTimeEnvironment ct_env;
    TypedAST typed_ast = ct_eval(clean_ast, ct_env);

    RuntimeTimeEnvironment rt_env;
    rt_eval(typed_ast, rt_env);

    ExitStatus runner_exit_code = runner(rt_env);
    return runner_exit_code;
}
```