### PR TITLE
Put the interpreter in namespace Interpreter

### DIFF
--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -4,7 +4,7 @@
 
 #include "garbage_collector.hpp"
 
-namespace Type {
+namespace Interpreter {
 
 void Scope::declare(const Identifier& i, Reference* v) {
 	// TODO: check name collision
@@ -16,7 +16,7 @@ Reference* Scope::access(const Identifier& i) {
 
 	if (v != m_declarations.end()){
 		assert(v->second->type() == value_type::Reference);
-		return static_cast<Type::Reference*>(v->second);
+		return static_cast<Reference*>(v->second);
 	}
 
 	if (m_parent != nullptr)
@@ -44,7 +44,7 @@ void Environment::end_scope() {
 	m_scope = prev;
 }
 
-void Environment::save_return_value(Type::Value* v) {
+void Environment::save_return_value(Value* v) {
 	// check if not stepping on another value
 	assert(!m_return_value);
 	m_return_value = v;

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -3,13 +3,9 @@
 #include "value.hpp"
 #include "error.hpp"
 
-namespace GarbageCollector {
+namespace Interpreter {
 
 struct GC;
-
-}
-
-namespace Type {
 
 struct Scope {
 	Scope* m_parent {nullptr};
@@ -22,20 +18,20 @@ struct Scope {
 };
 
 struct Environment {
-	GarbageCollector::GC* m_gc;
+	GC* m_gc;
 	Scope m_global_scope;
 
 	Scope* m_scope;
 	Value* m_return_value {nullptr};
 
-	Environment(GarbageCollector::GC* gc)
+	Environment(GC* gc)
 	    : m_gc { gc }, m_scope { &m_global_scope } {}
 
 	Scope* new_scope();
 	Scope* new_nested_scope();
 	void end_scope();
 
-	void save_return_value(Type::Value*);
+	void save_return_value(Value*);
 	Value* fetch_return_value();
 
 	// used as a short-hand

--- a/src/interpreter/environment_fwd.hpp
+++ b/src/interpreter/environment_fwd.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace Type {
+namespace Interpreter {
 
 struct Environment;
 

--- a/src/interpreter/error.cpp
+++ b/src/interpreter/error.cpp
@@ -2,7 +2,7 @@
 
 #include <sstream>
 
-namespace Type {
+namespace Interpreter {
 
 Error::Error() : Value(value_type::Error) {}
 Error::Error(std::string message) : Value(value_type::Error), m_error(message) {}
@@ -23,4 +23,4 @@ Error make_range_error(int accessed, int actual_size) {
 	return Error(ss.str());
 }
 
-}
+} // namespace Interpreter

--- a/src/interpreter/error.hpp
+++ b/src/interpreter/error.hpp
@@ -2,7 +2,7 @@
 
 #include "value.hpp"
 
-namespace Type {
+namespace Interpreter {
 
 struct Error : Value {
 	std::string m_error;
@@ -14,4 +14,4 @@ struct Error : Value {
 Error make_reference_error(const Identifier&);
 Error make_range_error(int,int);
 
-}
+} // namespace Interpreter

--- a/src/interpreter/eval.hpp
+++ b/src/interpreter/eval.hpp
@@ -7,5 +7,9 @@ namespace TypedAST {
 struct TypedAST;
 }
 
-Type::Value* eval(TypedAST::TypedAST*, Type::Environment&);
+namespace Interpreter {
+
+Value* eval(TypedAST::TypedAST*, Environment&);
+
+}
 

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -11,6 +11,8 @@
 #include "garbage_collector.hpp"
 #include "native.hpp"
 
+namespace Interpreter {
+
 exit_status_type execute(std::string const& source, bool dump_ast, Runner* runner) {
 
 	TokenArray ta;
@@ -36,8 +38,8 @@ exit_status_type execute(std::string const& source, bool dump_ast, Runner* runne
 
 	TypeChecker::match_identifiers(top_level.get(), ct_env);
 
-	GarbageCollector::GC gc;
-	Type::Environment env = { &gc };
+	GC gc;
+	Environment env = { &gc };
 	declare_native_functions(env);
 	eval(top_level.get(), env);
 
@@ -52,11 +54,13 @@ exit_status_type execute(std::string const& source, bool dump_ast, Runner* runne
 // this means we need to create a call expression node to run the program.
 // Having the TokenArray die here is not good, as it takes ownership of the tokens
 // TODO: We need to clean this up
-Type::Value* eval_expression(const std::string& expr, Type::Environment& env) {
+Value* eval_expression(const std::string& expr, Environment& env) {
 	TokenArray ta;
 
 	auto top_level_call_ast = parse_expression(expr, ta);
 	auto top_level_call = TypedAST::get_unique(top_level_call_ast.m_result);
 
-	return Type::unboxed(eval(top_level_call.get(), env));
+	return unboxed(eval(top_level_call.get(), env));
 }
+
+} // namespace Interpreter

--- a/src/interpreter/execute.hpp
+++ b/src/interpreter/execute.hpp
@@ -5,10 +5,15 @@
 #include "exit_status_type.hpp"
 #include "value.hpp"
 
-using Runner = auto (Type::Environment&) -> exit_status_type;
+
+namespace Interpreter {
+
+using Runner = auto (Environment&) -> exit_status_type;
 
 // returns an exit status
 exit_status_type execute(std::string const& source, bool dump_ast, Runner* runner);
 
 // creates an expression node and returns the unboxed value from it
-Type::Value* eval_expression(const std::string& expr, Type::Environment& env);
+Value* eval_expression(const std::string& expr, Environment& env);
+
+}

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -4,10 +4,10 @@
 #include <string>
 #include <unordered_map>
 
-namespace GarbageCollector {
+namespace Interpreter {
 
 GC::GC() {
-	m_null = new Type::Null;
+	m_null = new Null;
 }
 
 GC::~GC(){
@@ -30,89 +30,89 @@ void GC::run() {
 		}
 	}
 
-	auto is_null = [&](Type::Value* p) { return p == nullptr; };
+	auto is_null = [&](Value* p) { return p == nullptr; };
 
 	m_blocks.erase(
 	    std::remove_if(m_blocks.begin(), m_blocks.end(), is_null), m_blocks.end());
 }
 
-void GC::add_root(Type::Value* new_root) {
+void GC::add_root(Value* new_root) {
 	m_roots.push_back(new_root);
 }
 
-Type::Null* GC::null() {
+Null* GC::null() {
 	return m_null;
 }
 
 
 
-Type::Object* GC::new_object(Type::ObjectType declarations) {
-	auto result = new Type::Object;
+Object* GC::new_object(ObjectType declarations) {
+	auto result = new Object;
 	result->m_value = std::move(declarations);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::Dictionary* GC::new_dictionary(Type::ObjectType declarations) {
-	auto result = new Type::Dictionary;
+Dictionary* GC::new_dictionary(ObjectType declarations) {
+	auto result = new Dictionary;
 	result->m_value = std::move(declarations);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::Array* GC::new_list(Type::ArrayType elements) {
-	auto result = new Type::Array;
+Array* GC::new_list(ArrayType elements) {
+	auto result = new Array;
 	result->m_value = std::move(elements);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::Integer* GC::new_integer(int i) {
-	auto result = new Type::Integer(i);
+Integer* GC::new_integer(int i) {
+	auto result = new Integer(i);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::Float* GC::new_float(float f) {
-	auto result = new Type::Float(f);
+Float* GC::new_float(float f) {
+	auto result = new Float(f);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::Boolean* GC::new_boolean(bool b) {
-	auto result = new Type::Boolean(b);
+Boolean* GC::new_boolean(bool b) {
+	auto result = new Boolean(b);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::String* GC::new_string(std::string s) {
-	auto result = new Type::String(std::move(s));
+String* GC::new_string(std::string s) {
+	auto result = new String(std::move(s));
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::Function* GC::new_function(Type::FunctionType def, Type::ObjectType captures) {
-	auto result = new Type::Function(std::move(def), std::move(captures));
+Function* GC::new_function(FunctionType def, ObjectType captures) {
+	auto result = new Function(std::move(def), std::move(captures));
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::NativeFunction* GC::new_native_function(Type::NativeFunctionType* fptr) {
-	auto result = new Type::NativeFunction(fptr);
+NativeFunction* GC::new_native_function(NativeFunctionType* fptr) {
+	auto result = new NativeFunction(fptr);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::Error* GC::new_error(std::string s) {
-	auto result = new Type::Error(std::move(s));
+Error* GC::new_error(std::string s) {
+	auto result = new Error(std::move(s));
 	m_blocks.push_back(result);
 	return result;
 }
 
-Type::Reference* GC::new_reference(Type::Value* v) {
-	auto result = new Type::Reference(std::move(v));
+Reference* GC::new_reference(Value* v) {
+	auto result = new Reference(std::move(v));
 	m_blocks.push_back(result);
 	return result;
 }
 
-} // namespace GarbageCollector
+} // namespace Interpreter

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -5,34 +5,34 @@
 #include "value.hpp"
 #include "error.hpp"
 
-namespace GarbageCollector {
+namespace Interpreter {
 
 struct GC {
 private:
-	Type::Null* m_null;
+	Null* m_null;
 
 public:
-	std::vector<Type::Value*> m_blocks;
-	std::vector<Type::Value*> m_roots;
+	std::vector<Value*> m_blocks;
+	std::vector<Value*> m_roots;
 
 	GC();
 	~GC();
 	
 	void run ();
-	void add_root (Type::Value* new_root);
-	Type::Null* null();
+	void add_root (Value* new_root);
+	Null* null();
 
-	Type::Object* new_object (Type::ObjectType);
-	Type::Dictionary* new_dictionary (Type::ObjectType);
-	Type::Array* new_list (Type::ArrayType);
-	Type::Integer* new_integer (int);
-	Type::Float* new_float (float);
-	Type::Boolean* new_boolean (bool);
-	Type::String* new_string (std::string);
-	Type::Function* new_function (Type::FunctionType, Type::ObjectType);
-	Type::NativeFunction* new_native_function (Type::NativeFunctionType*);
-	Type::Error* new_error (std::string);
-	Type::Reference* new_reference (Type::Value*);
+	Object* new_object (ObjectType);
+	Dictionary* new_dictionary (ObjectType);
+	Array* new_list (ArrayType);
+	Integer* new_integer (int);
+	Float* new_float (float);
+	Boolean* new_boolean (bool);
+	String* new_string (std::string);
+	Function* new_function (FunctionType, ObjectType);
+	NativeFunction* new_native_function (NativeFunctionType*);
+	Error* new_error (std::string);
+	Reference* new_reference (Value*);
 };
 
-}
+} // namespace Interpreter

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -26,7 +26,7 @@ int main() {
 
 	std::string source = file_content.str();
 
-	exit_status_type exit_code = execute(source, false, +[](Type::Environment& env) -> exit_status_type {
+	exit_status_type exit_code = execute(source, false, +[](Interpreter::Environment& env) -> exit_status_type {
 
 		// NOTE: We currently implement funcion evaluation in eval(ASTCallExpression)
 		// this means we need to create a call expression node to run the program.
@@ -40,7 +40,7 @@ int main() {
 			auto* result = eval(top_level_call, env);
 
 			if (result)
-				Type::print(result);
+				Interpreter::print(result);
 			else
 				std::cout << "(nullptr)\n";
 

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -7,21 +7,23 @@
 
 #include <cassert>
 
+namespace Interpreter {
+
 // print(...) prints the values or references in ...
-Type::Value* print (Type::ArrayType v, Type::Environment& e) {
+Value* print (ArrayType v, Environment& e) {
     for (auto value : v) {
-        Type::print(value);
+        print(value);
     } 
     return e.null();
 }
 
 // array_append(arr, ...) appends the values or references
 // in ... to the array
-Type::Value* array_append(Type::ArrayType v, Type::Environment& e) {
+Value* array_append(ArrayType v, Environment& e) {
     // TODO proper error handling
     assert(v.size() > 0);
     assert(unboxed(v[0])->type() == value_type::Array);
-    Type::Array* array = static_cast<Type::Array*>(unboxed(v[0]));
+    Array* array = static_cast<Array*>(unboxed(v[0]));
     for (unsigned int i = 1; i < v.size(); i++) {
         array->m_value.push_back(unboxed(v[i]));
     }
@@ -30,13 +32,13 @@ Type::Value* array_append(Type::ArrayType v, Type::Environment& e) {
 
 // array_extend(arr1, arr2) appends the values in arr2 to
 // arr1
-Type::Value* array_extend(Type::ArrayType v, Type::Environment& e) {
+Value* array_extend(ArrayType v, Environment& e) {
     // TODO proper error handling
     assert(v.size() == 2);
     assert(unboxed(v[0])->type() == value_type::Array);
     assert(unboxed(v[1])->type() == value_type::Array);
-    Type::Array* arr1 = static_cast<Type::Array*>(unboxed(v[0]));
-    Type::Array* arr2 = static_cast<Type::Array*>(unboxed(v[1]));
+    Array* arr1 = static_cast<Array*>(unboxed(v[0]));
+    Array* arr2 = static_cast<Array*>(unboxed(v[1]));
     arr1->m_value.insert(
         arr1->m_value.end(), 
         arr2->m_value.begin(), 
@@ -45,23 +47,23 @@ Type::Value* array_extend(Type::ArrayType v, Type::Environment& e) {
 }
 
 // size(array) returns the size of the array
-Type::Value* size(Type::ArrayType v, Type::Environment& e) {
+Value* size(ArrayType v, Environment& e) {
     // TODO proper error handling
     assert(v.size() == 1);
     assert(unboxed(v[0])->type() == value_type::Array);
-    Type::Array* array = static_cast<Type::Array*>(unboxed(v[0]));
+    Array* array = static_cast<Array*>(unboxed(v[0]));
     return e.new_integer(array->m_value.size());
 } 
 
 // array_join(array, string) returns a string with
 // the array values separated by the string element
-Type::Value* array_join(Type::ArrayType v, Type::Environment& e) {
+Value* array_join(ArrayType v, Environment& e) {
     // TODO proper error handling
     assert(v.size() == 2);
     assert(unboxed(v[0])->type() == value_type::Array);
     assert(unboxed(v[1])->type() == value_type::String);
-    Type::Array* array = static_cast<Type::Array*>(unboxed(v[0]));
-    Type::String* string = static_cast<Type::String*>(unboxed(v[1]));
+    Array* array = static_cast<Array*>(unboxed(v[0]));
+    String* string = static_cast<String*>(unboxed(v[1]));
     std::stringstream result;
     for (unsigned int i = 0; i < array->m_value.size(); i++) {
         // TODO make it more general
@@ -69,18 +71,18 @@ Type::Value* array_join(Type::ArrayType v, Type::Environment& e) {
     
         assert(value->type() == value_type::Integer);
 
-        result << static_cast<Type::Integer*>(value)->m_value;
+        result << static_cast<Integer*>(value)->m_value;
         if (i < array->m_value.size()-1)
             result << string->m_value;
     }
     return e.new_string(result.str());
 }
 
-Type::Value* dummy(Type::ArrayType v, Type::Environment& e){
+Value* dummy(ArrayType v, Environment& e){
 	return e.null();
 }
 
-Type::Value* value_add(Type::ArrayType v, Type::Environment& e) {
+Value* value_add(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -90,16 +92,16 @@ Type::Value* value_add(Type::ArrayType v, Type::Environment& e) {
 	switch (lhs_val->type()) {
 	case value_type::Integer:
 		return e.new_integer(
-		    static_cast<Type::Integer*>(lhs_val)->m_value
-		    + static_cast<Type::Integer*>(rhs_val)->m_value);
+		    static_cast<Integer*>(lhs_val)->m_value
+		    + static_cast<Integer*>(rhs_val)->m_value);
 	case value_type::Float:
 		return e.new_float(
-		    static_cast<Type::Float*>(lhs_val)->m_value
-		    + static_cast<Type::Float*>(rhs_val)->m_value);
+		    static_cast<Float*>(lhs_val)->m_value
+		    + static_cast<Float*>(rhs_val)->m_value);
 	case value_type::String:
 		return e.new_string(
-		    static_cast<Type::String*>(lhs_val)->m_value
-		    + static_cast<Type::String*>(rhs_val)->m_value);
+		    static_cast<String*>(lhs_val)->m_value
+		    + static_cast<String*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];
@@ -107,7 +109,7 @@ Type::Value* value_add(Type::ArrayType v, Type::Environment& e) {
 	}
 }
 
-Type::Value* value_sub(Type::ArrayType v, Type::Environment& e) {
+Value* value_sub(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -117,12 +119,12 @@ Type::Value* value_sub(Type::ArrayType v, Type::Environment& e) {
 	switch (lhs_val->type()) {
 	case value_type::Integer:
 		return e.new_integer(
-		    static_cast<Type::Integer*>(lhs_val)->m_value
-		    - static_cast<Type::Integer*>(rhs_val)->m_value);
+		    static_cast<Integer*>(lhs_val)->m_value
+		    - static_cast<Integer*>(rhs_val)->m_value);
 	case value_type::Float:
 		return e.new_float(
-		    static_cast<Type::Float*>(lhs_val)->m_value
-		    - static_cast<Type::Float*>(rhs_val)->m_value);
+		    static_cast<Float*>(lhs_val)->m_value
+		    - static_cast<Float*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];
@@ -130,7 +132,7 @@ Type::Value* value_sub(Type::ArrayType v, Type::Environment& e) {
 	}
 }
 
-Type::Value* value_mul(Type::ArrayType v, Type::Environment& e) {
+Value* value_mul(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -140,12 +142,12 @@ Type::Value* value_mul(Type::ArrayType v, Type::Environment& e) {
 	switch (lhs_val->type()) {
 	case value_type::Integer:
 		return e.new_integer(
-		    static_cast<Type::Integer*>(lhs_val)->m_value
-		    * static_cast<Type::Integer*>(rhs_val)->m_value);
+		    static_cast<Integer*>(lhs_val)->m_value
+		    * static_cast<Integer*>(rhs_val)->m_value);
 	case value_type::Float:
 		return e.new_float(
-		    static_cast<Type::Float*>(lhs_val)->m_value
-		    * static_cast<Type::Float*>(rhs_val)->m_value);
+		    static_cast<Float*>(lhs_val)->m_value
+		    * static_cast<Float*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't multiply values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];
@@ -153,7 +155,7 @@ Type::Value* value_mul(Type::ArrayType v, Type::Environment& e) {
 	}
 }
 
-Type::Value* value_div(Type::ArrayType v, Type::Environment& e) {
+Value* value_div(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -163,12 +165,12 @@ Type::Value* value_div(Type::ArrayType v, Type::Environment& e) {
 	switch (lhs_val->type()) {
 	case value_type::Integer:
 		return e.new_integer(
-		    static_cast<Type::Integer*>(lhs_val)->m_value
-		    / static_cast<Type::Integer*>(rhs_val)->m_value);
+		    static_cast<Integer*>(lhs_val)->m_value
+		    / static_cast<Integer*>(rhs_val)->m_value);
 	case value_type::Float:
 		return e.new_float(
-		    static_cast<Type::Float*>(lhs_val)->m_value
-		    / static_cast<Type::Float*>(rhs_val)->m_value);
+		    static_cast<Float*>(lhs_val)->m_value
+		    / static_cast<Float*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't divide values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];
@@ -176,7 +178,7 @@ Type::Value* value_div(Type::ArrayType v, Type::Environment& e) {
 	}
 }
 
-Type::Value* value_logicand(Type::ArrayType v, Type::Environment& e) {
+Value* value_logicand(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -185,15 +187,15 @@ Type::Value* value_logicand(Type::ArrayType v, Type::Environment& e) {
 	if (lhs_val->type() == value_type::Boolean
 	    and rhs_val->type() == value_type::Boolean)
 		return e.new_boolean(
-		    static_cast<Type::Boolean*>(lhs_val)->m_value
-		    and static_cast<Type::Boolean*>(rhs_val)->m_value);
+		    static_cast<Boolean*>(lhs_val)->m_value
+		    and static_cast<Boolean*>(rhs_val)->m_value);
 	std::cerr << "ERROR: logical and operator not defined for types "
 	          << value_type_string[static_cast<int>(lhs_val->type())] << " and "
 	          << value_type_string[static_cast<int>(rhs_val->type())];
 	assert(0);
 }
 
-Type::Value* value_logicor(Type::ArrayType v, Type::Environment& e) {
+Value* value_logicor(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -202,15 +204,15 @@ Type::Value* value_logicor(Type::ArrayType v, Type::Environment& e) {
 	if (lhs_val->type() == value_type::Boolean
 	    and rhs_val->type() == value_type::Boolean)
 		return e.new_boolean(
-		    static_cast<Type::Boolean*>(lhs_val)->m_value
-		    or static_cast<Type::Boolean*>(rhs_val)->m_value);
+		    static_cast<Boolean*>(lhs_val)->m_value
+		    or static_cast<Boolean*>(rhs_val)->m_value);
 	std::cerr << "ERROR: logical or operator not defined for types "
 	          << value_type_string[static_cast<int>(lhs_val->type())] << " and "
 	          << value_type_string[static_cast<int>(rhs_val->type())];
 	assert(0);
 }
 
-Type::Value* value_logicxor(Type::ArrayType v, Type::Environment& e) {
+Value* value_logicxor(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -219,15 +221,15 @@ Type::Value* value_logicxor(Type::ArrayType v, Type::Environment& e) {
 	if (lhs_val->type() == value_type::Boolean
 	    and rhs_val->type() == value_type::Boolean)
 		return e.new_boolean(
-		    static_cast<Type::Boolean*>(lhs_val)->m_value
-		    != static_cast<Type::Boolean*>(rhs_val)->m_value);
+		    static_cast<Boolean*>(lhs_val)->m_value
+		    != static_cast<Boolean*>(rhs_val)->m_value);
 	std::cerr << "ERROR: exclusive or operator not defined for types "
 	          << value_type_string[static_cast<int>(lhs_val->type())] << " and "
 	          << value_type_string[static_cast<int>(rhs_val->type())];
 	assert(0);
 }
 
-Type::Value* value_equals(Type::ArrayType v, Type::Environment& e) {
+Value* value_equals(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -240,20 +242,20 @@ Type::Value* value_equals(Type::ArrayType v, Type::Environment& e) {
 		return e.new_boolean(true);
 	case value_type::Integer:
 		return e.new_boolean(
-		    static_cast<Type::Integer*>(lhs_val)->m_value
-		    == static_cast<Type::Integer*>(rhs_val)->m_value);
+		    static_cast<Integer*>(lhs_val)->m_value
+		    == static_cast<Integer*>(rhs_val)->m_value);
 	case value_type::Float:
 		return e.new_boolean(
-		    static_cast<Type::Float*>(lhs_val)->m_value
-		    == static_cast<Type::Float*>(rhs_val)->m_value);
+		    static_cast<Float*>(lhs_val)->m_value
+		    == static_cast<Float*>(rhs_val)->m_value);
 	case value_type::String:
 		return e.new_boolean(
-		    static_cast<Type::String*>(lhs_val)->m_value
-		    == static_cast<Type::String*>(rhs_val)->m_value);
+		    static_cast<String*>(lhs_val)->m_value
+		    == static_cast<String*>(rhs_val)->m_value);
 	case value_type::Boolean:
 		return e.new_boolean(
-		    static_cast<Type::Boolean*>(lhs_val)->m_value
-		    == static_cast<Type::Boolean*>(rhs_val)->m_value);
+		    static_cast<Boolean*>(lhs_val)->m_value
+		    == static_cast<Boolean*>(rhs_val)->m_value);
 	default: {
 		std::cerr << "ERROR: can't compare equality of types "
 		          << value_type_string[static_cast<int>(lhs_val->type())] << " and "
@@ -263,7 +265,7 @@ Type::Value* value_equals(Type::ArrayType v, Type::Environment& e) {
 	}
 }
 
-Type::Value* value_less(Type::ArrayType v, Type::Environment& e) {
+Value* value_less(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -274,16 +276,16 @@ Type::Value* value_less(Type::ArrayType v, Type::Environment& e) {
 	switch (lhs_val->type()) {
 	case value_type::Integer:
 		return e.new_boolean(
-		    static_cast<Type::Integer*>(lhs_val)->m_value
-		    < static_cast<Type::Integer*>(rhs_val)->m_value);
+		    static_cast<Integer*>(lhs_val)->m_value
+		    < static_cast<Integer*>(rhs_val)->m_value);
 	case value_type::Float:
 		return e.new_boolean(
-		    static_cast<Type::Float*>(lhs_val)->m_value
-		    < static_cast<Type::Float*>(rhs_val)->m_value);
+		    static_cast<Float*>(lhs_val)->m_value
+		    < static_cast<Float*>(rhs_val)->m_value);
 	case value_type::String:
 		return e.new_boolean(
-		    static_cast<Type::String*>(lhs_val)->m_value
-		    < static_cast<Type::String*>(rhs_val)->m_value);
+		    static_cast<String*>(lhs_val)->m_value
+		    < static_cast<String*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't compare values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];
@@ -291,7 +293,7 @@ Type::Value* value_less(Type::ArrayType v, Type::Environment& e) {
 	}
 }
 
-Type::Value* value_assign(Type::ArrayType v, Type::Environment& e) {
+Value* value_assign(ArrayType v, Environment& e) {
 	auto* lhs = v[0];
 	auto* rhs = v[1];
 	auto* lhs_val = unboxed(lhs);
@@ -301,44 +303,46 @@ Type::Value* value_assign(Type::ArrayType v, Type::Environment& e) {
 	assert(lhs->type() == value_type::Reference);
 	// NOTE: copied by reference, matters if rhs is actually a reference
 	// TODO: change in another pr, perhaps adding Environment::copy_value?
-	static_cast<Type::Reference*>(lhs)->m_value = rhs_val;
+	static_cast<Reference*>(lhs)->m_value = rhs_val;
 	return e.null();
 }
 
-void declare_native_functions(Type::Environment& env) {
+void declare_native_functions(Environment& env) {
     env.declare(
         "print",
         env.new_native_function(
-            static_cast<Type::NativeFunctionType*>(&print)));
+            static_cast<NativeFunctionType*>(&print)));
 
     env.declare(
         "array_append",
         env.new_native_function(
-            static_cast<Type::NativeFunctionType*>(&array_append)));
+            static_cast<NativeFunctionType*>(&array_append)));
 
     env.declare(
         "array_extend",
         env.new_native_function(
-            static_cast<Type::NativeFunctionType*>(&array_extend)));
+            static_cast<NativeFunctionType*>(&array_extend)));
 
     env.declare(
         "size",
         env.new_native_function(
-            static_cast<Type::NativeFunctionType*>(&size)));
+            static_cast<NativeFunctionType*>(&size)));
 
     env.declare(
         "array_join",
         env.new_native_function(
-            static_cast<Type::NativeFunctionType*>(&array_join)));
+            static_cast<NativeFunctionType*>(&array_join)));
 
-	env.declare("+", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_add)));
-	env.declare("-", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_sub)));
-	env.declare("*", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_mul)));
-	env.declare("/", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_div)));
-	env.declare("<", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_less)));
-	env.declare("=", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_assign)));
-	env.declare("==", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_equals)));
-	env.declare("^^", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_logicxor)));
-	env.declare("&&", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_logicand)));
-	env.declare("||", env.new_native_function(static_cast<Type::NativeFunctionType*>(&value_logicor)));
+	env.declare("+", env.new_native_function(static_cast<NativeFunctionType*>(&value_add)));
+	env.declare("-", env.new_native_function(static_cast<NativeFunctionType*>(&value_sub)));
+	env.declare("*", env.new_native_function(static_cast<NativeFunctionType*>(&value_mul)));
+	env.declare("/", env.new_native_function(static_cast<NativeFunctionType*>(&value_div)));
+	env.declare("<", env.new_native_function(static_cast<NativeFunctionType*>(&value_less)));
+	env.declare("=", env.new_native_function(static_cast<NativeFunctionType*>(&value_assign)));
+	env.declare("==", env.new_native_function(static_cast<NativeFunctionType*>(&value_equals)));
+	env.declare("^^", env.new_native_function(static_cast<NativeFunctionType*>(&value_logicxor)));
+	env.declare("&&", env.new_native_function(static_cast<NativeFunctionType*>(&value_logicand)));
+	env.declare("||", env.new_native_function(static_cast<NativeFunctionType*>(&value_logicor)));
 }
+
+} // namespace Interpreter

--- a/src/interpreter/native.hpp
+++ b/src/interpreter/native.hpp
@@ -2,4 +2,8 @@
 
 #include "environment_fwd.hpp"
 
-void declare_native_functions(Type::Environment& env);
+namespace Interpreter {
+
+void declare_native_functions(Environment& env);
+
+}

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -7,9 +7,9 @@
 #include "environment.hpp"
 #include "error.hpp"
 
-namespace Type {
+namespace Interpreter {
 
-Type::Value* unboxed(Type::Value* value) {
+Value* unboxed(Value* value) {
 	if (!value)
 		return value;
 
@@ -17,7 +17,7 @@ Type::Value* unboxed(Type::Value* value) {
 		return value;
 
 	// try unboxing recursively?
-	auto ref = static_cast<Type::Reference*>(value);
+	auto ref = static_cast<Reference*>(value);
 	return ref->m_value;
 }
 
@@ -309,4 +309,4 @@ void print(Value* v, int d) {
 	}
 }
 
-} // namespace Type
+} // namespace Interpreter

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -12,7 +12,7 @@ namespace TypedAST {
 struct FunctionLiteral;
 }
 
-namespace Type {
+namespace Interpreter {
 
 using Identifier = std::string;
 using ObjectType = std::unordered_map<Identifier, Value*>;
@@ -123,4 +123,4 @@ struct Reference : Value {
 	Reference(Value* value);
 };
 
-} // namespace Type
+} // namespace Interpreter

--- a/src/interpreter/value_fwd.hpp
+++ b/src/interpreter/value_fwd.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace Type {
+namespace Interpreter {
 
 struct Value;
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -73,7 +73,7 @@ int main() {
 				user2 := "anne";
 			};
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			eval_expression("__invoke()", env);
 			return exit_status_type::Ok;
 		}}
@@ -89,23 +89,23 @@ int main() {
 			float_div := 1.0 / 2.0;
 		)",
 		{
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::equals(eval_expression("int_val", env), 10);
 			},
 
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::equals(eval_expression("float_val", env), 3.5);
 			},
 
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::equals(eval_expression("string_val", env), "testing.");
 			},
 
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::equals(eval_expression("int_div", env), 0);
 			},
 
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::equals(eval_expression("float_div", env), 0.5);
 			},
 		}}
@@ -119,7 +119,7 @@ int main() {
 				return a + b;
 			};
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("f()", env), 3);
 		}}
 	);
@@ -133,7 +133,7 @@ int main() {
 				return K(a)(b);
 			};
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("f()", env), 42);
 		}}
 	);
@@ -146,7 +146,7 @@ int main() {
 			I := S(K)(K);
 			__invoke := fn () => I(42);
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("__invoke()", env), 42);
 		}}
 	);
@@ -172,7 +172,7 @@ int main() {
 				return car(cdr(cdr(a)));
 			};
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("__invoke()", env), 2);
 		}}
 	);
@@ -219,7 +219,7 @@ int main() {
 				return print_inorder(t7);
 			};
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("__invoke()", env), "abcdefg");
 		}}
 	);
@@ -232,15 +232,15 @@ int main() {
 			nullv := fn () { return null; };
 		)",
 		{
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::is_true(eval_expression("litt()", env));
 			},	
 
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::is_false(eval_expression("litf()", env));
 			},
 
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::is_null(eval_expression("nullv()", env));
 			}
 		}}
@@ -255,7 +255,7 @@ int main() {
 			};
 			__invoke := fn() => fib(6);
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("__invoke()", env), 8);
 		}}
 	);
@@ -272,7 +272,7 @@ int main() {
 				return sum;
 			};
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("__invoke()", env), 120);
 		}}
 	);
@@ -287,11 +287,11 @@ int main() {
 			};
 		)",
 		{
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::array_of_size(eval_expression("__invoke()", env), 1);
 			},
 
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::equals(eval_expression("__invoke()[0]", env), 10);
 			}
 		}}
