### PR TITLE
Typechecker context binding

### DIFF
--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -158,4 +158,27 @@ void CompileTimeEnvironment::exit_function() {
 	m_function_stack.pop_back();
 }
 
+MonoId CompileTimeEnvironment::new_type_var() {
+	MonoId result = m_typechecker.new_var();
+	VarId var = m_typechecker.m_core.mono_data[result].data_id;
+	current_scope().m_type_vars.insert(var);
+	return result;
+}
+
+bool CompileTimeEnvironment::has_type_var(VarId var) {
+	auto scan_scope = [](Scope& scope, VarId var) -> bool {
+		return scope.m_type_vars.count(var) != 0;
+	};
+
+	// scan nested scopes from the inside out
+	for (int i = m_scopes.size(); i--;) {
+		auto found = scan_scope(m_scopes[i], var);
+		if (found) return true;
+		if (!m_scopes[i].m_nested) break;
+	}
+
+	// fall back to global scope lookup
+	return scan_scope(m_global_scope, var);
+}
+
 } // namespace Frontend

--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "typechecker.hpp"
@@ -42,6 +43,7 @@ struct Binding {
 struct Scope {
 	bool m_nested { false };
 	std::unordered_map<std::string, Binding> m_vars;
+	std::unordered_set<VarId> m_type_vars;
 };
 
 struct CompileTimeEnvironment {
@@ -69,6 +71,9 @@ struct CompileTimeEnvironment {
 	void new_scope();
 	void new_nested_scope();
 	void end_scope();
+
+	MonoId new_type_var();
+	bool has_type_var(VarId);
 };
 
 } // namespace Frontend

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -140,11 +140,13 @@ void interpreter_tests(Test::Tester& tests) {
 		})
 	);
 
