### PR TITLE
General cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,6 +9,7 @@ PenaltyExcessCharacter: 5
 
 ReflowComments: false
 PenaltyBreakComment: 50 
+PenaltyReturnTypeOnItsOwnLine: 1000
 
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,7 @@ OBJNAMES := \
 	ast.o \
 	compile_time_environment.o \
 	desugar.o \
+	error_report.o \
 	lexer.o \
 	match_identifiers.o \
 	parser.o \

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -103,6 +103,14 @@ struct FunctionLiteral : public AST {
 	    : AST {ast_type::FunctionLiteral} {}
 };
 
+struct ShortFunctionLiteral : public AST {
+	std::unique_ptr<AST> m_body;
+	std::vector<std::unique_ptr<AST>> m_args;
+
+	ShortFunctionLiteral()
+	    : AST {ast_type::ShortFunctionLiteral} {}
+};
+
 struct DeclarationList : public AST {
 	std::vector<std::unique_ptr<AST>> m_declarations;
 

--- a/src/ast_type.hpp
+++ b/src/ast_type.hpp
@@ -10,6 +10,7 @@ constexpr const char* ast_type_string[] = {
 	"ArrayLiteral",
 	"DictionaryLiteral",
 	"FunctionLiteral",
+	"ShortFunctionLiteral",
 
 	"DeclarationList",
 	"Declaration",
@@ -37,6 +38,7 @@ enum class ast_type {
 	ArrayLiteral,
 	DictionaryLiteral,
 	FunctionLiteral,
+	ShortFunctionLiteral,
 
 	DeclarationList,
 	Declaration,

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -44,6 +44,22 @@ Own<AST> desugar(Own<FunctionLiteral> ast) {
 	return ast;
 }
 
+Own<AST> desugar(Own<ShortFunctionLiteral> ast) {
+	auto return_stmt = std::make_unique<ReturnStatement>();
+	return_stmt->m_value = desugar(std::move(ast->m_body));
+
+	auto block = std::make_unique<Block>();
+	block->m_body.push_back(std::move(return_stmt));
+
+	auto func = std::make_unique<FunctionLiteral>();
+	for (auto&& arg : ast->m_args)
+		func->m_args.push_back(desugar(std::move(arg)));
+
+	func->m_body = std::move(block);
+
+	return func;
+}
+
 Own<AST> desugar(Own<DeclarationList> ast) {
 	for (auto&& declaration : ast->m_declarations)
 		declaration = desugar(std::move(declaration));
@@ -189,6 +205,8 @@ Own<AST> desugar(Own<AST> ast) {
 		DISPATCH(ArrayLiteral);
 		DISPATCH(DictionaryLiteral);
 		DISPATCH(FunctionLiteral);
+		DISPATCH(ShortFunctionLiteral);
+
 		DISPATCH(DeclarationList);
 		DISPATCH(Declaration);
 		RETURN(Identifier);

--- a/src/error_report.cpp
+++ b/src/error_report.cpp
@@ -1,0 +1,17 @@
+#include "error_report.hpp"
+
+#include <iostream>
+
+bool ErrorReport::ok() {
+	return m_sub_errors.empty() && m_text.empty();
+}
+
+void ErrorReport::print(int d) {
+	for (int i = 0; i < d; ++i)
+		std::cerr << '-';
+
+	std::cerr << ' ' << m_text << '\n';
+
+	for (auto& sub : m_sub_errors)
+		sub.print(d + 1);
+}

--- a/src/error_report.hpp
+++ b/src/error_report.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct ErrorReport {
+	std::string m_text;
+	std::vector<ErrorReport> m_sub_errors;
+
+	bool ok();
+	void print(int d = 1);
+};

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -38,7 +38,14 @@ exit_status_type execute(std::string const& source, bool dump_ast, Runner* runne
 	auto top_level = TypedAST::get_unique(desugared_ast);
 	Frontend::CompileTimeEnvironment ct_env;
 
-	TypeChecker::match_identifiers(top_level.get(), ct_env);
+	{
+		auto err = TypeChecker::match_identifiers(top_level.get(), ct_env);
+		if (!err.ok()) {
+			err.print();
+			return exit_status_type::StaticError;
+		}
+	}
+
 	TypeChecker::typecheck(top_level.get(), ct_env);
 
 	GC gc;

--- a/src/interpreter/exit_status_type.hpp
+++ b/src/interpreter/exit_status_type.hpp
@@ -17,6 +17,7 @@ enum class exit_status_type {
 	Ok = 0,
 
 	ParseError,
+	StaticError,
 	TopLevelTypeError,
 
 	NullError,

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -112,9 +112,8 @@ namespace TypeChecker {
 	// scan body
 	assert(ast->m_body->type() == ast_type::Block);
 	auto body = static_cast<TypedAST::Block*>(ast->m_body.get());
-	for (auto& child : body->m_body) {
+	for (auto& child : body->m_body)
 		CHECK_AND_RETURN(match_identifiers(child.get(), env));
-	}
 
 	env.end_scope();
 	env.exit_function();

--- a/src/match_identifiers.hpp
+++ b/src/match_identifiers.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "error_report.hpp"
+
 namespace TypedAST {
 struct TypedAST;
 }
@@ -10,6 +12,6 @@ struct CompileTimeEnvironment;
 
 namespace TypeChecker {
 
-void match_identifiers(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment&);
+[[nodiscard]] ErrorReport match_identifiers(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment&);
 
 }

--- a/src/match_identifiers.hpp
+++ b/src/match_identifiers.hpp
@@ -12,6 +12,10 @@ struct CompileTimeEnvironment;
 
 namespace TypeChecker {
 
-[[nodiscard]] ErrorReport match_identifiers(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment&);
-
-}
+/*
+ * Matches every identifier in the given ast with a declaration.
+ * This also includes captures in a closure.
+ */
+[[nodiscard]] ErrorReport match_identifiers(
+    TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment&);
+} // namespace TypeChecker

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -24,14 +24,14 @@ bool handle_error(Writer<T>& lhs, Writer<U>&& rhs) {
 	return false;
 }
 
-ParseError make_expected_error(string_view expected, Token const* found_token) {
+ErrorReport make_expected_error(string_view expected, Token const* found_token) {
 	std::stringstream ss;
 	ss << "Parse Error: @ " << found_token->m_line0 + 1 << ":"
 	   << found_token->m_col0 + 1 << ": Expected " << expected << " but got "
 	   << token_type_string[int(found_token->m_type)] << ' '
 	   << found_token->m_text << " instead";
 
-	return ParseError {ss.str()};
+	return ErrorReport {ss.str()};
 }
 
 Writer<Token const*> Parser::require(token_type expected_type) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -47,15 +47,18 @@ Writer<Token const*> Parser::require(token_type expected_type) {
 	return make_writer(current_token);
 }
 
-bool Parser::consume(token_type maybe_token) {
-	Token const* current_token = &m_lexer->current_token();
-
-	if (current_token->m_type != maybe_token) {
-		return false;
+bool Parser::consume(token_type expected_type) {
+	if (match(expected_type)) {
+		m_lexer->advance();
+		return true;
 	}
+	return false;
+}
 
-	m_lexer->advance();
-
+bool Parser::match(token_type expected_type) {
+	Token const* current_token = &m_lexer->current_token();
+	if (current_token->m_type != expected_type)
+		return false;
 	return true;
 }
 
@@ -180,12 +183,8 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_declaration() {
 
 	Writer<std::unique_ptr<AST::AST>> type;
 
-	auto p0 = peek();
-
-	if (p0->m_type == token_type::DECLARE_ASSIGN) {
-		m_lexer->advance();
-	} else if (p0->m_type == token_type::DECLARE) {
-		m_lexer->advance();
+	if (consume(token_type::DECLARE_ASSIGN)) {
+	} else if (consume(token_type::DECLARE)) {
 
 		type = parse_type_term();
 		if (handle_error(result, type))
@@ -195,7 +194,7 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_declaration() {
 			return result;
 	} else {
 		result.m_error.m_sub_errors.push_back(
-		    make_expected_error("':' or ':='", p0));
+		    make_expected_error("':' or ':='", peek()));
 	}
 
 	auto value = parse_expression();
@@ -295,7 +294,7 @@ Writer<std::vector<std::unique_ptr<AST::AST>>> Parser::parse_argument_list() {
 	return args;
 }
 
-/* If I am not mistaken, the algorithm used here is called 'Pratt Parsing'
+/* The algorithm used here is called 'Pratt Parsing'
  * Here is an article with more information:
  * https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html
  */
@@ -652,24 +651,21 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_function() {
 	// TODO: refactor
 	std::vector<std::unique_ptr<AST::AST>> args;
 	while (1) {
-		auto p0 = peek();
-
-		if (p0->m_type == token_type::PAREN_CLOSE) {
-			m_lexer->advance();
+		if (consume(token_type::PAREN_CLOSE)) {
 			break;
-		} else if (p0->m_type == token_type::IDENTIFIER) {
+		} else if (match(token_type::IDENTIFIER)) {
 			// consume argument name
 
 			auto arg = std::make_unique<AST::Declaration>();
-			arg->m_identifier_token = p0;
+
+			arg->m_identifier_token = peek();
+			m_lexer->advance();
 
 			// now we optionally consume a type hint
 			// NOTE: a type hint is a colon followed by a type name.
 			// Example: ': int'
-			m_lexer->advance();
-			auto p1 = peek();
-			if (p1->m_type == token_type::DECLARE) {
-				m_lexer->advance();
+
+			if (consume(token_type::DECLARE)) {
 				// consume type separator (:)
 				// must be followed by a type
 
@@ -678,8 +674,6 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_function() {
 					return result;
 
 				arg->m_type = std::move(type.m_result);
-
-				p1 = peek();
 			}
 
 			args.push_back(std::move(arg));
@@ -688,28 +682,24 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_function() {
 			// if we find a comma, we have to parse another argument, so we loop again.
 			// if we find a closing paren, we are done parsing arguments, so we stop.
 			// Anything else is unexpected input, so we report an error.
-			if (p1->m_type == token_type::COMMA) {
-				m_lexer->advance();
+			if (consume(token_type::COMMA)) {
 				continue;
-			} else if (p1->m_type == token_type::PAREN_CLOSE) {
-				m_lexer->advance();
+			} else if (consume(token_type::PAREN_CLOSE)) {
 				break;
 			} else {
 				result.m_error.m_sub_errors.push_back(
-				    make_expected_error("',' or ')'", p1));
+				    make_expected_error("',' or ')'", peek()));
 				return result;
 			}
 		} else {
 			result.m_error.m_sub_errors.push_back(
-			    make_expected_error("an argument name (IDENTIFIER)", p0));
+			    make_expected_error("an argument name (IDENTIFIER)", peek()));
 			return result;
 		}
 	}
 
 	auto e = std::make_unique<AST::FunctionLiteral>();
-	auto p0 = peek();
-	if (p0->m_type == token_type::ARROW) {
-		m_lexer->advance();
+	if (consume(token_type::ARROW)) {
 		auto expression = parse_expression();
 		if (handle_error(result, expression)) {
 			return result;
@@ -932,7 +922,8 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_statement() {
 	Writer<std::unique_ptr<AST::AST>> result = {
 	    {"Parse Error: Failed to parse statement"}};
 
-	// TODO: recognize literals
+	// TODO: paren_open, string tokens, integer and numer
+	// tokens, etc should also be recognized as expressions.
 	auto* p0 = peek(0);
 	if (p0->m_type == token_type::IDENTIFIER) {
 		auto* p1 = peek(1);
@@ -993,8 +984,6 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_statement() {
 		}
 		return block_statement;
 	} else {
-		// TODO: parse loops, conditionals, etc.
-
 		auto err = make_expected_error("a statement", p0);
 
 		result.m_error.m_sub_errors.push_back(std::move(err));
@@ -1015,20 +1004,17 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_type_term() {
 	auto e = std::make_unique<AST::TypeTerm>();
 	e->m_callee = std::move(callee.m_result);
 
-	if (peek()->m_type != token_type::POLY_OPEN)
+	if (!consume(token_type::POLY_OPEN))
 		return make_writer<std::unique_ptr<AST::AST>>(std::move(e));
 
-	m_lexer->advance();
-
 	std::vector<std::unique_ptr<AST::AST>> args;
-	while (peek()->m_type != token_type::POLY_CLOSE) {
+	while (!consume(token_type::POLY_CLOSE)) {
 		auto arg = parse_type_term();
 		if (handle_error(result, arg))
 			return result;
 
 		args.push_back(std::move(arg.m_result));
 	}
-	m_lexer->advance();
 
 	e->m_args = std::move(args);
 	return make_writer<std::unique_ptr<AST::AST>>(std::move(e));

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,41 +1,16 @@
 #pragma once
 
-// TODO: do not include iostream here
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "ast.hpp"
+#include "error_report.hpp"
 #include "lexer.hpp"
-
-struct ParseError {
-	std::string m_text;
-	std::vector<ParseError> m_sub_errors;
-
-	bool ok() {
-		return m_sub_errors.empty() && m_text.empty();
-	}
-
-	void print(int d = 1) {
-		/* indent */
-		for (int i = 0; i < d; ++i)
-			std::cerr << '-';
-
-		/* print error */
-		std::cerr << ' ';
-		std::cerr << m_text << '\n';
-
-		/* print suberrors one place further right */
-		for (auto& sub : m_sub_errors) {
-			sub.print(d + 1);
-		}
-	}
-};
 
 template <typename T>
 struct Writer {
-	ParseError m_error {};
+	ErrorReport m_error {};
 	T m_result {};
 
 	bool ok() {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -50,8 +50,9 @@ struct Parser {
 	Writer<std::unique_ptr<AST::AST>> parse_while_statement();
 	Writer<std::unique_ptr<AST::AST>> parse_type_term();
 
-	Writer<Token const*> require(token_type t);
-	bool consume(token_type t);
+	Writer<Token const*> require(token_type);
+	bool consume(token_type);
+	bool match(token_type);
 
 	Token const* peek(int dt = 0) {
 		return &m_lexer->peek_token(dt);

--- a/src/typecheck.hpp
+++ b/src/typecheck.hpp
@@ -10,6 +10,14 @@ struct CompileTimeEnvironment;
 
 namespace TypeChecker {
 
+/*
+ * Runs type deduction and checking on the given ast.
+ *
+ * Implements a variant of the Hindley-Milbner type
+ * inference algorithm.
+ *
+ * PRECONDITION: match_identifiers has already been called
+ * the given ast.
+ */
 void typecheck(TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment&);
-
-}
+} // namespace TypeChecker

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -62,20 +62,4 @@ MonoId TypeChecker::rule_app(std::vector<MonoId> args_types, MonoId func_type) {
 	return return_type;
 }
 
-// TODO
-MonoId TypeChecker::rule_abs() {
-	assert(0);
-}
-
-// TODO
-MonoId TypeChecker::rule_let(MonoId mono) {
-	assert(0);
-	// return m_core.generalize(mono);
-}
-
-// TODO
-MonoId TypeChecker::rule_rec() {
-	assert(0);
-}
-
 } // namespace TypeChecker

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -63,8 +63,6 @@ struct TypeSystemCore {
 	std::vector<TypeFunctionData> type_function_data;
 	std::vector<PolyData> poly_data;
 
-	// TODO: add an environment.
-
 	MonoId new_var();
 	MonoId new_term(
 	    TypeFunctionId type_function,


### PR DESCRIPTION
I started doing some general cleanup and refactoring, and ended up making match_identifiers return an error report object. talk about scope creep, huh.

`typecheck` should also return an ErrorReport. So I do it in this pr, or do I leave it for later?