@@ -308,11 +308,11 @@ int main() {
 			};
 		)",
 		{
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::array_of_size(eval_expression("__invoke()", env), 1);
 			},
 
-			+[](Type::Environment& env) -> exit_status_type {
+			+[](Interpreter::Environment& env) -> exit_status_type {
 				return Assert::equals(eval_expression("__invoke()[0]", env), 10);
 			}
 		}}
@@ -327,7 +327,7 @@ int main() {
 				return size(A);
 			};
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("__invoke()", env), 2);
 		}}
 	);
@@ -341,7 +341,7 @@ int main() {
 				return array_join(A, ",");
 			};
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("__invoke()", env), "10,10");
 		}}
 	);
@@ -363,7 +363,7 @@ int main() {
 				return val;
 			};
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("__invoke()", env), 4);
 		}}
 	);
@@ -374,7 +374,7 @@ int main() {
 			f := fn(x) => x + 7;
 			__invoke := fn() => 6 |> f();
 		)",
-		+[](Type::Environment& env) -> exit_status_type {
+		+[](Interpreter::Environment& env) -> exit_status_type {
 			return Assert::equals(eval_expression("__invoke()", env), 13);
 		}}
 	);

--- a/src/test/test_set.cpp
+++ b/src/test/test_set.cpp
@@ -18,7 +18,7 @@ exit_status_type TestSet::execute(bool dump_ast) {
 		return exit_status_type::Empty;
 
 	for(auto* f : m_testers) {
-		exit_status_type answer = ::execute(m_source, dump_ast, f);
+		exit_status_type answer = Interpreter::execute(m_source, dump_ast, f);
 
 		if (exit_status_type::Ok != answer)
 			return answer;

--- a/src/test/test_set.hpp
+++ b/src/test/test_set.hpp
@@ -8,7 +8,7 @@
 
 namespace Test {
 
-using TestFunction = exit_status_type (*)(Type::Environment&);
+using TestFunction = exit_status_type (*)(Interpreter::Environment&);
 
 struct TestSet {
 

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -9,7 +9,7 @@
 
 namespace Assert {
 
-exit_status_type of_type(Type::Value* rv, value_type v_type) {
+exit_status_type of_type(Interpreter::Value* rv, value_type v_type) {
 
 	if (!rv)
 		return exit_status_type::NullError;
@@ -21,7 +21,7 @@ exit_status_type of_type(Type::Value* rv, value_type v_type) {
 }
 
 template <typename RuntimeValue, typename NativeValue>
-exit_status_type scalar_equals(Type::Value* rv, const value_type v_type, const NativeValue& expected) {
+exit_status_type scalar_equals(Interpreter::Value* rv, const value_type v_type, const NativeValue& expected) {
 	exit_status_type fail = of_type(rv, v_type);
 
 	if (exit_status_type::Ok != fail)
@@ -33,42 +33,42 @@ exit_status_type scalar_equals(Type::Value* rv, const value_type v_type, const N
 	return exit_status_type::Ok;
 }
 
-exit_status_type equals(Type::Value* rv, std::string const& expected) {
-	return scalar_equals<Type::String, std::string>(rv, value_type::String, expected);
+exit_status_type equals(Interpreter::Value* rv, std::string const& expected) {
+	return scalar_equals<Interpreter::String, std::string>(rv, value_type::String, expected);
 }
 
-exit_status_type equals(Type::Value* rv, int expected) {
-	return scalar_equals<Type::Integer, int>(rv, value_type::Integer, expected);
+exit_status_type equals(Interpreter::Value* rv, int expected) {
+	return scalar_equals<Interpreter::Integer, int>(rv, value_type::Integer, expected);
 }
 
-exit_status_type equals(Type::Value* rv, float expected) {
-	return scalar_equals<Type::Float, float>(rv, value_type::Float, expected);
+exit_status_type equals(Interpreter::Value* rv, float expected) {
+	return scalar_equals<Interpreter::Float, float>(rv, value_type::Float, expected);
 }
 
 // NOTE: allows literals to be used (e.g. 3.5), may need to change in the future?
-exit_status_type equals(Type::Value* rv, double expected) {
+exit_status_type equals(Interpreter::Value* rv, double expected) {
 	return equals(rv, float(expected));
 }
 
-exit_status_type is_true(Type::Value* rv) {
-	return scalar_equals<Type::Boolean, bool>(rv, value_type::Boolean, true);
+exit_status_type is_true(Interpreter::Value* rv) {
+	return scalar_equals<Interpreter::Boolean, bool>(rv, value_type::Boolean, true);
 }
 
-exit_status_type is_false(Type::Value* rv) {
-	return scalar_equals<Type::Boolean, bool>(rv, value_type::Boolean, false);
+exit_status_type is_false(Interpreter::Value* rv) {
+	return scalar_equals<Interpreter::Boolean, bool>(rv, value_type::Boolean, false);
 }
 
-exit_status_type is_null(Type::Value* rv) {
+exit_status_type is_null(Interpreter::Value* rv) {
 	return of_type(rv, value_type::Null);
 }
 
-exit_status_type array_of_size(Type::Value* rv, unsigned int size) {
+exit_status_type array_of_size(Interpreter::Value* rv, unsigned int size) {
 	exit_status_type fail = of_type(rv, value_type::Array);
 
 	if (exit_status_type::Ok != fail)
 		return fail;
 
-	if ((static_cast<Type::Array*>(rv))->m_value.size() != size)
+	if ((static_cast<Interpreter::Array*>(rv))->m_value.size() != size)
 		return exit_status_type::ValueError;
 
 	return exit_status_type::Ok;


### PR DESCRIPTION
I am trying to sort out the namespaces, I started by putting all of the interpreter into the all-new `namespace Interpreter`

I was thinking about cleaning up the whole `AST-TypedAST-Frontend-TypeChecker` mess as well. I don't think we should have that much stuff in the top-level namespace.

Ideally, Jasper should be embeddable in other programs, so it will all have to be put into a `Jasper` namespace as well, eventually.