### PR TITLE
Add gc handles

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ PenaltyExcessCharacter: 5
 ReflowComments: false
 PenaltyBreakComment: 50 
 
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,6 +26,7 @@ ITPR_OBJNAMES := \
 	interpreter/eval.o \
 	interpreter/execute.o \
 	interpreter/garbage_collector.o \
+	interpreter/gc_ptr.o \
 	interpreter/value.o \
 	interpreter/native.o
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,8 @@ ITPR_OBJNAMES := \
 	interpreter/garbage_collector.o \
 	interpreter/gc_ptr.o \
 	interpreter/value.o \
-	interpreter/native.o
+	interpreter/native.o \
+	interpreter/utils.o
 
 TEST_OBJNAMES := \
 	test/tester.o \

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -114,28 +114,28 @@ gc_ptr<String> Environment::new_string(std::string s)
 { return m_gc->new_string(std::move(s)); }
 
 gc_ptr<Array> Environment::new_list(ArrayType elements)
-{ return m_gc->new_list_unsafe(std::move(elements)); }
+{ return m_gc->new_list(std::move(elements)); }
 
 gc_ptr<Object> Environment::new_object(ObjectType declarations)
-{ return m_gc->new_object_unsafe(std::move(declarations)); }
+{ return m_gc->new_object(std::move(declarations)); }
 
 gc_ptr<Dictionary> Environment::new_dictionary(ObjectType declarations)
-{ return m_gc->new_dictionary_unsafe(std::move(declarations)); }
+{ return m_gc->new_dictionary(std::move(declarations)); }
 
 gc_ptr<Function> Environment::new_function(FunctionType def, ObjectType s)
-{ return m_gc->new_function_unsafe(def, std::move(s)); }
+{ return m_gc->new_function(def, std::move(s)); }
 
 gc_ptr<NativeFunction> Environment::new_native_function(NativeFunctionType* fptr)
-{ return m_gc->new_native_function_unsafe(fptr); }
+{ return m_gc->new_native_function(fptr); }
 
 gc_ptr<Error> Environment::new_error(std::string e)
-{ return m_gc->new_error_unsafe(e); }
+{ return m_gc->new_error(e); }
 
 gc_ptr<Reference> Environment::new_reference(Value* v) {
 	assert(
 	    v->type() != value_type::Reference
 	    && "References to references are not allowed.");
-	return m_gc->new_reference_unsafe(v);
+	return m_gc->new_reference(v);
 }
 
 } // Interpreter

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -98,40 +98,40 @@ Null* Environment::null()
 { return m_gc->null(); }
 
 Integer* Environment::new_integer(int i)
-{ return m_gc->new_integer(i); }
+{ return m_gc->new_integer_unsafe(i); }
 
 Float* Environment::new_float(float f)
-{ return m_gc->new_float(f); }
+{ return m_gc->new_float_unsafe(f); }
 
 Boolean* Environment::new_boolean(bool b)
-{ return m_gc->new_boolean(b); }
+{ return m_gc->new_boolean_unsafe(b); }
 
 String* Environment::new_string(std::string s)
-{ return m_gc->new_string(s); }
+{ return m_gc->new_string_unsafe(std::move(s)); }
 
 Array* Environment::new_list(ArrayType elements)
-{ return m_gc->new_list(std::move(elements)); }
+{ return m_gc->new_list_unsafe(std::move(elements)); }
 
 Object* Environment::new_object(ObjectType declarations)
-{ return m_gc->new_object(std::move(declarations)); }
+{ return m_gc->new_object_unsafe(std::move(declarations)); }
 
 Dictionary* Environment::new_dictionary(ObjectType declarations)
-{ return m_gc->new_dictionary(std::move(declarations)); }
+{ return m_gc->new_dictionary_unsafe(std::move(declarations)); }
 
 Function* Environment::new_function(FunctionType def, ObjectType s)
-{ return m_gc->new_function(def, std::move(s)); }
+{ return m_gc->new_function_unsafe(def, std::move(s)); }
 
 NativeFunction* Environment::new_native_function(NativeFunctionType* fptr)
-{ return m_gc->new_native_function(fptr); }
+{ return m_gc->new_native_function_unsafe(fptr); }
 
 Error* Environment::new_error(std::string e)
-{ return m_gc->new_error(e); }
+{ return m_gc->new_error_unsafe(e); }
 
 Reference* Environment::new_reference(Value* v) {
 	assert(
 	    v->type() != value_type::Reference
 	    && "References to references are not allowed.");
-	return m_gc->new_reference(v);
+	return m_gc->new_reference_unsafe(v);
 }
 
 } // Interpreter

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -80,12 +80,16 @@ void Environment::direct_declare(const Identifier& i, Reference* r) {
 	m_scope->declare(i, r);
 }
 
