### PR TITLE
Test: Add a NormalTestSet, for tests that don't need an interpreter

### DIFF
--- a/src/test/test_set.cpp
+++ b/src/test/test_set.cpp
@@ -11,8 +11,6 @@ InterpreterTestSet::InterpreterTestSet(std::string s, Interpret tf)
 InterpreterTestSet::InterpreterTestSet(std::string s, std::vector<Interpret> tfs)
     : m_source(std::move(s)), m_testers(std::move(tfs)) {};
 
-
-
 TestReport InterpreterTestSet::execute() {
 	if (m_testers.empty())
 		return { test_status::Empty };
@@ -31,4 +29,29 @@ TestReport InterpreterTestSet::execute() {
 	return { test_status::Ok };
 }
 
+
+NormalTestSet::NormalTestSet() {}
+
+NormalTestSet::NormalTestSet(std::vector<TestFunction> testers)
+    : m_testers { std::move(testers) } {}
+
+TestReport NormalTestSet::execute() {
+	if (m_testers.empty())
+		return { test_status::Empty };
+
+	try {
+		for (auto* test : m_testers) {
+			auto report = test();
+
+			// FUTURE: Accumulate failed tests
+			if (report.m_code != test_status::Ok)
+				return report;
+		}
+	} catch (std::exception const& e) {
+		return { test_status::Error, e.what() };
+	}
+
+	return { test_status::Ok };
 }
+
+} // namespace Test

--- a/src/test/test_set.hpp
+++ b/src/test/test_set.hpp
@@ -30,4 +30,15 @@ struct InterpreterTestSet : public TestSet {
 	TestReport execute() override;
 };
 
+struct NormalTestSet : public TestSet {
+	using TestFunction = TestReport (*)();
+
+	NormalTestSet();
+	NormalTestSet(std::vector<TestFunction>);
+
+	std::vector<TestFunction> m_testers;
+
+	TestReport execute() override;
+};
+
 }


### PR DESCRIPTION
I am just getting this out of the way to be able to add tests for my implementation of Tarjan's algorithm in my other PR.

I know it doesn't have the features we probably want, but we can do that later: I don't wanna get too caught up on the test framework while I'm working on the type system