### PR TITLE
separate the typechecking from `match_identifiers`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,6 +15,7 @@ OBJNAMES := \
 	string_view.o \
 	tarjan_solver.o \
 	token.o \
+	typecheck.o \
 	typechecker.o \
 	typed_ast.o \
 	typesystem.o

--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -38,29 +38,44 @@ CompileTimeEnvironment::CompileTimeEnvironment() {
 	declare_builtin("array_extend");
 	declare_builtin("array_join");
 
-	// TODO: refactor, figure out a nice way to build types
-	auto var_mono_id = m_typechecker.new_var();
-	auto var_id = m_typechecker.m_core.mono_data[var_mono_id].data_id;
+	{
+		// TODO: refactor, figure out a nice way to build types
+		auto var_mono_id = m_typechecker.new_var();
+		auto var_id = m_typechecker.m_core.mono_data[var_mono_id].data_id;
 
-	// TODO: i use the same mono thrice... does this make sense?
-	auto term_mono_id = m_typechecker.m_core.new_term(
-		TypeChecker::BuiltinType::Function,
-		{var_mono_id, var_mono_id, var_mono_id},
-		"[builtin] (a, a) -> a");
+		// TODO: i use the same mono thrice... does this make sense?
+		auto term_mono_id = m_typechecker.m_core.new_term(
+		    TypeChecker::BuiltinType::Function,
+		    { var_mono_id, var_mono_id, var_mono_id },
+		    "[builtin] (a, a) -> a");
 
-	auto poly_id = m_typechecker.m_core.new_poly(term_mono_id, {var_id});
+		auto poly_id = m_typechecker.m_core.new_poly(term_mono_id, { var_id });
 
-	// TODO: re using the same PolyId... is this ok?
-	// I think this is fine because we always do inst_fresh when we use a poly
-	// , so it can't somehow get mutated
-	declare_builtin("+" , poly_id);
-	declare_builtin("-" , poly_id);
-	declare_builtin("*" , poly_id);
-	declare_builtin("/" , poly_id);
-	declare_builtin("<" , poly_id);
-	declare_builtin("=" , poly_id);
-	declare_builtin("==", poly_id);
-	declare_builtin("." , poly_id);
+		// TODO: re using the same PolyId... is this ok?
+		// I think this is fine because we always do inst_fresh when we use a poly
+		// , so it can't somehow get mutated
+		declare_builtin("+", poly_id);
+		declare_builtin("-", poly_id);
+		declare_builtin("*", poly_id);
+		declare_builtin("/", poly_id);
+		declare_builtin(".", poly_id);
+	}
+
+	{
+		auto var_mono_id = m_typechecker.new_var();
+		auto var_id = m_typechecker.m_core.mono_data[var_mono_id].data_id;
+
+		auto term_mono_id = m_typechecker.m_core.new_term(
+		    TypeChecker::BuiltinType::Function,
+		    { var_mono_id, var_mono_id, m_typechecker.mono_boolean() },
+		    "[builtin] (a, a) -> Bool");
+
+		auto poly_id = m_typechecker.m_core.new_poly(term_mono_id, { var_id });
+
+		declare_builtin("<", poly_id);
+		declare_builtin("=", poly_id);
+		declare_builtin("==", poly_id);
+	}
 };
 
 Scope& CompileTimeEnvironment::current_scope() {

--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -59,6 +59,7 @@ CompileTimeEnvironment::CompileTimeEnvironment() {
 		declare_builtin("*", poly_id);
 		declare_builtin("/", poly_id);
 		declare_builtin(".", poly_id);
+		declare_builtin("=", poly_id);
 	}
 
 	{
@@ -73,7 +74,6 @@ CompileTimeEnvironment::CompileTimeEnvironment() {
 		auto poly_id = m_typechecker.m_core.new_poly(term_mono_id, { var_id });
 
 		declare_builtin("<", poly_id);
-		declare_builtin("=", poly_id);
 		declare_builtin("==", poly_id);
 	}
 };

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -5,6 +5,7 @@
 #include "../match_identifiers.hpp"
 #include "../parse.hpp"
 #include "../token_array.hpp"
+#include "../typecheck.hpp"
 #include "../typed_ast.hpp"
 #include "environment.hpp"
 #include "eval.hpp"
@@ -38,6 +39,7 @@ exit_status_type execute(std::string const& source, bool dump_ast, Runner* runne
 	Frontend::CompileTimeEnvironment ct_env;
 
 	TypeChecker::match_identifiers(top_level.get(), ct_env);
+	TypeChecker::typecheck(top_level.get(), ct_env);
 
 	GC gc;
 	Environment env = { &gc };

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -81,7 +81,7 @@ void match_identifiers(
 
 	int arg_count = ast->m_args.size();
 
-	for (int i = 0; i < arg_count; ++i){
+	for (int i = 0; i < arg_count; ++i) {
 		auto& arg_decl = ast->m_args[i];
 		env.declare_arg(arg_decl.identifier_text(), ast, i);
 	}

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -5,73 +5,27 @@
 
 #include "compile_time_environment.hpp"
 #include "typed_ast.hpp"
-#include "typesystem_types.hpp"
 
 #include <cassert>
 
 namespace TypeChecker {
 
 void match_identifiers(
-    TypedAST::NumberLiteral* ast, Frontend::CompileTimeEnvironment& env) {
-	ast->m_value_type = env.m_typechecker.mono_float();
-}
-
-void match_identifiers(
-    TypedAST::IntegerLiteral* ast, Frontend::CompileTimeEnvironment& env) {
-	ast->m_value_type = env.m_typechecker.mono_int();
-}
-
-void match_identifiers(
-    TypedAST::StringLiteral* ast, Frontend::CompileTimeEnvironment& env) {
-	ast->m_value_type = env.m_typechecker.mono_string();
-}
-
-void match_identifiers(
-    TypedAST::BooleanLiteral* ast, Frontend::CompileTimeEnvironment& env) {
-	ast->m_value_type = env.m_typechecker.mono_boolean();
-}
-
-void match_identifiers(
-    TypedAST::NullLiteral* ast, Frontend::CompileTimeEnvironment& env) {
-	ast->m_value_type = env.m_typechecker.mono_unit();
-}
-
-void match_identifiers(
     TypedAST::Declaration* ast, Frontend::CompileTimeEnvironment& env) {
-#if DEBUG
-	std::cerr << "Typechecking " << ast->identifier_text() << '\n';
-#endif
 
 	ast->m_surrounding_function = env.current_function();
 	env.declare(ast->identifier_text(), ast);
 
-	// this is where we implement let-polymorphism. TODO: refactor (duplication).
 	if (ast->m_value)
 		match_identifiers(ast->m_value.get(), env);
-
-	MonoId mono = ast->m_value ? ast->m_value->m_value_type
-	                           : env.m_typechecker.new_var();
-
-	ast->m_decl_type = env.m_typechecker.m_core.generalize(mono);
-
-#if DEBUG
-	{
-		std::cerr << "Type of " << ast->identifier_text() << " is:\n";
-		auto poly = ast->m_decl_type;
-		auto mono = env.m_typechecker.m_core.poly_data[poly].base;
-		env.m_typechecker.m_core.print_type(mono);
-	}
-#endif
 }
 
 void match_identifiers(TypedAST::Identifier* ast, Frontend::CompileTimeEnvironment& env) {
 	Frontend::Binding* binding = env.access_binding(ast->text());
 	assert(binding && "accessed an undeclared identifier");
 
-	// here we implement the [var] rule
 	// TODO: refactor
 	TypedAST::FunctionLiteral* surrounding_function = nullptr;
-	MonoId mono = -1;
 	if (binding->m_type == Frontend::BindingType::Declaration) {
 		TypedAST::Declaration* declaration = binding->get_decl();
 
@@ -79,7 +33,6 @@ void match_identifiers(TypedAST::Identifier* ast, Frontend::CompileTimeEnvironme
 		ast->m_declaration = declaration;
 
 		surrounding_function = declaration->m_surrounding_function;
-		mono = env.m_typechecker.m_core.inst_fresh(declaration->m_decl_type);
 	} else {
 		TypedAST::FunctionArgument& arg = binding->get_arg();
 
@@ -89,15 +42,10 @@ void match_identifiers(TypedAST::Identifier* ast, Frontend::CompileTimeEnvironme
 		ast->m_declaration = nullptr;
 
 		surrounding_function = binding->get_func();
-		mono = arg.m_value_type;
 	}
 
-	assert(mono != -1);
-
-	ast->m_value_type = mono;
-
 	// dont capture globals
-	if(surrounding_function) {
+	if (surrounding_function) {
 		for (int i = env.m_function_stack.size(); i--;) {
 			auto* func = env.m_function_stack[i];
 			if (func == surrounding_function)
@@ -105,7 +53,6 @@ void match_identifiers(TypedAST::Identifier* ast, Frontend::CompileTimeEnvironme
 			func->m_captures.insert(ast->text());
 		}
 	}
-
 }
 
 void match_identifiers(TypedAST::Block* ast, Frontend::CompileTimeEnvironment& env) {
@@ -124,12 +71,6 @@ void match_identifiers(TypedAST::CallExpression* ast, Frontend::CompileTimeEnvir
 	match_identifiers(ast->m_callee.get(), env);
 	for (auto& arg : ast->m_args)
 		match_identifiers(arg.get(), env);
-
-	std::vector<MonoId> arg_types;
-	for (auto& arg : ast->m_args)
-		arg_types.push_back(arg->m_value_type);
-
-	ast->m_value_type = env.m_typechecker.rule_app(std::move(arg_types), ast->m_callee->m_value_type);
 }
 
 void match_identifiers(
@@ -138,30 +79,11 @@ void match_identifiers(
 	env.enter_function(ast);
 	env.new_nested_scope(); // NOTE: this is nested because of lexical scoping
 
-	{
-		// TODO: do something better, use the type hints
-		ast->m_return_type = env.m_typechecker.new_var();
+	int arg_count = ast->m_args.size();
 
-		int arg_count = ast->m_args.size();
-		std::vector<MonoId> arg_types;
-
-		for (int i = 0; i < arg_count; ++i){
-			auto& arg_decl = ast->m_args[i];
-
-			int mono = env.m_typechecker.new_var();
-
-			arg_types.push_back(mono);
-			arg_decl.m_value_type = mono;
-
-			env.declare_arg(arg_decl.identifier_text(), ast, i);
-		}
-
-		// return type
-		arg_types.push_back(ast->m_return_type);
-
-
-		MonoId term_mono_id = env.m_typechecker.m_core.new_term(BuiltinType::Function, std::move(arg_types));
-		ast->m_value_type = term_mono_id;
+	for (int i = 0; i < arg_count; ++i){
+		auto& arg_decl = ast->m_args[i];
+		env.declare_arg(arg_decl.identifier_text(), ast, i);
 	}
 
 	// scan body
@@ -186,10 +108,6 @@ void match_identifiers(TypedAST::ForStatement* ast, Frontend::CompileTimeEnviron
 void match_identifiers(
     TypedAST::ReturnStatement* ast, Frontend::CompileTimeEnvironment& env) {
 	match_identifiers(ast->m_value.get(), env);
-
-	auto mono = ast->m_value->m_value_type;
-	auto func = env.current_function();
-	env.m_typechecker.m_core.unify(func->m_return_type, mono);
 }
 
 void match_identifiers(TypedAST::IndexExpression* ast, Frontend::CompileTimeEnvironment& env) {
@@ -197,7 +115,8 @@ void match_identifiers(TypedAST::IndexExpression* ast, Frontend::CompileTimeEnvi
 	match_identifiers(ast->m_index.get(), env);
 }
 
-void match_identifiers(TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment& env) {
+void match_identifiers(
+    TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment& env) {
 	for (auto& decl : ast->m_declarations) {
 		auto d = static_cast<TypedAST::Declaration*>(decl.get());
 		env.declare(d->identifier_text(), d);
@@ -207,26 +126,8 @@ void match_identifiers(TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvi
 	for (auto& decl : ast->m_declarations) {
 		auto d = static_cast<TypedAST::Declaration*>(decl.get());
 
-		// this is where we implement let-polymorphism. TODO: refactor (duplication).
 		if (d->m_value)
 			match_identifiers(d->m_value.get(), env);
-
-		MonoId mono = d->m_value ? d->m_value->m_value_type
-			: env.m_typechecker.new_var();
-
-		d->m_decl_type = env.m_typechecker.m_core.generalize(mono);
-
-#if DEBUG
-		{
-			std::cerr << "@@ Type of " << d->identifier_text() << '\n';
-			env.m_typechecker.m_core.print_type(mono);
-
-			auto poly = d->m_decl_type;
-			auto& poly_data = env.m_typechecker.m_core.poly_data[poly];
-
-			std::cerr << "@@ Has " << poly_data.vars.size() << " variables\n";
-		}
-#endif
 	}
 }
 
@@ -235,13 +136,17 @@ void match_identifiers(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment
 	case ast_type::type:                                                       \
 		return match_identifiers(static_cast<TypedAST::type*>(ast), env);
 
+#define DO_NOTHING(type)                                                       \
+	case ast_type::type:                                                       \
+		return;
+
 	// TODO: Compound literals
 	switch (ast->type()) {
-		DISPATCH(NumberLiteral);
-		DISPATCH(IntegerLiteral);
-		DISPATCH(StringLiteral);
-		DISPATCH(BooleanLiteral);
-		DISPATCH(NullLiteral);
+		DO_NOTHING(NumberLiteral);
+		DO_NOTHING(IntegerLiteral);
+		DO_NOTHING(StringLiteral);
+		DO_NOTHING(BooleanLiteral);
+		DO_NOTHING(NullLiteral);
 
 		DISPATCH(Declaration);
 		DISPATCH(Identifier);
@@ -258,6 +163,7 @@ void match_identifiers(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment
 		return;
 	}
 
+#undef DO_NOTHING
 #undef DISPATCH
 }
 

--- a/src/match_identifiers.hpp
+++ b/src/match_identifiers.hpp
@@ -1,3 +1,4 @@
+#pragma once
 
 namespace TypedAST {
 struct TypedAST;

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -160,6 +160,16 @@ void typecheck(TypedAST::ForStatement* ast, Frontend::CompileTimeEnvironment& en
 	env.end_scope();
 }
 
+void typecheck(TypedAST::WhileStatement* ast, Frontend::CompileTimeEnvironment& env) {
+	env.new_nested_scope();
+	typecheck(ast->m_condition.get(), env);
+	env.m_typechecker.m_core.unify(
+	    ast->m_condition->m_value_type, env.m_typechecker.mono_boolean());
+
+	typecheck(ast->m_body.get(), env);
+	env.end_scope();
+}
+
 void typecheck(TypedAST::ReturnStatement* ast, Frontend::CompileTimeEnvironment& env) {
 	typecheck(ast->m_value.get(), env);
 
@@ -224,6 +234,7 @@ void typecheck(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment& env) {
 		DISPATCH(Identifier);
 		DISPATCH(Block);
 		DISPATCH(ForStatement);
+		DISPATCH(WhileStatement);
 		DISPATCH(IfStatement);
 		DISPATCH(FunctionLiteral);
 		DISPATCH(CallExpression);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -1,0 +1,237 @@
+#include "typecheck.hpp"
+
+#include "compile_time_environment.hpp"
+#include "typesystem_types.hpp"
+#include "typed_ast.hpp"
+
+#include <cassert>
+
+namespace TypeChecker {
+
+// NOTE: This file duplicates a bit of what match_identifiers does.
+// however, I think that's the right thing to do.
+// At least, the alternative just sucks.
+
+void typecheck(TypedAST::NumberLiteral* ast, Frontend::CompileTimeEnvironment& env) {
+	ast->m_value_type = env.m_typechecker.mono_float();
+}
+
+void typecheck(TypedAST::IntegerLiteral* ast, Frontend::CompileTimeEnvironment& env) {
+	ast->m_value_type = env.m_typechecker.mono_int();
+}
+
+void typecheck(TypedAST::StringLiteral* ast, Frontend::CompileTimeEnvironment& env) {
+	ast->m_value_type = env.m_typechecker.mono_string();
+}
+
+void typecheck(TypedAST::BooleanLiteral* ast, Frontend::CompileTimeEnvironment& env) {
+	ast->m_value_type = env.m_typechecker.mono_boolean();
+}
+
+void typecheck(TypedAST::NullLiteral* ast, Frontend::CompileTimeEnvironment& env) {
+	ast->m_value_type = env.m_typechecker.mono_unit();
+}
+
+void typecheck(TypedAST::Declaration* ast, Frontend::CompileTimeEnvironment& env) {
+#if DEBUG
+	std::cerr << "Typechecking " << ast->identifier_text() << '\n';
+#endif
+
+	env.declare(ast->identifier_text(), ast);
+
+	// this is where we implement let-polymorphism.
+	// TODO: refactor (duplication).
+	if (ast->m_value)
+		typecheck(ast->m_value.get(), env);
+
+	MonoId mono = ast->m_value ? ast->m_value->m_value_type
+	                           : env.m_typechecker.new_var();
+
+	ast->m_decl_type = env.m_typechecker.m_core.generalize(mono);
+
+#if DEBUG
+	{
+		std::cerr << "Type of " << ast->identifier_text() << " is:\n";
+		auto poly = ast->m_decl_type;
+		auto mono = env.m_typechecker.m_core.poly_data[poly].base;
+		env.m_typechecker.m_core.print_type(mono);
+	}
+#endif
+}
+
+void typecheck(TypedAST::Identifier* ast, Frontend::CompileTimeEnvironment& env) {
+	Frontend::Binding* binding = env.access_binding(ast->text());
+	assert(binding && "accessed an undeclared identifier");
+
+	// here we implement the [var] rule
+	// TODO: refactor
+	MonoId mono = -1;
+	if (binding->m_type == Frontend::BindingType::Declaration) {
+		TypedAST::Declaration* declaration = binding->get_decl();
+		assert(declaration);
+		mono = env.m_typechecker.m_core.inst_fresh(declaration->m_decl_type);
+	} else {
+		TypedAST::FunctionArgument& arg = binding->get_arg();
+		mono = arg.m_value_type;
+	}
+
+	assert(mono != -1);
+	ast->m_value_type = mono;
+}
+
+void typecheck(TypedAST::Block* ast, Frontend::CompileTimeEnvironment& env) {
+	env.new_nested_scope();
+	for (auto& child : ast->m_body)
+		typecheck(child.get(), env);
+	env.end_scope();
+}
+
+void typecheck(TypedAST::IfStatement* ast, Frontend::CompileTimeEnvironment& env) {
+	typecheck(ast->m_condition.get(), env);
+	env.m_typechecker.m_core.unify(
+	    ast->m_condition->m_value_type, env.m_typechecker.mono_boolean());
+
+	typecheck(ast->m_body.get(), env);
+}
+
+void typecheck(TypedAST::CallExpression* ast, Frontend::CompileTimeEnvironment& env) {
+	typecheck(ast->m_callee.get(), env);
+	for (auto& arg : ast->m_args)
+		typecheck(arg.get(), env);
+
+	std::vector<MonoId> arg_types;
+	for (auto& arg : ast->m_args)
+		arg_types.push_back(arg->m_value_type);
+
+	ast->m_value_type = env.m_typechecker.rule_app(
+	    std::move(arg_types), ast->m_callee->m_value_type);
+}
+
+void typecheck(TypedAST::FunctionLiteral* ast, Frontend::CompileTimeEnvironment& env) {
+
+	env.enter_function(ast);
+	env.new_nested_scope(); // NOTE: this is nested because of lexical scoping
+
+	{
+		// TODO: do something better, use the type hints
+		ast->m_return_type = env.m_typechecker.new_var();
+
+		int arg_count = ast->m_args.size();
+		std::vector<MonoId> arg_types;
+
+		for (int i = 0; i < arg_count; ++i) {
+			auto& arg_decl = ast->m_args[i];
+
+			int mono = env.m_typechecker.new_var();
+
+			arg_types.push_back(mono);
+			arg_decl.m_value_type = mono;
+
+			env.declare_arg(arg_decl.identifier_text(), ast, i);
+		}
+
+		// return type
+		arg_types.push_back(ast->m_return_type);
+
+		MonoId term_mono_id = env.m_typechecker.m_core.new_term(
+		    BuiltinType::Function, std::move(arg_types));
+		ast->m_value_type = term_mono_id;
+	}
+
+	// scan body
+	assert(ast->m_body->type() == ast_type::Block);
+	auto body = static_cast<TypedAST::Block*>(ast->m_body.get());
+	for (auto& child : body->m_body)
+		typecheck(child.get(), env);
+
+	env.end_scope();
+	env.exit_function();
+}
+
+void typecheck(TypedAST::ForStatement* ast, Frontend::CompileTimeEnvironment& env) {
+	env.new_nested_scope();
+	typecheck(ast->m_declaration.get(), env);
+	typecheck(ast->m_condition.get(), env);
+	typecheck(ast->m_action.get(), env);
+	typecheck(ast->m_body.get(), env);
+	env.end_scope();
+}
+
+void typecheck(TypedAST::ReturnStatement* ast, Frontend::CompileTimeEnvironment& env) {
+	typecheck(ast->m_value.get(), env);
+
+	auto mono = ast->m_value->m_value_type;
+	auto func = env.current_function();
+	env.m_typechecker.m_core.unify(func->m_return_type, mono);
+}
+
+void typecheck(TypedAST::IndexExpression* ast, Frontend::CompileTimeEnvironment& env) {
+	typecheck(ast->m_callee.get(), env);
+	typecheck(ast->m_index.get(), env);
+}
+
+void typecheck(TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment& env) {
+	for (auto& decl : ast->m_declarations) {
+		auto d = static_cast<TypedAST::Declaration*>(decl.get());
+		env.declare(d->identifier_text(), d);
+		d->m_surrounding_function = env.current_function();
+	}
+
+	for (auto& decl : ast->m_declarations) {
+		auto d = static_cast<TypedAST::Declaration*>(decl.get());
+
+		// this is where we implement let-polymorphism. TODO: refactor (duplication).
+		if (d->m_value)
+			typecheck(d->m_value.get(), env);
+
+		MonoId mono = d->m_value ? d->m_value->m_value_type
+		                         : env.m_typechecker.new_var();
+
+		d->m_decl_type = env.m_typechecker.m_core.generalize(mono);
+
+#if DEBUG
+		{
+			std::cerr << "@@ Type of " << d->identifier_text() << '\n';
+			env.m_typechecker.m_core.print_type(mono);
+
+			auto poly = d->m_decl_type;
+			auto& poly_data = env.m_typechecker.m_core.poly_data[poly];
+
+			std::cerr << "@@ Has " << poly_data.vars.size() << " variables\n";
+		}
+#endif
+	}
+}
+
+void typecheck(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment& env) {
+#define DISPATCH(type)                                                         \
+	case ast_type::type:                                                       \
+		return typecheck(static_cast<TypedAST::type*>(ast), env);
+
+	// TODO: Compound literals
+	switch (ast->type()) {
+		DISPATCH(NumberLiteral);
+		DISPATCH(IntegerLiteral);
+		DISPATCH(StringLiteral);
+		DISPATCH(BooleanLiteral);
+		DISPATCH(NullLiteral);
+
+		DISPATCH(Declaration);
+		DISPATCH(Identifier);
+		DISPATCH(Block);
+		DISPATCH(ForStatement);
+		DISPATCH(IfStatement);
+		DISPATCH(FunctionLiteral);
+		DISPATCH(CallExpression);
+		DISPATCH(ReturnStatement);
+		DISPATCH(IndexExpression);
+		DISPATCH(DeclarationList);
+	case ast_type::BinaryExpression:
+		assert(0);
+		return;
+	}
+
+#undef DISPATCH
+}
+
+} // namespace TypeChecker

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -152,6 +152,9 @@ void typecheck(TypedAST::ForStatement* ast, Frontend::CompileTimeEnvironment& en
 	env.new_nested_scope();
 	typecheck(ast->m_declaration.get(), env);
 	typecheck(ast->m_condition.get(), env);
+	env.m_typechecker.m_core.unify(
+	    ast->m_condition->m_value_type, env.m_typechecker.mono_boolean());
+
 	typecheck(ast->m_action.get(), env);
 	typecheck(ast->m_body.get(), env);
 	env.end_scope();
@@ -171,10 +174,11 @@ void typecheck(TypedAST::IndexExpression* ast, Frontend::CompileTimeEnvironment&
 }
 
 void typecheck(TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment& env) {
+	// TODO: SCC decomposition mumbo jumbo
+
 	for (auto& decl : ast->m_declarations) {
 		auto d = static_cast<TypedAST::Declaration*>(decl.get());
 		env.declare(d->identifier_text(), d);
-		d->m_surrounding_function = env.current_function();
 	}
 
 	for (auto& decl : ast->m_declarations) {

--- a/src/typecheck.hpp
+++ b/src/typecheck.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace TypedAST {
+struct TypedAST;
+}
+
+namespace Frontend {
+struct CompileTimeEnvironment;
+}
+
+namespace TypeChecker {
+
+void typecheck(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment&);
+
+}


### PR DESCRIPTION
~We are back to being a dynamically typed language... yay?~

dynamism is no more. morality is restored.