+void Environment::declare(const Identifier& i, gc_ptr<Value> v) {
+	declare(i, v.get());
+}
+
 void Environment::declare(const Identifier& i, Value* v) {
 	if(v->type() == value_type::Reference){
 		assert(0 && "declared a reference!");
 	}
 	auto r = new_reference(v);
-	m_scope->declare(i, r);
+	m_scope->declare(i, r.get());
 }
 
 Reference* Environment::access(const Identifier& i) {
@@ -109,25 +113,25 @@ gc_ptr<Boolean> Environment::new_boolean(bool b)
 gc_ptr<String> Environment::new_string(std::string s)
 { return m_gc->new_string(std::move(s)); }
 
-Array* Environment::new_list(ArrayType elements)
+gc_ptr<Array> Environment::new_list(ArrayType elements)
 { return m_gc->new_list_unsafe(std::move(elements)); }
 
-Object* Environment::new_object(ObjectType declarations)
+gc_ptr<Object> Environment::new_object(ObjectType declarations)
 { return m_gc->new_object_unsafe(std::move(declarations)); }
 
-Dictionary* Environment::new_dictionary(ObjectType declarations)
+gc_ptr<Dictionary> Environment::new_dictionary(ObjectType declarations)
 { return m_gc->new_dictionary_unsafe(std::move(declarations)); }
 
-Function* Environment::new_function(FunctionType def, ObjectType s)
+gc_ptr<Function> Environment::new_function(FunctionType def, ObjectType s)
 { return m_gc->new_function_unsafe(def, std::move(s)); }
 
-NativeFunction* Environment::new_native_function(NativeFunctionType* fptr)
+gc_ptr<NativeFunction> Environment::new_native_function(NativeFunctionType* fptr)
 { return m_gc->new_native_function_unsafe(fptr); }
 
-Error* Environment::new_error(std::string e)
+gc_ptr<Error> Environment::new_error(std::string e)
 { return m_gc->new_error_unsafe(e); }
 
-Reference* Environment::new_reference(Value* v) {
+gc_ptr<Reference> Environment::new_reference(Value* v) {
 	assert(
 	    v->type() != value_type::Reference
 	    && "References to references are not allowed.");

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -97,8 +97,8 @@ Reference* Environment::access(const Identifier& i) {
 Null* Environment::null()
 { return m_gc->null(); }
 
-Integer* Environment::new_integer(int i)
-{ return m_gc->new_integer_unsafe(i); }
+gc_ptr<Integer> Environment::new_integer(int i)
+{ return m_gc->new_integer(i); }
 
 Float* Environment::new_float(float f)
 { return m_gc->new_float_unsafe(f); }

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -100,11 +100,11 @@ Null* Environment::null()
 gc_ptr<Integer> Environment::new_integer(int i)
 { return m_gc->new_integer(i); }
 
-Float* Environment::new_float(float f)
-{ return m_gc->new_float_unsafe(f); }
+gc_ptr<Float> Environment::new_float(float f)
+{ return m_gc->new_float(f); }
 
-Boolean* Environment::new_boolean(bool b)
-{ return m_gc->new_boolean_unsafe(b); }
+gc_ptr<Boolean> Environment::new_boolean(bool b)
+{ return m_gc->new_boolean(b); }
 
 String* Environment::new_string(std::string s)
 { return m_gc->new_string_unsafe(std::move(s)); }

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -106,8 +106,8 @@ gc_ptr<Float> Environment::new_float(float f)
 gc_ptr<Boolean> Environment::new_boolean(bool b)
 { return m_gc->new_boolean(b); }
 
-String* Environment::new_string(std::string s)
-{ return m_gc->new_string_unsafe(std::move(s)); }
+gc_ptr<String> Environment::new_string(std::string s)
+{ return m_gc->new_string(std::move(s)); }
 
 Array* Environment::new_list(ArrayType elements)
 { return m_gc->new_list_unsafe(std::move(elements)); }

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -41,6 +41,7 @@ struct Environment {
 
 	// Binds a name to a new reference of the given value
 	void declare(const Identifier&, Value*);
+	void declare(const Identifier&, gc_ptr<Value>);
 	// Binds a name to the given reference
 	void direct_declare(const Identifier& i, Reference* v);
 	Reference* access(const Identifier&);
@@ -50,13 +51,13 @@ struct Environment {
 	auto new_float(float) -> gc_ptr<Float>;
 	auto new_boolean(bool) -> gc_ptr<Boolean>;
 	auto new_string(std::string) -> gc_ptr<String>;
-	auto new_list(ArrayType) -> Array*;
-	auto new_object(ObjectType) -> Object*;
-	auto new_dictionary(ObjectType) -> Dictionary*;
-	auto new_function(FunctionType, ObjectType) -> Function*;
-	auto new_native_function(NativeFunctionType*) -> NativeFunction*;
-	auto new_error(std::string) -> Error*;
-	auto new_reference(Value*) -> Reference*;
+	auto new_list(ArrayType) -> gc_ptr<Array>;
+	auto new_object(ObjectType) -> gc_ptr<Object>;
+	auto new_dictionary(ObjectType) -> gc_ptr<Dictionary>;
+	auto new_function(FunctionType, ObjectType) -> gc_ptr<Function>;
+	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
+	auto new_error(std::string) -> gc_ptr<Error>;
+	auto new_reference(Value*) -> gc_ptr<Reference>;
 };
 
 } // Interpreter

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -49,7 +49,7 @@ struct Environment {
 	auto new_integer(int) -> gc_ptr<Integer>;
 	auto new_float(float) -> gc_ptr<Float>;
 	auto new_boolean(bool) -> gc_ptr<Boolean>;
-	auto new_string(std::string) -> String*;
+	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_list(ArrayType) -> Array*;
 	auto new_object(ObjectType) -> Object*;
 	auto new_dictionary(ObjectType) -> Dictionary*;

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -47,8 +47,8 @@ struct Environment {
 
 	auto null() -> Null*;
 	auto new_integer(int) -> gc_ptr<Integer>;
-	auto new_float(float) -> Float*;
-	auto new_boolean(bool) -> Boolean*;
+	auto new_float(float) -> gc_ptr<Float>;
+	auto new_boolean(bool) -> gc_ptr<Boolean>;
 	auto new_string(std::string) -> String*;
 	auto new_list(ArrayType) -> Array*;
 	auto new_object(ObjectType) -> Object*;

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -2,6 +2,7 @@
 
 #include "value.hpp"
 #include "error.hpp"
+#include "gc_ptr.hpp"
 
 namespace Interpreter {
 
@@ -45,7 +46,7 @@ struct Environment {
 	Reference* access(const Identifier&);
 
 	auto null() -> Null*;
-	auto new_integer(int) -> Integer*;
+	auto new_integer(int) -> gc_ptr<Integer>;
 	auto new_float(float) -> Float*;
 	auto new_boolean(bool) -> Boolean*;
 	auto new_string(std::string) -> String*;

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -39,7 +39,7 @@ gc_ptr<Value> eval(TypedAST::IntegerLiteral* ast, Environment& e) {
 	return e.new_integer(std::stoi(ast->text()));
 }
 
-Value* eval(TypedAST::StringLiteral* ast, Environment& e) {
+gc_ptr<Value> eval(TypedAST::StringLiteral* ast, Environment& e) {
 	return e.new_string(ast->text());
 };
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -28,11 +28,10 @@ Value* eval(TypedAST::Declaration* ast, Environment& e) {
 		auto unboxed_val = unboxed(value.get());
 		ref->m_value = unboxed_val;
 	}
-
 	return e.null();
 };
 
-Value* eval(TypedAST::NumberLiteral* ast, Environment& e) {
+gc_ptr<Value> eval(TypedAST::NumberLiteral* ast, Environment& e) {
 	return e.new_float(std::stof(ast->text()));
 }
 
@@ -44,7 +43,7 @@ Value* eval(TypedAST::StringLiteral* ast, Environment& e) {
 	return e.new_string(ast->text());
 };
 
-Value* eval(TypedAST::BooleanLiteral* ast, Environment& e) {
+gc_ptr<Value> eval(TypedAST::BooleanLiteral* ast, Environment& e) {
 	bool b = ast->m_token->m_type == token_type::KEYWORD_TRUE;
 	return e.new_boolean(b);
 };
@@ -289,7 +288,7 @@ gc_ptr<Value> eval(TypedAST::TypedAST* ast, Environment& e) {
 	case ast_type::NumberLiteral:
 		return eval(static_cast<TypedAST::NumberLiteral*>(ast), e);
 	case ast_type::IntegerLiteral:
-		return eval(static_cast<TypedAST::IntegerLiteral*>(ast), e).get();
+		return eval(static_cast<TypedAST::IntegerLiteral*>(ast), e);
 	case ast_type::StringLiteral:
 		return eval(static_cast<TypedAST::StringLiteral*>(ast), e);
 	case ast_type::BooleanLiteral:

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -34,7 +34,7 @@ Value* eval(TypedAST::NumberLiteral* ast, Environment& e) {
 	return e.new_float(std::stof(ast->text()));
 }
 
-Value* eval(TypedAST::IntegerLiteral* ast, Environment& e) {
+gc_ptr<Value> eval(TypedAST::IntegerLiteral* ast, Environment& e) {
 	return e.new_integer(std::stoi(ast->text()));
 }
 
@@ -276,7 +276,7 @@ Value* eval(TypedAST::TypedAST* ast, Environment& e) {
 	case ast_type::NumberLiteral:
 		return eval(static_cast<TypedAST::NumberLiteral*>(ast), e);
 	case ast_type::IntegerLiteral:
-		return eval(static_cast<TypedAST::IntegerLiteral*>(ast), e);
+		return eval(static_cast<TypedAST::IntegerLiteral*>(ast), e).get();
 	case ast_type::StringLiteral:
 		return eval(static_cast<TypedAST::StringLiteral*>(ast), e);
 	case ast_type::BooleanLiteral:

--- a/src/interpreter/eval.hpp
+++ b/src/interpreter/eval.hpp
@@ -2,6 +2,7 @@
 
 #include "value_fwd.hpp"
 #include "environment_fwd.hpp"
+#include "gc_ptr.hpp"
 
 namespace TypedAST {
 struct TypedAST;
@@ -9,7 +10,7 @@ struct TypedAST;
 
 namespace Interpreter {
 
-Value* eval(TypedAST::TypedAST*, Environment&);
+gc_ptr<Value> eval(TypedAST::TypedAST*, Environment&);
 
 }
 

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -10,6 +10,7 @@
 #include "eval.hpp"
 #include "garbage_collector.hpp"
 #include "native.hpp"
+#include "utils.hpp"
 
 namespace Interpreter {
 
@@ -58,7 +59,9 @@ Value* eval_expression(const std::string& expr, Environment& env) {
 	auto top_level_call_ast = parse_expression(expr, ta);
 	auto top_level_call = TypedAST::get_unique(top_level_call_ast.m_result);
 
-	return unboxed(eval(top_level_call.get(), env));
+	// TODO: return a gc_ptr
+	auto value = eval(top_level_call.get(), env);
+	return unboxed(value.get());
 }
 
 } // namespace Interpreter

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -62,114 +62,76 @@ Null* GC::null() {
 	return m_null;
 }
 
+
+
+
+
+
+
 gc_ptr<Object> GC::new_object(ObjectType declarations) {
-	return { new_object_unsafe(std::move(declarations)) };
-}
-
-gc_ptr<Dictionary> GC::new_dictionary(ObjectType declarations) {
-	return { new_dictionary_unsafe(std::move(declarations)) };
-}
-
-gc_ptr<Array> GC::new_list(ArrayType elements) {
-	return { new_list_unsafe(std::move(elements)) };
-}
-
-gc_ptr<Integer> GC::new_integer(int i) {
-	return { new_integer_unsafe(std::move(i)) };
-}
-
-gc_ptr<Float> GC::new_float(float f) {
-	return { new_float_unsafe(std::move(f)) };
-}
-
-gc_ptr<Boolean> GC::new_boolean(bool b) {
-	return { new_boolean_unsafe(std::move(b)) };
-}
-
-gc_ptr<String> GC::new_string(std::string s) {
-	return { new_string_unsafe(std::move(s)) };
-}
-
-gc_ptr<Function> GC::new_function(FunctionType def, ObjectType captures) {
-	return { new_function_unsafe(std::move(def), std::move(captures)) };
-}
-
-gc_ptr<NativeFunction> GC::new_native_function(NativeFunctionType* fptr) {
-	return { new_native_function_unsafe(std::move(fptr)) };
-}
-
-gc_ptr<Error> GC::new_error(std::string s) {
-	return { new_error_unsafe(std::move(s)) };
-}
-
-gc_ptr<Reference> GC::new_reference(Value* v) {
-	return { new_reference_unsafe(std::move(v)) };
-}
-
-Object* GC::new_object_unsafe(ObjectType declarations) {
 	auto result = new Object;
 	result->m_value = std::move(declarations);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Dictionary* GC::new_dictionary_unsafe(ObjectType declarations) {
+gc_ptr<Dictionary> GC::new_dictionary(ObjectType declarations) {
 	auto result = new Dictionary;
 	result->m_value = std::move(declarations);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Array* GC::new_list_unsafe(ArrayType elements) {
+gc_ptr<Array> GC::new_list(ArrayType elements) {
 	auto result = new Array;
 	result->m_value = std::move(elements);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Integer* GC::new_integer_unsafe(int i) {
+gc_ptr<Integer> GC::new_integer(int i) {
 	auto result = new Integer(i);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Float* GC::new_float_unsafe(float f) {
+gc_ptr<Float> GC::new_float(float f) {
 	auto result = new Float(f);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Boolean* GC::new_boolean_unsafe(bool b) {
+gc_ptr<Boolean> GC::new_boolean(bool b) {
 	auto result = new Boolean(b);
 	m_blocks.push_back(result);
 	return result;
 }
 
-String* GC::new_string_unsafe(std::string s) {
+gc_ptr<String> GC::new_string(std::string s) {
 	auto result = new String(std::move(s));
 	m_blocks.push_back(result);
 	return result;
 }
 
-Function* GC::new_function_unsafe(FunctionType def, ObjectType captures) {
+gc_ptr<Function> GC::new_function(FunctionType def, ObjectType captures) {
 	auto result = new Function(std::move(def), std::move(captures));
 	m_blocks.push_back(result);
 	return result;
 }
 
-NativeFunction* GC::new_native_function_unsafe(NativeFunctionType* fptr) {
+gc_ptr<NativeFunction> GC::new_native_function(NativeFunctionType* fptr) {
 	auto result = new NativeFunction(fptr);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Error* GC::new_error_unsafe(std::string s) {
+gc_ptr<Error> GC::new_error(std::string s) {
 	auto result = new Error(std::move(s));
 	m_blocks.push_back(result);
 	return result;
 }
 
-Reference* GC::new_reference_unsafe(Value* v) {
+gc_ptr<Reference> GC::new_reference(Value* v) {
 	auto result = new Reference(std::move(v));
 	m_blocks.push_back(result);
 	return result;

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -62,70 +62,114 @@ Null* GC::null() {
 	return m_null;
 }
 
-Object* GC::new_object(ObjectType declarations) {
+gc_ptr<Object> GC::new_object(ObjectType declarations) {
+	return { new_object_unsafe(std::move(declarations)) };
+}
+
+gc_ptr<Dictionary> GC::new_dictionary(ObjectType declarations) {
+	return { new_dictionary_unsafe(std::move(declarations)) };
+}
+
+gc_ptr<Array> GC::new_list(ArrayType elements) {
+	return { new_list_unsafe(std::move(elements)) };
+}
+
+gc_ptr<Integer> GC::new_integer(int i) {
+	return { new_integer_unsafe(std::move(i)) };
+}
+
+gc_ptr<Float> GC::new_float(float f) {
+	return { new_float_unsafe(std::move(f)) };
+}
+
+gc_ptr<Boolean> GC::new_boolean(bool b) {
+	return { new_boolean_unsafe(std::move(b)) };
+}
+
+gc_ptr<String> GC::new_string(std::string s) {
+	return { new_string_unsafe(std::move(s)) };
+}
+
+gc_ptr<Function> GC::new_function(FunctionType def, ObjectType captures) {
+	return { new_function_unsafe(std::move(def), std::move(captures)) };
+}
+
+gc_ptr<NativeFunction> GC::new_native_function(NativeFunctionType* fptr) {
+	return { new_native_function_unsafe(std::move(fptr)) };
+}
+
+gc_ptr<Error> GC::new_error(std::string s) {
+	return { new_error_unsafe(std::move(s)) };
+}
+
+gc_ptr<Reference> GC::new_reference(Value* v) {
+	return { new_reference_unsafe(std::move(v)) };
+}
+
+Object* GC::new_object_unsafe(ObjectType declarations) {
 	auto result = new Object;
 	result->m_value = std::move(declarations);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Dictionary* GC::new_dictionary(ObjectType declarations) {
+Dictionary* GC::new_dictionary_unsafe(ObjectType declarations) {
 	auto result = new Dictionary;
 	result->m_value = std::move(declarations);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Array* GC::new_list(ArrayType elements) {
+Array* GC::new_list_unsafe(ArrayType elements) {
 	auto result = new Array;
 	result->m_value = std::move(elements);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Integer* GC::new_integer(int i) {
+Integer* GC::new_integer_unsafe(int i) {
 	auto result = new Integer(i);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Float* GC::new_float(float f) {
+Float* GC::new_float_unsafe(float f) {
 	auto result = new Float(f);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Boolean* GC::new_boolean(bool b) {
+Boolean* GC::new_boolean_unsafe(bool b) {
 	auto result = new Boolean(b);
 	m_blocks.push_back(result);
 	return result;
 }
 
-String* GC::new_string(std::string s) {
+String* GC::new_string_unsafe(std::string s) {
 	auto result = new String(std::move(s));
 	m_blocks.push_back(result);
 	return result;
 }
 
-Function* GC::new_function(FunctionType def, ObjectType captures) {
+Function* GC::new_function_unsafe(FunctionType def, ObjectType captures) {
 	auto result = new Function(std::move(def), std::move(captures));
 	m_blocks.push_back(result);
 	return result;
 }
 
-NativeFunction* GC::new_native_function(NativeFunctionType* fptr) {
+NativeFunction* GC::new_native_function_unsafe(NativeFunctionType* fptr) {
 	auto result = new NativeFunction(fptr);
 	m_blocks.push_back(result);
 	return result;
 }
 
-Error* GC::new_error(std::string s) {
+Error* GC::new_error_unsafe(std::string s) {
 	auto result = new Error(std::move(s));
 	m_blocks.push_back(result);
 	return result;
 }
 
-Reference* GC::new_reference(Value* v) {
+Reference* GC::new_reference_unsafe(Value* v) {
 	auto result = new Reference(std::move(v));
 	m_blocks.push_back(result);
 	return result;

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -25,6 +25,12 @@ void GC::mark_roots() {
 	for (auto* root : m_roots) {
 		gc_visit(root);
 	}
+
+	for (auto* val : m_blocks) {
+		if (val->m_cpp_refcount != 0) {
+			gc_visit(val);
+		}
+	}
 }
 
 void GC::sweep() {

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -4,6 +4,7 @@
 
 #include "value.hpp"
 #include "error.hpp"
+#include "gc_ptr.hpp"
 
 namespace Interpreter {
 
@@ -26,17 +27,30 @@ public:
 	void add_root(Value* new_root);
 
 	auto null() -> Null*;
-	auto new_object(ObjectType) -> Object*;
-	auto new_dictionary(ObjectType) -> Dictionary*;
-	auto new_list(ArrayType) -> Array*;
-	auto new_integer(int) -> Integer*;
-	auto new_float(float) -> Float*;
-	auto new_boolean(bool) -> Boolean*;
-	auto new_string(std::string) -> String*;
-	auto new_function(FunctionType, ObjectType) -> Function*;
-	auto new_native_function(NativeFunctionType*) -> NativeFunction*;
-	auto new_error(std::string) -> Error*;
-	auto new_reference(Value*) -> Reference*;
+
+	auto new_object(ObjectType) -> gc_ptr<Object>;
+	auto new_dictionary(ObjectType) -> gc_ptr<Dictionary>;
+	auto new_list(ArrayType) -> gc_ptr<Array>;
+	auto new_integer(int) -> gc_ptr<Integer>;
+	auto new_float(float) -> gc_ptr<Float>;
+	auto new_boolean(bool) -> gc_ptr<Boolean>;
+	auto new_string(std::string) -> gc_ptr<String>;
+	auto new_function(FunctionType, ObjectType) -> gc_ptr<Function>;
+	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
+	auto new_error(std::string) -> gc_ptr<Error>;
+	auto new_reference(Value*) -> gc_ptr<Reference>;
+
+	auto new_object_unsafe(ObjectType) -> Object*;
+	auto new_dictionary_unsafe(ObjectType) -> Dictionary*;
+	auto new_list_unsafe(ArrayType) -> Array*;
+	auto new_integer_unsafe(int) -> Integer*;
+	auto new_float_unsafe(float) -> Float*;
+	auto new_boolean_unsafe(bool) -> Boolean*;
+	auto new_string_unsafe(std::string) -> String*;
+	auto new_function_unsafe(FunctionType, ObjectType) -> Function*;
+	auto new_native_function_unsafe(NativeFunctionType*) -> NativeFunction*;
+	auto new_error_unsafe(std::string) -> Error*;
+	auto new_reference_unsafe(Value*) -> Reference*;
 };
 
 } // namespace Interpreter

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -39,18 +39,6 @@ public:
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 	auto new_reference(Value*) -> gc_ptr<Reference>;
-
-	auto new_object_unsafe(ObjectType) -> Object*;
-	auto new_dictionary_unsafe(ObjectType) -> Dictionary*;
-	auto new_list_unsafe(ArrayType) -> Array*;
-	auto new_integer_unsafe(int) -> Integer*;
-	auto new_float_unsafe(float) -> Float*;
-	auto new_boolean_unsafe(bool) -> Boolean*;
-	auto new_string_unsafe(std::string) -> String*;
-	auto new_function_unsafe(FunctionType, ObjectType) -> Function*;
-	auto new_native_function_unsafe(NativeFunctionType*) -> NativeFunction*;
-	auto new_error_unsafe(std::string) -> Error*;
-	auto new_reference_unsafe(Value*) -> Reference*;
 };
 
 } // namespace Interpreter

--- a/src/interpreter/gc_ptr.cpp
+++ b/src/interpreter/gc_ptr.cpp
@@ -1,0 +1,1 @@
+#include "gc_ptr.hpp"

--- a/src/interpreter/gc_ptr.hpp
+++ b/src/interpreter/gc_ptr.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+template <typename ValueType>
+struct gc_ptr {
+private:
+	ValueType* m_ptr;
+
+public:
+	gc_ptr(gc_ptr const& o) : m_ptr { o.m_ptr } {
+		m_ptr->m_cpp_refcount += 1;
+	}
+
+	gc_ptr(gc_ptr&& o) : m_ptr { o.m_ptr } {
+		o.m_ptr = nullptr;
+	}
+
+	gc_ptr(ValueType* ptr) : m_ptr { ptr } {
+		m_ptr->m_cpp_refcount += 1;
+	}
+
+	~gc_ptr() {
+		if (m_ptr)
+			m_ptr->m_cpp_refcount -= 1;
+	}
+
+	ValueType* get() const {
+		return m_ptr;
+	}
+
+	ValueType* operator-> () const {
+		return get();
+	}
+};

--- a/src/interpreter/gc_ptr.hpp
+++ b/src/interpreter/gc_ptr.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 template <typename ValueType>
 struct gc_ptr {
 private:
@@ -11,6 +13,13 @@ public:
 	}
 
 	gc_ptr(gc_ptr&& o) : m_ptr { o.m_ptr } {
+		o.m_ptr = nullptr;
+	}
+
+	template <typename T> friend class gc_ptr;
+
+	template <typename T, typename = typename std::enable_if<std::is_convertible<T*, ValueType*>::value>::type>
+	gc_ptr(gc_ptr<T>&& o) : m_ptr { o.m_ptr } {
 		o.m_ptr = nullptr;
 	}
 

--- a/src/interpreter/gc_ptr.hpp
+++ b/src/interpreter/gc_ptr.hpp
@@ -9,11 +9,16 @@ private:
 
 public:
 	gc_ptr(gc_ptr const& o) : m_ptr { o.m_ptr } {
-		m_ptr->m_cpp_refcount += 1;
+		if(m_ptr)
+			m_ptr->m_cpp_refcount += 1;
 	}
 
 	gc_ptr(gc_ptr&& o) : m_ptr { o.m_ptr } {
 		o.m_ptr = nullptr;
+	}
+
+	explicit operator bool () const {
+		return m_ptr != nullptr;
 	}
 
 	template <typename T> friend class gc_ptr;
@@ -24,7 +29,8 @@ public:
 	}
 
 	gc_ptr(ValueType* ptr) : m_ptr { ptr } {
-		m_ptr->m_cpp_refcount += 1;
+		if(m_ptr)
+			m_ptr->m_cpp_refcount += 1;
 	}
 
 	~gc_ptr() {

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -37,10 +37,10 @@ int main() {
 			auto top_level_call_ast = parse_expression("__invoke()", ta);
 			auto top_level_call = TypedAST::convertAST(top_level_call_ast.m_result.get());
 
-			auto* result = eval(top_level_call, env);
+			auto result = eval(top_level_call, env);
 
 			if (result)
-				Interpreter::print(result);
+				Interpreter::print(result.get());
 			else
 				std::cout << "(nullptr)\n";
 

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -80,7 +80,7 @@ Value* array_join(ArrayType v, Environment& e) {
         if (i < array->m_value.size()-1)
             result << string->m_value;
     }
-    return e.new_string(result.str());
+    return e.new_string(result.str()).get();
 }
 
 Value* dummy(ArrayType v, Environment& e){
@@ -107,7 +107,7 @@ Value* value_add(ArrayType v, Environment& e) {
 	case value_type::String:
 		return e.new_string(
 		    static_cast<String*>(lhs_val)->m_value
-		    + static_cast<String*>(rhs_val)->m_value);
+		    + static_cast<String*>(rhs_val)->m_value).get();
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -10,6 +10,8 @@
 
 namespace Interpreter {
 
+// TODO: All of these should return gc_ptr
+
 // print(...) prints the values or references in ...
 Value* print (ArrayType v, Environment& e) {
     for (auto value : v) {
@@ -101,7 +103,7 @@ Value* value_add(ArrayType v, Environment& e) {
 	case value_type::Float:
 		return e.new_float(
 		    static_cast<Float*>(lhs_val)->m_value
-		    + static_cast<Float*>(rhs_val)->m_value);
+		    + static_cast<Float*>(rhs_val)->m_value).get();
 	case value_type::String:
 		return e.new_string(
 		    static_cast<String*>(lhs_val)->m_value
@@ -129,7 +131,7 @@ Value* value_sub(ArrayType v, Environment& e) {
 	case value_type::Float:
 		return e.new_float(
 		    static_cast<Float*>(lhs_val)->m_value
-		    - static_cast<Float*>(rhs_val)->m_value);
+		    - static_cast<Float*>(rhs_val)->m_value).get();
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];
@@ -153,7 +155,7 @@ Value* value_mul(ArrayType v, Environment& e) {
 	case value_type::Float:
 		return e.new_float(
 		    static_cast<Float*>(lhs_val)->m_value
-		    * static_cast<Float*>(rhs_val)->m_value);
+		    * static_cast<Float*>(rhs_val)->m_value).get();
 	default:
 		std::cerr << "ERROR: can't multiply values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];
@@ -177,7 +179,7 @@ Value* value_div(ArrayType v, Environment& e) {
 	case value_type::Float:
 		return e.new_float(
 		    static_cast<Float*>(lhs_val)->m_value
-		    / static_cast<Float*>(rhs_val)->m_value);
+		    / static_cast<Float*>(rhs_val)->m_value).get();
 	default:
 		std::cerr << "ERROR: can't divide values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];
@@ -195,7 +197,7 @@ Value* value_logicand(ArrayType v, Environment& e) {
 	    and rhs_val->type() == value_type::Boolean)
 		return e.new_boolean(
 		    static_cast<Boolean*>(lhs_val)->m_value
-		    and static_cast<Boolean*>(rhs_val)->m_value);
+		    and static_cast<Boolean*>(rhs_val)->m_value).get();
 	std::cerr << "ERROR: logical and operator not defined for types "
 	          << value_type_string[static_cast<int>(lhs_val->type())] << " and "
 	          << value_type_string[static_cast<int>(rhs_val->type())];
@@ -212,7 +214,7 @@ Value* value_logicor(ArrayType v, Environment& e) {
 	    and rhs_val->type() == value_type::Boolean)
 		return e.new_boolean(
 		    static_cast<Boolean*>(lhs_val)->m_value
-		    or static_cast<Boolean*>(rhs_val)->m_value);
+		    or static_cast<Boolean*>(rhs_val)->m_value).get();
 	std::cerr << "ERROR: logical or operator not defined for types "
 	          << value_type_string[static_cast<int>(lhs_val->type())] << " and "
 	          << value_type_string[static_cast<int>(rhs_val->type())];
@@ -229,7 +231,7 @@ Value* value_logicxor(ArrayType v, Environment& e) {
 	    and rhs_val->type() == value_type::Boolean)
 		return e.new_boolean(
 		    static_cast<Boolean*>(lhs_val)->m_value
-		    != static_cast<Boolean*>(rhs_val)->m_value);
+		    != static_cast<Boolean*>(rhs_val)->m_value).get();
 	std::cerr << "ERROR: exclusive or operator not defined for types "
 	          << value_type_string[static_cast<int>(lhs_val->type())] << " and "
 	          << value_type_string[static_cast<int>(rhs_val->type())];
@@ -246,23 +248,23 @@ Value* value_equals(ArrayType v, Environment& e) {
 
 	switch (lhs_val->type()) {
 	case value_type::Null:
-		return e.new_boolean(true);
+		return e.new_boolean(true).get();
 	case value_type::Integer:
 		return e.new_boolean(
 		    static_cast<Integer*>(lhs_val)->m_value
-		    == static_cast<Integer*>(rhs_val)->m_value);
+		    == static_cast<Integer*>(rhs_val)->m_value).get();
 	case value_type::Float:
 		return e.new_boolean(
 		    static_cast<Float*>(lhs_val)->m_value
-		    == static_cast<Float*>(rhs_val)->m_value);
+		    == static_cast<Float*>(rhs_val)->m_value).get();
 	case value_type::String:
 		return e.new_boolean(
 		    static_cast<String*>(lhs_val)->m_value
-		    == static_cast<String*>(rhs_val)->m_value);
+		    == static_cast<String*>(rhs_val)->m_value).get();
 	case value_type::Boolean:
 		return e.new_boolean(
 		    static_cast<Boolean*>(lhs_val)->m_value
-		    == static_cast<Boolean*>(rhs_val)->m_value);
+		    == static_cast<Boolean*>(rhs_val)->m_value).get();
 	default: {
 		std::cerr << "ERROR: can't compare equality of types "
 		          << value_type_string[static_cast<int>(lhs_val->type())] << " and "
@@ -284,15 +286,15 @@ Value* value_less(ArrayType v, Environment& e) {
 	case value_type::Integer:
 		return e.new_boolean(
 		    static_cast<Integer*>(lhs_val)->m_value
-		    < static_cast<Integer*>(rhs_val)->m_value);
+		    < static_cast<Integer*>(rhs_val)->m_value).get();
 	case value_type::Float:
 		return e.new_boolean(
 		    static_cast<Float*>(lhs_val)->m_value
-		    < static_cast<Float*>(rhs_val)->m_value);
+		    < static_cast<Float*>(rhs_val)->m_value).get();
 	case value_type::String:
 		return e.new_boolean(
 		    static_cast<String*>(lhs_val)->m_value
-		    < static_cast<String*>(rhs_val)->m_value);
+		    < static_cast<String*>(rhs_val)->m_value).get();
 	default:
 		std::cerr << "ERROR: can't compare values of type "
 		          << value_type_string[static_cast<int>(lhs_val->type())];

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -1,6 +1,7 @@
 #include "value.hpp"
 #include "environment.hpp"
 #include "value_type.hpp"
+#include "utils.hpp"
 
 #include <sstream>
 #include <iostream>

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -52,7 +52,9 @@ Value* size(ArrayType v, Environment& e) {
     assert(v.size() == 1);
     assert(unboxed(v[0])->type() == value_type::Array);
     Array* array = static_cast<Array*>(unboxed(v[0]));
-    return e.new_integer(array->m_value.size());
+
+	// TODO: don't get()
+    return e.new_integer(array->m_value.size()).get();
 } 
 
 // array_join(array, string) returns a string with
@@ -91,9 +93,10 @@ Value* value_add(ArrayType v, Environment& e) {
 	assert(lhs_val->type() == rhs_val->type());
 	switch (lhs_val->type()) {
 	case value_type::Integer:
+		//TODO: don't get()
 		return e.new_integer(
 		    static_cast<Integer*>(lhs_val)->m_value
-		    + static_cast<Integer*>(rhs_val)->m_value);
+		    + static_cast<Integer*>(rhs_val)->m_value).get();
 	case value_type::Float:
 		return e.new_float(
 		    static_cast<Float*>(lhs_val)->m_value
@@ -118,9 +121,10 @@ Value* value_sub(ArrayType v, Environment& e) {
 	assert(lhs_val->type() == rhs_val->type());
 	switch (lhs_val->type()) {
 	case value_type::Integer:
+		// TODO: don't get()
 		return e.new_integer(
 		    static_cast<Integer*>(lhs_val)->m_value
-		    - static_cast<Integer*>(rhs_val)->m_value);
+		    - static_cast<Integer*>(rhs_val)->m_value).get();
 	case value_type::Float:
 		return e.new_float(
 		    static_cast<Float*>(lhs_val)->m_value
@@ -141,9 +145,10 @@ Value* value_mul(ArrayType v, Environment& e) {
 	assert(lhs_val->type() == rhs_val->type());
 	switch (lhs_val->type()) {
 	case value_type::Integer:
+		// TODO: don't get()
 		return e.new_integer(
 		    static_cast<Integer*>(lhs_val)->m_value
-		    * static_cast<Integer*>(rhs_val)->m_value);
+		    * static_cast<Integer*>(rhs_val)->m_value).get();
 	case value_type::Float:
 		return e.new_float(
 		    static_cast<Float*>(lhs_val)->m_value
@@ -164,9 +169,10 @@ Value* value_div(ArrayType v, Environment& e) {
 	assert(lhs_val->type() == rhs_val->type());
 	switch (lhs_val->type()) {
 	case value_type::Integer:
+		// TODO: don't get()
 		return e.new_integer(
 		    static_cast<Integer*>(lhs_val)->m_value
-		    / static_cast<Integer*>(rhs_val)->m_value);
+		    / static_cast<Integer*>(rhs_val)->m_value).get();
 	case value_type::Float:
 		return e.new_float(
 		    static_cast<Float*>(lhs_val)->m_value

--- a/src/interpreter/utils.cpp
+++ b/src/interpreter/utils.cpp
@@ -1,0 +1,19 @@
+#include "utils.hpp"
+
+#include "value.hpp"
+
+namespace Interpreter {
+
+Value* unboxed(Value* value) {
+	if (!value)
+		return value;
+
+	if (value->type() != value_type::Reference)
+		return value;
+
+	// try unboxing recursively?
+	auto ref = static_cast<Reference*>(value);
+	return ref->m_value;
+}
+
+}

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -1,0 +1,7 @@
+#include "value_fwd.hpp"
+
+namespace Interpreter {
+
+Value* unboxed(Value* value);
+
+}

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -9,18 +9,6 @@
 
 namespace Interpreter {
 
-Value* unboxed(Value* value) {
-	if (!value)
-		return value;
-
-	if (value->type() != value_type::Reference)
-		return value;
-
-	// try unboxing recursively?
-	auto ref = static_cast<Reference*>(value);
-	return ref->m_value;
-}
-
 
 Null::Null() : Value(value_type::Null) {}
 

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -21,7 +21,6 @@ using FunctionType = TypedAST::FunctionLiteral*;
 using NativeFunctionType = auto(ArrayType, Environment&) -> Value*;
 
 // Returns the value pointed to by a reference
-Value* unboxed(Value* value);
 void print(Value* v, int d = 0);
 void gc_visit(Value*);
 

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -31,6 +31,7 @@ protected:
 
 public:
 	bool m_visited = false;
+	int m_cpp_refcount = 0;
 
 	Value(value_type type) : m_type(type) {}
 	value_type type() const { return m_type; }


### PR DESCRIPTION
This will prevent us from having dangling pointers when we manipulate gc objects

The main machinery is in `interpreter/gc_ptr.hpp`. It uses a tiny bit of template trickery to let us move from a `gc_ptr<subclass>` into a `gc_ptr<superclass>`. I don't know that much about template magic, so I just did the same thing `std::shared_pointer` does in the standard library implementation that's on my machine.

Whether it works or not is TBD, maybe we should try calling `Environment::run_gc` at the top of every `Environment::new_*` function. TBH, my brain is pretty much dry, so we will have to see tomorrow or whenever.