### PR TITLE
Implement Tarjan's SCC decomposition algorithm

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,6 +13,7 @@ OBJNAMES := \
 	parser.o \
 	parse.o \
 	string_view.o \
+	tarjan_solver.o \
 	token.o \
 	typechecker.o \
 	typed_ast.o \

--- a/src/tarjan_solver.cpp
+++ b/src/tarjan_solver.cpp
@@ -13,20 +13,26 @@ TarjanSolver::TarjanSolver(int vertex_count)
     , m_component_of(vertex_count, -1) {}
 
 void TarjanSolver::add_adge(int u, int v) {
+	assert(!m_solved);
 	assert(0 <= u && u < m_vertex_count);
 	assert(0 <= v && v < m_vertex_count);
 	m_graph[u].push_back(v);
 }
 
 void TarjanSolver::solve() {
+	assert(!m_solved);
+
 	for (int u { 0 }; u < m_vertex_count; ++u) {
 		if (!m_discovery_time[u]) {
 			visit(u);
 		}
 	}
+
+	m_solved = true;
 }
 
 void TarjanSolver::visit(int u) {
+	assert(!m_solved);
 	assert(0 <= u && u < m_vertex_count);
 
 	m_current_time += 1;

--- a/src/tarjan_solver.cpp
+++ b/src/tarjan_solver.cpp
@@ -69,3 +69,13 @@ void TarjanSolver::visit(int u) {
 		}
 	}
 }
+
+std::vector<std::vector<int>> const& TarjanSolver::vertices_of_components() const {
+	assert(m_solved);
+	return m_scc_vertices;
+}
+
+std::vector<int> const& TarjanSolver::component_of_vertices() const {
+	assert(m_solved);
+	return m_component_of;
+}

--- a/src/tarjan_solver.cpp
+++ b/src/tarjan_solver.cpp
@@ -6,8 +6,8 @@
 #include <cassert>
 
 TarjanSolver::TarjanSolver(int vertex_count)
-    : m_vertex_count { vertex_count }
-    , m_graph(vertex_count)
+    : m_graph(vertex_count)
+    , m_vertex_count { vertex_count }
     , m_discovery_time(vertex_count, 0)
     , m_lowest_visible(vertex_count, std::numeric_limits<int>::max())
     , m_component_of(vertex_count, -1) {}

--- a/src/tarjan_solver.cpp
+++ b/src/tarjan_solver.cpp
@@ -1,0 +1,65 @@
+#include "tarjan_solver.hpp"
+
+#include <algorithm>
+#include <limits>
+
+#include <cassert>
+
+TarjanSolver::TarjanSolver(int vertex_count)
+    : m_vertex_count { vertex_count }
+    , m_graph(vertex_count)
+    , m_discovery_time(vertex_count, 0)
+    , m_lowest_visible(vertex_count, std::numeric_limits<int>::max())
+    , m_component_of(vertex_count, -1) {}
+
+void TarjanSolver::add_adge(int u, int v) {
+	assert(0 <= u && u < m_vertex_count);
+	assert(0 <= v && v < m_vertex_count);
+	m_graph[u].push_back(v);
+}
+
+void TarjanSolver::solve() {
+	for (int u { 0 }; u < m_vertex_count; ++u) {
+		if (!m_discovery_time[u]) {
+			visit(u);
+		}
+	}
+}
+
+void TarjanSolver::visit(int u) {
+	assert(0 <= u && u < m_vertex_count);
+
+	m_current_time += 1;
+	m_discovery_time[u] = m_current_time;
+	m_lowest_visible[u] = m_current_time;
+	m_vertex_stack.push_back(u);
+
+	for (int v : m_graph[u]) {
+		if (!m_discovery_time[v]) {
+			// v is not yet discovered
+			visit(v);
+			m_lowest_visible[u] = std::min(m_lowest_visible[u], m_lowest_visible[v]);
+		} else if (m_component_of[v] == -1) {
+			// v is discovered, but not yet assigned to a
+			// component. (i.e. v is still in the stack)
+			m_lowest_visible[u] = std::min(m_lowest_visible[u], m_lowest_visible[v]);
+		}
+	}
+
+	// there are no edges going over `u`, thus it must be
+	// the root of an SCC.
+	// We don't really care about roots, so we use an
+	// index, instead.
+	if (m_lowest_visible[u] == m_discovery_time[u]) {
+		int component_number = m_scc_vertices.size();
+		m_scc_vertices.push_back({});
+		while (1) {
+			int w = m_vertex_stack.back();
+			m_vertex_stack.pop_back();
+			m_component_of[w] = component_number;
+			m_scc_vertices.back().push_back(w);
+			if (w == u)
+				break;
+		}
+	}
+}

--- a/src/tarjan_solver.cpp
+++ b/src/tarjan_solver.cpp
@@ -12,7 +12,7 @@ TarjanSolver::TarjanSolver(int vertex_count)
     , m_lowest_visible(vertex_count, std::numeric_limits<int>::max())
     , m_component_of(vertex_count, -1) {}
 
