### PR TITLE
Parse union typedefs

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -118,6 +118,14 @@ struct DeclarationList : public AST {
 	    : AST {ast_type::DeclarationList} {}
 };
 
+// TODO: better name
+struct UnionTypeExpression : public AST {
+	std::vector<std::unique_ptr<AST>> m_declarations;
+
+	UnionTypeExpression()
+	    : AST {ast_type::UnionTypeExpression} {}
+};
+
 struct Declaration : public AST {
 	Token const* m_identifier_token;
 	std::unique_ptr<AST> m_type;  // can be nullptr

--- a/src/ast_type.hpp
+++ b/src/ast_type.hpp
@@ -26,6 +26,7 @@ constexpr const char* ast_type_string[] = {
 	"WhileStatement",
 
 	"TypeTerm",
+	"UnionTypeExpression",
 };
 
 enum class ast_type {
@@ -54,4 +55,5 @@ enum class ast_type {
 	WhileStatement,
 
 	TypeTerm,
+	UnionTypeExpression,
 };

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -125,6 +125,12 @@ bool Lexer::consume_keyword() {
 			return true;
 		}
 		break;
+	case 'u':
+		if (peek_char(1) == 'n' && peek_char(2) == 'i' && peek_char(3) == 'o' &&
+		    peek_char(4) == 'n' && not is_identifier_char(peek_char(5))) {
+			push_token(token_type::KEYWORD_UNION, 4);
+			return true;
+		}
 	case 'n':
 		if (peek_char(1) == 'u' && peek_char(2) == 'l' && peek_char(3) == 'l' &&
 		    not is_identifier_char(peek_char(4))) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -99,6 +99,13 @@ bool Lexer::consume_keyword() {
 			return true;
 		}
 		break;
+	case 'm':
+		if (peek_char(1) == 'a' && peek_char(2) == 't' && peek_char(3) == 'c' &&
+		    peek_char(4) == 'h' && not is_identifier_char(peek_char(5))) {
+			push_token(token_type::KEYWORD_MATCH, 5);
+			return true;
+		}
+		break;
 	case 'o':
 		if (peek_char(1) == 'b' && peek_char(2) == 't' &&
 		    not is_identifier_char(peek_char(3))) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -79,8 +79,8 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_top_level() {
 	return make_writer<std::unique_ptr<AST::AST>>(std::move(e));
 }
 
-Writer<std::vector<std::unique_ptr<AST::AST>>>
-Parser::parse_declaration_list(token_type terminator) {
+Writer<std::vector<std::unique_ptr<AST::AST>>> Parser::parse_declaration_list(
+    token_type terminator) {
 	Writer<std::vector<std::unique_ptr<AST::AST>>> result = {
 	    {"Parse Error: Failed to parse declaration list"}};
 
@@ -1006,5 +1006,22 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_type_term() {
 	}
 
 	e->m_args = std::move(args);
+	return make_writer<std::unique_ptr<AST::AST>>(std::move(e));
+}
+
+Writer<std::unique_ptr<AST::AST>> Parser::parse_union_type_expression() {
+	Writer<std::unique_ptr<AST::AST>> result = {
+	    {"Parse Error: Failed to parse union"}};
+
+	if (handle_error(result, require(token_type::KEYWORD_UNION)))
+		return result;
+
+	if (handle_error(result, require(token_type::BRACE_OPEN)))
+		return result;
+
+	if (handle_error(result, require(token_type::BRACE_CLOSE)))
+		return result;
+
+	auto e = std::make_unique<AST::UnionTypeExpression>();
 	return make_writer<std::unique_ptr<AST::AST>>(std::move(e));
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -48,7 +48,10 @@ struct Parser {
 	Writer<std::unique_ptr<AST::AST>> parse_if_else_statement();
 	Writer<std::unique_ptr<AST::AST>> parse_for_statement();
 	Writer<std::unique_ptr<AST::AST>> parse_while_statement();
+
+	// TODO: better names
 	Writer<std::unique_ptr<AST::AST>> parse_type_term();
+	Writer<std::unique_ptr<AST::AST>> parse_union_type_expression();
 
 	Writer<Token const*> require(token_type);
 	bool consume(token_type);

--- a/src/token_type.hpp
+++ b/src/token_type.hpp
@@ -77,6 +77,7 @@ constexpr const char* token_type_string[] = {
 	"KEYWORD_FOR",
 	"KEYWORD_WHILE",
 	"KEYWORD_MATCH",
+	"KEYWORD_UNION",
 
 	"END",
 };
@@ -158,6 +159,7 @@ enum class token_type {
 	KEYWORD_FOR,
 	KEYWORD_WHILE,
 	KEYWORD_MATCH,
+	KEYWORD_UNION,
 
 	END,
 };

--- a/src/token_type.hpp
+++ b/src/token_type.hpp
@@ -76,6 +76,7 @@ constexpr const char* token_type_string[] = {
 	"KEYWORD_ELSE",
 	"KEYWORD_FOR",
 	"KEYWORD_WHILE",
+	"KEYWORD_MATCH",
 
 	"END",
 };
@@ -156,6 +157,7 @@ enum class token_type {
 	KEYWORD_ELSE,
 	KEYWORD_FOR,
 	KEYWORD_WHILE,
+	KEYWORD_MATCH,
 
 	END,
 };


### PR DESCRIPTION
I actually have some free time before the actual competition, so I decided to chip in.

I added some generally non-controversial code, and realized I didn't really know what to do next, because we have not decided on the syntax for type expressions.

I am not sure if you're familiar with BNF style syntax but here goes: this is what I think the syntax should be for types (roughly speaking).

BNF is just a way to define syntax kinda formally. You can put names on constructs with `::=`, `|` is an alternation, and a sequence of constructs just means concatenation. Plus, `...` just means "an arbitrary amount of repetitions of the stuff on the left".

```yacc
type_expr   ::= mono_type | type_func

mono_type   ::= type_var | type_term
type_var    ::= "@" identifier
type_term   ::= type_func "(<" mono_type "," ... ">)"

type_func   ::= union_expr | struct_expr | identifier

union_expr  ::= "union"  "{" declarator ";" ... ";" "}"
struct_expr ::= "struct" "{" declarator ";" ... ";" "}"

declarator  ::= identifier ":" mono_type
```

I did this because it really helps to remove ambiguity and make communication clearer (which is very helpful, because I am not very good at communicating clearly a lot of the time).

Let me know what you think about this particular syntax