-	/*
 	tests.add_test(
 		std::make_unique<TestCase>(R"(
+			// K : forall a b. a -> b -> a
 			K := fn (x) => fn (y) => x;
+			// S : forall a b c. (a->b->c) -> (a->b) -> a -> c
 			S := fn(x) => fn(y) => fn(z) => x(z)(y(z));
+			// I : foral a. a -> a
 			I := S(K)(K);
 			__invoke := fn () => I(42);
 		)",
@@ -152,7 +154,6 @@ void interpreter_tests(Test::Tester& tests) {
 			return Assert::equals(eval_expression("__invoke()", env), 42);
 		})
 	);
-	*/
 
 	/*
 	tests.add_test(

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -45,7 +45,7 @@ void typecheck(TypedAST::Declaration* ast, Frontend::CompileTimeEnvironment& env
 		typecheck(ast->m_value.get(), env);
 
 	MonoId mono = ast->m_value ? ast->m_value->m_value_type
-	                           : env.m_typechecker.new_var();
+	                           : env.new_type_var();
 
 	ast->m_decl_type = env.m_typechecker.m_core.generalize(mono);
 
@@ -114,7 +114,7 @@ void typecheck(TypedAST::FunctionLiteral* ast, Frontend::CompileTimeEnvironment&
 
 	{
 		// TODO: do something better, use the type hints
-		ast->m_return_type = env.m_typechecker.new_var();
+		ast->m_return_type = env.new_type_var();
 
 		int arg_count = ast->m_args.size();
 		std::vector<MonoId> arg_types;
@@ -122,7 +122,7 @@ void typecheck(TypedAST::FunctionLiteral* ast, Frontend::CompileTimeEnvironment&
 		for (int i = 0; i < arg_count; ++i) {
 			auto& arg_decl = ast->m_args[i];
 
-			int mono = env.m_typechecker.new_var();
+			int mono = env.new_type_var();
 
 			arg_types.push_back(mono);
 			arg_decl.m_value_type = mono;
@@ -199,7 +199,7 @@ void typecheck(TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment&
 			typecheck(d->m_value.get(), env);
 
 		MonoId mono = d->m_value ? d->m_value->m_value_type
-		                         : env.m_typechecker.new_var();
+		                         : env.new_type_var();
 
 		d->m_decl_type = env.m_typechecker.m_core.generalize(mono);
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -6,6 +6,10 @@
 
 #include <cassert>
 
+#if DEBUG
+#include <iostream>
+#endif
+
 namespace TypeChecker {
 
 // NOTE: This file duplicates a bit of what match_identifiers does.
@@ -205,13 +209,13 @@ void typecheck(TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment&
 
 #if DEBUG
 		{
-			std::cerr << "@@ Type of " << d->identifier_text() << '\n';
-			env.m_typechecker.m_core.print_type(mono);
-
 			auto poly = d->m_decl_type;
 			auto& poly_data = env.m_typechecker.m_core.poly_data[poly];
 
+			std::cerr << "@@ Type of " << d->identifier_text() << '\n';
 			std::cerr << "@@ Has " << poly_data.vars.size() << " variables\n";
+			std::cerr << "@@ It is equal to:\n";
+			env.m_typechecker.m_core.print_type(mono);
 		}
 #endif
 	}

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -47,7 +47,7 @@ void typecheck(TypedAST::Declaration* ast, Frontend::CompileTimeEnvironment& env
 	MonoId mono = ast->m_value ? ast->m_value->m_value_type
 	                           : env.new_type_var();
 
-	ast->m_decl_type = env.m_typechecker.m_core.generalize(mono);
+	ast->m_decl_type = env.m_typechecker.m_core.generalize(mono, env);
 
 #if DEBUG
 	{
@@ -201,7 +201,7 @@ void typecheck(TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment&
 		MonoId mono = d->m_value ? d->m_value->m_value_type
 		                         : env.new_type_var();
 
-		d->m_decl_type = env.m_typechecker.m_core.generalize(mono);
+		d->m_decl_type = env.m_typechecker.m_core.generalize(mono, env);
 
 #if DEBUG
 		{

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -77,6 +77,7 @@ void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<VarId>& fr
 // qualifies all free variables in the given monotype
 // TODO(Mestre): I dont think this is right, we are supposed to only qualify
 // 'unbound' variables... whatever than means.
+// TODO: only generalize a variable if it is not in the CT environment
 PolyId TypeSystemCore::generalize(MonoId mono) {
 	std::unordered_set<VarId> free_vars;
 	gather_free_vars(mono, free_vars);

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -149,6 +149,13 @@ void TypeSystemCore::unify(MonoId a, MonoId b) {
 		return;
 
 	if (mono_data[a].type == mono_type::Var) {
+		if (mono_data[b].type == mono_type::Var) {
+			if (mono_data[a].data_id < mono_data[b].data_id) {
+				// make the newer one point to the older one
+				std::swap(a, b);
+			}
+		}
+
 		VarId va = mono_data[a].data_id;
 
 		if (occurs_in(va, b)) {

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -1,8 +1,14 @@
+#pragma once
+
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
 
 #include "typesystem_types.hpp"
+
+namespace Frontend {
+struct CompileTimeEnvironment;
+}
 
 // A type function gives the 'real value' of a type.
 // This can refer to a sum type, a product type, a built-in type, etc.
@@ -62,10 +68,10 @@ struct TypeSystemCore {
 	MonoId new_var();
 	MonoId new_term(TypeFunctionId type_function, std::vector<MonoId> args, char const* tag=nullptr);
 	PolyId new_poly(MonoId mono, std::vector<VarId> vars);
-	PolyId generalize(MonoId mono);
 
 	// qualifies all unbound variables in the given monotype
-	// PolyId new_poly (MonoId mono) { } // TODO
+	PolyId generalize(MonoId mono, Frontend::CompileTimeEnvironment&);
+
 
 	void gather_free_vars(MonoId mono, std::unordered_set<VarId>& free_vars);
 


### PR DESCRIPTION
Hindley-Milner relies on the "context" to know which type variables to generalize, and which ones to leave open for unification.

I implemented this "context' as a part of the CompileTimeEnvironment