### PR TITLE
use # operator in Xmacros

### DIFF
--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -32,7 +32,7 @@
 	X(TupleExpression) \
 	X(StructExpression)
 
-#define X(name) "name",
+#define X(name) #name,
 constexpr const char* ast_string[] = {
 	AST_TAGS
 };

--- a/src/interpreter/exit_status_tag.hpp
+++ b/src/interpreter/exit_status_tag.hpp
@@ -13,7 +13,7 @@
 	X(ValueError) \
 	X(Empty)
 
-#define X(name) "name",
+#define X(name) #name,
 constexpr const char* exit_status_string[] = {
 	EXIT_STATUS_TAGS
 };

--- a/src/interpreter/value_tag.hpp
+++ b/src/interpreter/value_tag.hpp
@@ -18,7 +18,7 @@
 \
 	X(Reference)
 
-#define X(name) "name",
+#define X(name) #name,
 constexpr const char* value_string[] = {
 	VALUE_TAGS
 };

--- a/src/test/test_status_tag.hpp
+++ b/src/test/test_status_tag.hpp
@@ -6,7 +6,7 @@
 	X(Fail) \
 	X(Empty)
 
-#define X(name) "name",
+#define X(name) #name,
 constexpr const char* test_status_string[] = {
 	TEST_STATUS_TAGS
 };


### PR DESCRIPTION
CPP interprets `"name" ` as a single token, not as `"` `name` `"`. To do this, CPP provides the `#` operator.