-void TarjanSolver::add_adge(int u, int v) {
+void TarjanSolver::add_edge(int u, int v) {
 	assert(!m_solved);
 	assert(0 <= u && u < m_vertex_count);
 	assert(0 <= v && v < m_vertex_count);

--- a/src/tarjan_solver.hpp
+++ b/src/tarjan_solver.hpp
@@ -26,4 +26,6 @@ private:
 	// they also happen to be in topological order
 	std::vector<std::vector<int>> m_scc_vertices;
 	std::vector<int> m_vertex_stack;
+
+	bool m_solved { false };
 };

--- a/src/tarjan_solver.hpp
+++ b/src/tarjan_solver.hpp
@@ -14,8 +14,8 @@ private:
 	void visit(int u);
 
 	// inputs
-	int m_vertex_count;
 	std::vector<std::vector<int>> m_graph;
+	int m_vertex_count;
 
 	// intermediate state
 	int m_current_time { 0 };

--- a/src/tarjan_solver.hpp
+++ b/src/tarjan_solver.hpp
@@ -7,6 +7,9 @@ public:
 	TarjanSolver(int vertex_count);
 	void add_adge(int u, int v);
 	void solve();
+	std::vector<std::vector<int>> const& vertices_of_components() const;
+	std::vector<int> const& component_of_vertices() const;
+
 private:
 	void visit(int u);
 

--- a/src/tarjan_solver.hpp
+++ b/src/tarjan_solver.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <vector>
+
+struct TarjanSolver {
+public:
+	TarjanSolver(int vertex_count);
+	void add_adge(int u, int v);
+	void solve();
+private:
+	void visit(int u);
+
+	// inputs
+	int m_vertex_count;
+	std::vector<std::vector<int>> m_graph;
+
+	// intermediate state
+	int m_current_time { 0 };
+	// 0 means 'not discovered yet'
+	std::vector<int> m_discovery_time;
+	std::vector<int> m_lowest_visible;
+
+	// outputs
+	std::vector<int> m_component_of;
+	// a list of vertices of each strongly connected component
+	// they also happen to be in topological order
+	std::vector<std::vector<int>> m_scc_vertices;
+	std::vector<int> m_vertex_stack;
+};

--- a/src/tarjan_solver.hpp
+++ b/src/tarjan_solver.hpp
@@ -5,7 +5,7 @@
 struct TarjanSolver {
 public:
 	TarjanSolver(int vertex_count);
-	void add_adge(int u, int v);
+	void add_edge(int u, int v);
 	void solve();
 	std::vector<std::vector<int>> const& vertices_of_components() const;
 	std::vector<int> const& component_of_vertices() const;

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -4,6 +4,8 @@
 
 #include "../interpreter/environment_fwd.hpp"
 #include "../interpreter/execute.hpp"
+#include "../tarjan_solver.hpp"
+#include "test_status.hpp"
 #include "test_utils.hpp"
 #include "tester.hpp"
 
@@ -381,8 +383,51 @@ void interpreter_tests(Test::Tester& tests) {
 
 }
 
+void tarjan_algorithm_tests(Test::Tester& tester) {
+	tester.add_test(std::make_unique<Test::NormalTestSet>(std::vector<Test::NormalTestSet::TestFunction>{
+		+[]() -> TestReport {
+			TarjanSolver solver (3);
+			solver.add_edge(0, 1);
+			solver.add_edge(1, 2);
+			solver.add_edge(2, 0);
+			solver.solve();
+
+			auto const& cov = solver.component_of_vertices();
+
+			if (cov[0] != cov[1] || cov[0] != cov[2])
+			    return {
+				    test_status::Fail,
+				    "All vertices in a 3-cycle should be in the same SCC"
+			    };
+
+		    return { test_status::Ok };
+		},
+		+[]() -> TestReport {
+
+			TarjanSolver solver (2);
+			solver.add_edge(0, 1);
+			solver.solve();
+
+			auto const& cov = solver.component_of_vertices();
+		    if (cov[0] == cov[1])
+				return {
+					test_status::Fail,
+					"Vertices that are only weakly connected should not be in the same SCC"
+				};
+
+			if (cov[0] < cov[1])
+				return {
+					test_status::Fail,
+					"SCCs should be in reverse topological sort."
+				};
+
+		    return { test_status::Ok };
+		} }));
+}
+
 int main() {
 	Test::Tester tests;
 	interpreter_tests(tests);
+	tarjan_algorithm_tests(tests);
 	tests.execute();
 }

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -7,11 +7,9 @@
 #include "test_utils.hpp"
 #include "tester.hpp"
 
-void interpreter_tests() {
+void interpreter_tests(Test::Tester& tests) {
 	using TestCase = Test::InterpreterTestSet;
 	using Testers = std::vector<Test::Interpret>;
-
-	Test::Tester tests;
 
 	/*
 	tests.add_test(
@@ -381,9 +379,10 @@ void interpreter_tests() {
 		})
 	);
 
-	tests.execute();
 }
 
 int main() {
-	interpreter_tests();
+	Test::Tester tests;
+	interpreter_tests(tests);
+	tests.execute();
 }


### PR DESCRIPTION
To separate declarations into rec-blocks, we need to find the strongly
connected components of the graph formed by declarations referencing
each other.

Once we get that, we need to find a topological sort of that
condensation graph. Luckily Tarjan's algorithm gives us the SCCs already
topologically sorted, so there is no need for additional computation.

[Wikipedia link](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm)

TODO:
- ~add an API to retrieve the result~
- ~testing~