### PR TITLE
parse record access expressions directly

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -164,8 +164,7 @@ void print(RecordAccessExpression* ast, int d) {
 	print(ast->m_record.get(), d + 1);
 
 	print_indentation(d);
-	std::cout << "Member:\n";
-	print(ast->m_member.get(), d + 1);
+	std::cout << "Member: " << ast->m_member->m_text << "\n";
 
 	print_indentation(d - 1);
 	std::cout << "]\n";

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -170,7 +170,7 @@ struct IndexExpression : public AST {
 
 struct RecordAccessExpression : public AST {
 	Own<AST> m_record;
-	Own<Identifier> m_member;
+	Token const* m_member;
 
 	RecordAccessExpression()
 	    : AST {ASTTag::RecordAccessExpression} {}

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -85,18 +85,9 @@ Own<AST> desugarPizza(Own<BinaryExpression> ast) {
 	return rhs;
 }
 
-Own<AST> desugarDot(Own<BinaryExpression> ast) {
-	// TODO: error handling
-	// TODO: move this check to the parser
-	assert(ast->m_rhs->type() == ASTTag::Identifier);
-	auto identifier_ptr = static_cast<Identifier*>(ast->m_rhs.release());
-	auto identifier = Own<Identifier>(identifier_ptr);
-
-	auto result = std::make_unique<RecordAccessExpression>();
-	result->m_member = std::move(identifier);
-	result->m_record = desugar(std::move(ast->m_lhs));
-
-	return result;
+Own<AST> desugar(Own<RecordAccessExpression> ast) {
+	ast->m_record = desugar(std::move(ast->m_record));
+	return ast;
 }
 
 // This function desugars binary operators into function calls
@@ -106,7 +97,7 @@ Own<AST> desugar(Own<BinaryExpression> ast) {
 		return desugarPizza(std::move(ast));
 
 	if (ast->m_op_token->m_type == TokenTag::DOT)
-		return desugarDot(std::move(ast));
+		assert(0);
 
 	auto identifier = std::make_unique<Identifier>();
 	identifier->m_token = ast->m_op_token;
@@ -215,7 +206,7 @@ Own<AST> desugar(Own<AST> ast) {
 		DISPATCH(TernaryExpression);
 		DISPATCH(CallExpression);
 		DISPATCH(IndexExpression);
-		REJECT(RecordAccessExpression);
+		DISPATCH(RecordAccessExpression);
 
 		DISPATCH(DeclarationList);
 		DISPATCH(Declaration);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -372,6 +372,20 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_expression(int bp) {
 			continue;
 		}
 
+		if (consume(TokenTag::DOT)) {
+			auto member = require(TokenTag::IDENTIFIER);
+
+			if (handle_error(result, member))
+				return result;
+
+			auto e = std::make_unique<AST::RecordAccessExpression>();
+			e->m_record = std::move(lhs.m_result);
+			e->m_member = std::move(member.m_result);
+			lhs.m_result = std::move(e);
+
+			continue;
+		}
+
 		m_lexer->advance();
 		auto rhs = parse_expression(rp);
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -235,7 +235,7 @@ void typecheck(TypedAST::RecordAccessExpression* ast, Frontend::CompileTimeEnvir
 	ast->m_value_type = member_type;
 
 	TypeFunctionId dummy_tf = env.m_typechecker.m_core.new_dummy_type_function(
-	    TypeFunctionTag::Record, {{ast->m_member->text(), member_type}});
+	    TypeFunctionTag::Record, {{ast->m_member->m_text, member_type}});
 	MonoId term_type = env.m_typechecker.m_core.new_term(dummy_tf, {}, "record instance");
 
 	env.m_typechecker.m_core.unify(ast->m_record->m_value_type, term_type);

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -147,8 +147,7 @@ TypedAST* convertAST(AST::TernaryExpression* ast) {
 TypedAST* convertAST(AST::RecordAccessExpression* ast) {
 	auto typed_ast = new RecordAccessExpression;
 
-	// TODO: this line is extremely disgusting
-	typed_ast->m_member = Own<Identifier>(static_cast<Identifier*>(convertAST(ast->m_member.get())));
+	typed_ast->m_member = ast->m_member;
 	typed_ast->m_record = Own<TypedAST>(convertAST(ast->m_record.get()));
 
 	return typed_ast;

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -188,7 +188,7 @@ struct IndexExpression : public TypedAST {
 
 struct RecordAccessExpression : public TypedAST {
 	Own<TypedAST> m_record;
-	Own<Identifier> m_member;
+	Token const* m_member;
 
 	RecordAccessExpression()
 	    : TypedAST {TypedASTTag::RecordAccessExpression} {}


### PR DESCRIPTION
This makes the representation of record access nodes a bit nicer to work with