### PR TITLE
Tc core simplification

### DIFF
--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -225,13 +225,14 @@ MonoId CompileTimeEnvironment::new_hidden_type_var() {
 
 MonoId CompileTimeEnvironment::new_type_var() {
 	MonoId result = m_typechecker.new_var();
-	VarId var = m_typechecker.m_core.mono_data[result].data_id;
-	current_scope().m_type_vars.insert(var);
+	current_scope().m_type_vars.insert(result);
 	return result;
 }
 
-bool CompileTimeEnvironment::has_type_var(VarId var) {
-	auto scan_scope = [](Scope& scope, VarId var) -> bool {
+bool CompileTimeEnvironment::has_type_var(MonoId var) {
+	// TODO: check that the given mono is actually a var
+
+	auto scan_scope = [](Scope& scope, MonoId var) -> bool {
 		return scope.m_type_vars.count(var) != 0;
 	};
 

--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -40,7 +40,7 @@ struct Binding {
 struct Scope {
 	bool m_nested {false};
 	std::unordered_map<std::string, Binding> m_vars;
-	std::unordered_set<VarId> m_type_vars;
+	std::unordered_set<MonoId> m_type_vars;
 };
 
 struct CompileTimeEnvironment {
@@ -77,7 +77,7 @@ struct CompileTimeEnvironment {
 
 	MonoId new_type_var();
 	MonoId new_hidden_type_var();
-	bool has_type_var(VarId);
+	bool has_type_var(MonoId);
 };
 
 } // namespace Frontend

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -12,13 +12,11 @@ void TypeSystemCore::print_type(MonoId mono, int d) {
 		std::cerr << ' ';
 	std::cerr << "[" << mono << "] ";
 	if (data.type == mono_type::Var) {
-		VarId var = data.data_id;
-		VarData& data = var_data[var];
-		if (data.equals == mono) {
+		if (data.data_id == mono) {
 			std::cerr << "Free Var\n";
 		} else {
 			std::cerr << "Var\n";
-			print_type(data.equals, d + 1);
+			print_type(data.data_id, d + 1);
 		}
 	} else {
 		TermId term = data.data_id;
@@ -32,12 +30,8 @@ void TypeSystemCore::print_type(MonoId mono, int d) {
 }
 
 MonoId TypeSystemCore::new_var() {
-	int var = var_data.size();
 	int mono = mono_data.size();
-
-	var_data.push_back({mono});
-	mono_data.push_back({mono_type::Var, var});
-
+	mono_data.push_back({mono_type::Var, mono});
 	return mono;
 }
 
@@ -58,21 +52,21 @@ MonoId TypeSystemCore::new_term(
 	return mono;
 }
 
-PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<VarId> vars) {
+PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
+	// TODO: check that the given vars are actually vars
 	PolyData data;
 	data.base = mono;
 	data.vars = std::move(vars);
 	PolyId poly = poly_data.size();
-	poly_data.push_back(data);
+	poly_data.push_back(std::move(data));
 	return poly;
 }
 
-void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<VarId>& free_vars) {
+void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<MonoId>& free_vars) {
 	MonoId repr = find(mono);
 	MonoData const& data = mono_data[repr];
 	if (data.type == mono_type::Var) {
-		VarId var = data.data_id;
-		free_vars.insert(var);
+		free_vars.insert(repr);
 	} else {
 		TermId term = data.data_id;
 		for (MonoId arg : term_data[term].arguments)
@@ -84,13 +78,13 @@ void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<VarId>& fr
 // NOTE(Mestre): I don't like how we take the CTenv as an
 // argument. This calls for some refactoring...
 PolyId TypeSystemCore::generalize(MonoId mono, Frontend::CompileTimeEnvironment& env) {
-	std::unordered_set<VarId> free_vars;
+	std::unordered_set<MonoId> free_vars;
 	gather_free_vars(mono, free_vars);
 
 	std::vector<MonoId> new_vars;
-	std::unordered_map<VarId, MonoId> mapping;
+	std::unordered_map<MonoId, MonoId> mapping;
 	int i = 0;
-	for (VarId var : free_vars) {
+	for (MonoId var : free_vars) {
 		if (!env.has_type_var(var)) {
 			auto fresh_var = new_var();
 			new_vars.push_back(fresh_var);
@@ -99,33 +93,30 @@ PolyId TypeSystemCore::generalize(MonoId mono, Frontend::CompileTimeEnvironment&
 	}
 
 	MonoId base = inst_impl(mono, mapping);
-	std::vector<VarId> vars;
-	for (MonoId m : new_vars)
-		vars.push_back(mono_data[m].data_id);
 
-	return new_poly(base, std::move(vars));
+	return new_poly(base, std::move(new_vars));
 }
 
 MonoId TypeSystemCore::find(MonoId mono) {
-	if (mono_data[mono].type != mono_type::Var)
-		return mono;
+	MonoData& data = mono_data[mono];
 
-	VarId var = mono_data[mono].data_id;
-	VarData& data = var_data[var];
+	if (data.type != mono_type::Var)
+		return mono;
 
 	// pointing to self
-	if (data.equals == mono)
+	if (data.data_id == mono)
 		return mono;
 
-	return data.equals = find(data.equals);
+	return data.data_id = find(data.data_id);
 }
 
-bool TypeSystemCore::occurs_in(VarId var, MonoId mono) {
+bool TypeSystemCore::occurs_in(MonoId var, MonoId mono) {
 
 	{
-		// the variable must point to itself
-		MonoData const& var_mono_data = mono_data[var_data[var].equals];
-		assert(var_mono_data.type == mono_type::Var && var == var_mono_data.data_id);
+		// var must be a variable that points to itself
+		MonoData const& var_mono_data = mono_data[var];
+		assert(var_mono_data.type == mono_type::Var);
+		assert(var == var_mono_data.data_id);
 	}
 
 	mono = find(mono);
@@ -135,6 +126,7 @@ bool TypeSystemCore::occurs_in(VarId var, MonoId mono) {
 	}
 
 	assert(mono_data[mono].type == mono_type::Term);
+
 	TermId term = mono_data[mono].data_id;
 	TermData data = term_data[term];
 
@@ -154,19 +146,17 @@ void TypeSystemCore::unify(MonoId a, MonoId b) {
 
 	if (mono_data[a].type == mono_type::Var) {
 		if (mono_data[b].type == mono_type::Var) {
-			if (mono_data[a].data_id < mono_data[b].data_id) {
+			if (a < b) {
 				// make the newer one point to the older one
 				std::swap(a, b);
 			}
 		}
 
-		VarId va = mono_data[a].data_id;
-
-		if (occurs_in(va, b)) {
+		if (occurs_in(a, b)) {
 			assert(0 && "recursive unification\n");
 		}
 
-		var_data[va].equals = b;
+		mono_data[a].data_id = b;
 	} else if (mono_data[b].type == mono_type::Var) {
 		return unify(b, a);
 	} else {
@@ -198,7 +188,7 @@ void TypeSystemCore::unify(MonoId a, MonoId b) {
 }
 
 MonoId TypeSystemCore::inst_impl(
-    MonoId mono, std::unordered_map<VarId, MonoId> const& mapping) {
+    MonoId mono, std::unordered_map<MonoId, MonoId> const& mapping) {
 
 	// NOTE(Mestre): Is just calling find good enough? It means we
 	// should only ever qualify variables that are their own
@@ -207,8 +197,7 @@ MonoId TypeSystemCore::inst_impl(
 	MonoData data = mono_data[mono];
 
 	if (data.type == mono_type::Var) {
-		auto it = mapping.find(data.data_id);
-		// TODO: make a new mono with the same var?
+		auto it = mapping.find(mono);
 		return it == mapping.end() ? mono : it->second;
 	}
 
@@ -228,7 +217,7 @@ MonoId TypeSystemCore::inst_with(PolyId poly, std::vector<MonoId> const& vals) {
 
 	assert(data.vars.size() == vals.size());
 
-	std::unordered_map<VarId, MonoId> old_to_new;
+	std::unordered_map<MonoId, MonoId> old_to_new;
 	for (int i {0}; i != data.vars.size(); ++i) {
 		old_to_new[data.vars[i]] = vals[i];
 	}
@@ -238,8 +227,7 @@ MonoId TypeSystemCore::inst_with(PolyId poly, std::vector<MonoId> const& vals) {
 
 MonoId TypeSystemCore::inst_fresh(PolyId poly) {
 	std::vector<MonoId> vals;
-	for (int i {0}; i != poly_data[poly].vars.size(); ++i) {
+	for (int i {0}; i != poly_data[poly].vars.size(); ++i)
 		vals.push_back(new_var());
-	}
 	return inst_with(poly, vals);
 }

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -23,7 +23,7 @@ enum class mono_type { Var, Term };
 // A monotype is a reference to a concrete type. It can be a
 // variable or a term.
 // We express this variant using an enum, and an index that points
-// to the where the data is in the correct TypeSystemCore vector.
+// to where the data is in the correct TypeSystemCore vector.
 //
 // If type is mono_type::Var, the data_id index points to a
 // different mono in TypeSystemCore::mono_data.

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -36,14 +36,6 @@ struct MonoData {
 	int data_id;
 };
 
-// A variable is just a name for a different monotype.
-// VarData stores a MonoID that indicates which monotype it is equal
-// to. It can also indicate that it is equal to itself, meaning that
-// we don't know its concrete type.
-struct VarData {
-	MonoId equals;
-};
-
 // A term is an application of a type function.
 struct TermData {
 	TypeFunctionId type_function;

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -20,14 +20,17 @@ struct TypeFunctionData {
 };
 
 enum class mono_type { Var, Term };
-// A monotype is a reference to a 'real' type. It can be a variable
-// or a term.
+// A monotype is a reference to a concrete type. It can be a
+// variable or a term.
 // We express this variant using an enum, and an index that points
-// to the where the concrete data is in the correct TypeSystemCore
-// vector.
-// If type is mono_type::Var, then the data is stored in
-// TypeSystemCore::var_data. And if it is mono_type::term, the data
-// is stored in TypeSystemCore::term_data.
+// to the where the data is in the correct TypeSystemCore vector.
+//
+// If type is mono_type::Var, the data_id index points to a
+// different mono in TypeSystemCore::mono_data.
+// It may point to itself, meaning that the type is not known.
+//
+// If the type is mono_type::Term, the index points to a term,
+// that is stored in TypeSystemCore::term_data
 struct MonoData {
 	mono_type type;
 	int data_id;
@@ -52,12 +55,11 @@ struct TermData {
 // any value, and still give a valid typing.
 struct PolyData {
 	MonoId base;
-	std::vector<VarId> vars;
+	std::vector<MonoId> vars;
 };
 
 struct TypeSystemCore {
 	std::vector<MonoData> mono_data;
-	std::vector<VarData> var_data;
 	std::vector<TermData> term_data;
 
 	std::vector<TypeFunctionData> type_function_data;
@@ -68,19 +70,23 @@ struct TypeSystemCore {
 	    TypeFunctionId type_function,
 	    std::vector<MonoId> args,
 	    char const* tag = nullptr);
-	PolyId new_poly(MonoId mono, std::vector<VarId> vars);
+	PolyId new_poly(MonoId mono, std::vector<MonoId> vars);
 
 	// qualifies all unbound variables in the given monotype
 	PolyId generalize(MonoId mono, Frontend::CompileTimeEnvironment&);
 
-	void gather_free_vars(MonoId mono, std::unordered_set<VarId>& free_vars);
+	void gather_free_vars(MonoId mono, std::unordered_set<MonoId>& free_vars);
 
+	// gives the representative for a given mono
 	MonoId find(MonoId mono);
-	// expects the variable to be its own representative
-	bool occurs_in(VarId var, MonoId mono);
+
+	// var must be a variable that is its own representative
+	bool occurs_in(MonoId var, MonoId mono);
+
+	// makes the two given types equal
 	void unify(MonoId a, MonoId b);
 
-	MonoId inst_impl(MonoId mono, std::unordered_map<VarId, MonoId> const& mapping);
+	MonoId inst_impl(MonoId mono, std::unordered_map<MonoId, MonoId> const& mapping);
 	MonoId inst_with(PolyId poly, std::vector<MonoId> const& vals);
 	MonoId inst_fresh(PolyId poly);
 

--- a/src/typesystem_types.hpp
+++ b/src/typesystem_types.hpp
@@ -2,7 +2,6 @@
 
 // TODO: make these type-safe
 using TypeFunctionId = int;
-using VarId = int;
 using TermId = int;
 using MonoId = int;
 using PolyId = int;


### PR DESCRIPTION
It turns out, type vars don't have any data to them, so we don't really need to put them in a whole new array, we can just use the `data_id` in `MonoData` as the var index.

This is a lot simpler, and more efficient.

PS: I also added or touched up some comments