### PR TITLE
Cleanup convert ast

### DIFF
--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -35,7 +35,7 @@ ExitStatusTag execute(std::string const& source, bool dump_ast, Runner* runner) 
 		return ExitStatusTag::TopLevelTypeError;
 
 	auto desugared_ast = AST::desugar(std::move(top_level_ast));
-	auto top_level = TypedAST::get_unique(desugared_ast);
+	auto top_level = TypedAST::convertAST(desugared_ast.get());
 	Frontend::CompileTimeEnvironment ct_env;
 
 	{
@@ -66,7 +66,7 @@ Value* eval_expression(const std::string& expr, Environment& env) {
 	TokenArray ta;
 
 	auto top_level_call_ast = parse_expression(expr, ta);
-	auto top_level_call = TypedAST::get_unique(top_level_call_ast.m_result);
+	auto top_level_call = TypedAST::convertAST(top_level_call_ast.m_result.get());
 
 	// TODO: return a gc_ptr
 	auto value = eval(top_level_call.get(), env);

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -35,7 +35,7 @@ ExitStatusTag execute(std::string const& source, bool dump_ast, Runner* runner) 
 		return ExitStatusTag::TopLevelTypeError;
 
 	auto desugared_ast = AST::desugar(std::move(top_level_ast));
-	auto top_level = TypedAST::convertAST(desugared_ast.get());
+	auto top_level = TypedAST::convert_ast(desugared_ast.get());
 	Frontend::CompileTimeEnvironment ct_env;
 
 	{
@@ -66,7 +66,7 @@ Value* eval_expression(const std::string& expr, Environment& env) {
 	TokenArray ta;
 
 	auto top_level_call_ast = parse_expression(expr, ta);
-	auto top_level_call = TypedAST::convertAST(top_level_call_ast.m_result.get());
+	auto top_level_call = TypedAST::convert_ast(top_level_call_ast.m_result.get());
 
 	// TODO: return a gc_ptr
 	auto value = eval(top_level_call.get(), env);

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -36,7 +36,7 @@ int main() {
 			    TokenArray ta;
 			    auto top_level_call_ast = parse_expression("__invoke()", ta);
 			    auto top_level_call =
-			        TypedAST::convertAST(top_level_call_ast.m_result.get());
+			        TypedAST::convert_ast(top_level_call_ast.m_result.get());
 
 			    auto result = eval(top_level_call.get(), env);
 

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -38,14 +38,12 @@ int main() {
 			    auto top_level_call =
 			        TypedAST::convertAST(top_level_call_ast.m_result.get());
 
-			    auto result = eval(top_level_call, env);
+			    auto result = eval(top_level_call.get(), env);
 
 			    if (result)
 				    Interpreter::print(result.get());
 			    else
 				    std::cout << "(nullptr)\n";
-
-			    delete top_level_call;
 		    }
 
 		    return ExitStatusTag::Ok;

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -7,72 +7,56 @@
 
 namespace TypedAST {
 
-std::unique_ptr<TypedAST> get_unique(std::unique_ptr<AST::AST>& ast) {
-	return std::unique_ptr<TypedAST>(convertAST(ast.get()));
-}
-
-TypedAST* convertAST(AST::IntegerLiteral* ast) {
-	auto typed_integer = new IntegerLiteral;
+Own<TypedAST> convertAST(AST::IntegerLiteral* ast) {
+	auto typed_integer = std::make_unique<IntegerLiteral>();
 	typed_integer->m_token = ast->m_token;
 	return typed_integer;
 }
 
-TypedAST* convertAST(AST::NumberLiteral* ast) {
-	auto typed_number = new NumberLiteral;
+Own<TypedAST> convertAST(AST::NumberLiteral* ast) {
+	auto typed_number = std::make_unique<NumberLiteral>();
 	typed_number->m_token = ast->m_token;
 	return typed_number;
 }
 
-TypedAST* convertAST(AST::StringLiteral* ast) {
-	auto typed_string = new StringLiteral;
+Own<TypedAST> convertAST(AST::StringLiteral* ast) {
+	auto typed_string = std::make_unique<StringLiteral>();
 	typed_string->m_token = ast->m_token;
 	return typed_string;
 }
 
-TypedAST* convertAST(AST::BooleanLiteral* ast) {
-	auto typed_boolean = new BooleanLiteral;
+Own<TypedAST> convertAST(AST::BooleanLiteral* ast) {
+	auto typed_boolean = std::make_unique<BooleanLiteral>();
 	typed_boolean->m_token = ast->m_token;
 	return typed_boolean;
 }
 
-TypedAST* convertAST(AST::NullLiteral* ast) {
-	return new NullLiteral;
+Own<TypedAST> convertAST(AST::NullLiteral* ast) {
+	return std::make_unique<NullLiteral>();
 }
 
-TypedAST* convertAST(AST::ObjectLiteral* ast) {
-	auto typed_object = new ObjectLiteral;
-	// al tipo de los objetos se les debe sumar una identificacion
-	// de clase
-
-	for (auto& element : ast->m_body) {
-		typed_object->m_body.push_back(get_unique(element));
-	}
-
-	return typed_object;
-}
-
-TypedAST* convertAST(AST::ArrayLiteral* ast) {
-	auto typed_array = new ArrayLiteral;
+Own<TypedAST> convertAST(AST::ArrayLiteral* ast) {
+	auto typed_array = std::make_unique<ArrayLiteral>();
 
 	for (auto& element : ast->m_elements) {
-		typed_array->m_elements.push_back(get_unique(element));
+		typed_array->m_elements.push_back(convertAST(element.get()));
 	}
 
 	return typed_array;
 }
 
-TypedAST* convertAST(AST::DictionaryLiteral* ast) {
-	auto typed_dict = new DictionaryLiteral;
+Own<TypedAST> convertAST(AST::DictionaryLiteral* ast) {
+	auto typed_dict = std::make_unique<DictionaryLiteral>();
 
 	for (auto& element : ast->m_body) {
-		typed_dict->m_body.push_back(get_unique(element));
+		typed_dict->m_body.push_back(convertAST(element.get()));
 	}
 
 	return typed_dict;
 }
 
-TypedAST* convertAST(AST::FunctionLiteral* ast) {
-	auto typed_function = new FunctionLiteral;
+Own<TypedAST> convertAST(AST::FunctionLiteral* ast) {
+	auto typed_function = std::make_unique<FunctionLiteral>();
 
 	for (auto& arg : ast->m_args) {
 		assert(arg->type() == ASTTag::Declaration);
@@ -81,130 +65,131 @@ TypedAST* convertAST(AST::FunctionLiteral* ast) {
 		typed_function->m_args.push_back({decl->m_identifier_token});
 	}
 
-	typed_function->m_body = get_unique(ast->m_body);
+	typed_function->m_body = convertAST(ast->m_body.get());
 
 	return typed_function;
 }
 
-TypedAST* convertAST(AST::DeclarationList* ast) {
-	auto typed_declist = new DeclarationList;
+Own<TypedAST> convertAST(AST::DeclarationList* ast) {
+	auto typed_declist = std::make_unique<DeclarationList>();
 
 	for (auto& declaration : ast->m_declarations) {
-		typed_declist->m_declarations.push_back(get_unique(declaration));
+		typed_declist->m_declarations.push_back(convertAST(declaration.get()));
 	}
 
 	return typed_declist;
 }
 
-TypedAST* convertAST(AST::Declaration* ast) {
-	auto typed_dec = new Declaration;
+Own<TypedAST> convertAST(AST::Declaration* ast) {
+	auto typed_dec = std::make_unique<Declaration>();
 
 	typed_dec->m_identifier_token = ast->m_identifier_token;
 	// TODO: handle type hint
 	if (ast->m_value)
-		typed_dec->m_value = get_unique(ast->m_value);
+		typed_dec->m_value = convertAST(ast->m_value.get());
 
 	return typed_dec;
 }
 
-TypedAST* convertAST(AST::Identifier* ast) {
-	auto typed_id = new Identifier;
+Own<TypedAST> convertAST(AST::Identifier* ast) {
+	auto typed_id = std::make_unique<Identifier>();
 	typed_id->m_token = ast->m_token;
 	return typed_id;
 }
 
-TypedAST* convertAST(AST::CallExpression* ast) {
-	auto typed_ce = new CallExpression;
+Own<TypedAST> convertAST(AST::CallExpression* ast) {
+	auto typed_ce = std::make_unique<CallExpression>();
 
 	for (auto& arg : ast->m_args) {
-		typed_ce->m_args.push_back(get_unique(arg));
+		typed_ce->m_args.push_back(convertAST(arg.get()));
 	}
 
-	typed_ce->m_callee = get_unique(ast->m_callee);
+	typed_ce->m_callee = convertAST(ast->m_callee.get());
 
 	return typed_ce;
 }
 
-TypedAST* convertAST(AST::IndexExpression* ast) {
-	auto typed_index = new IndexExpression;
+Own<TypedAST> convertAST(AST::IndexExpression* ast) {
+	auto typed_index = std::make_unique<IndexExpression>();
 
-	typed_index->m_callee = get_unique(ast->m_callee);
-	typed_index->m_index = get_unique(ast->m_index);
+	typed_index->m_callee = convertAST(ast->m_callee.get());
+	typed_index->m_index = convertAST(ast->m_index.get());
 
 	return typed_index;
 }
 
-TypedAST* convertAST(AST::TernaryExpression* ast) {
-	auto typed_ternary = new TernaryExpression;
+Own<TypedAST> convertAST(AST::TernaryExpression* ast) {
+	auto typed_ternary = std::make_unique<TernaryExpression>();
 
-	typed_ternary->m_condition = get_unique(ast->m_condition);
-	typed_ternary->m_then_expr = get_unique(ast->m_then_expr);
-	typed_ternary->m_else_expr = get_unique(ast->m_else_expr);
+	typed_ternary->m_condition = convertAST(ast->m_condition.get());
+	typed_ternary->m_then_expr = convertAST(ast->m_then_expr.get());
+	typed_ternary->m_else_expr = convertAST(ast->m_else_expr.get());
 
 	return typed_ternary;
 }
 
-TypedAST* convertAST(AST::RecordAccessExpression* ast) {
-	auto typed_ast = new RecordAccessExpression;
+Own<TypedAST> convertAST(AST::RecordAccessExpression* ast) {
+	auto typed_ast = std::make_unique<RecordAccessExpression>();
 
 	// TODO: this line is extremely disgusting
-	typed_ast->m_member = Own<Identifier>(static_cast<Identifier*>(convertAST(ast->m_member.get())));
-	typed_ast->m_record = Own<TypedAST>(convertAST(ast->m_record.get()));
+	typed_ast->m_member = Own<Identifier>(
+	    static_cast<Identifier*>(convertAST(ast->m_member.get()).release()));
+	typed_ast->m_record = convertAST(ast->m_record.get());
 
 	return typed_ast;
 }
 
-TypedAST* convertAST(AST::Block* ast) {
-	auto typed_block = new Block;
+Own<TypedAST> convertAST(AST::Block* ast) {
+	auto typed_block = std::make_unique<Block>();
 
 	for (auto& element : ast->m_body) {
-		typed_block->m_body.push_back(get_unique(element));
+		typed_block->m_body.push_back(convertAST(element.get()));
 	}
 
 	return typed_block;
 }
 
-TypedAST* convertAST(AST::ReturnStatement* ast) {
-	auto typed_rs = new ReturnStatement;
+Own<TypedAST> convertAST(AST::ReturnStatement* ast) {
+	auto typed_rs = std::make_unique<ReturnStatement>();
 
-	typed_rs->m_value = get_unique(ast->m_value);
+	typed_rs->m_value = convertAST(ast->m_value.get());
 
 	return typed_rs;
 }
 
-TypedAST* convertAST(AST::IfElseStatement* ast) {
-	auto typed_if_else = new IfElseStatement;
+Own<TypedAST> convertAST(AST::IfElseStatement* ast) {
+	auto typed_if_else = std::make_unique<IfElseStatement>();
 
-	typed_if_else->m_condition = get_unique(ast->m_condition);
-	typed_if_else->m_body = get_unique(ast->m_body);
+	typed_if_else->m_condition = convertAST(ast->m_condition.get());
+	typed_if_else->m_body = convertAST(ast->m_body.get());
 
 	if (ast->m_else_body)
-		typed_if_else->m_else_body = get_unique(ast->m_else_body);
+		typed_if_else->m_else_body = convertAST(ast->m_else_body.get());
 
 	return typed_if_else;
 }
 
-TypedAST* convertAST(AST::ForStatement* ast) {
-	auto typed_for = new ForStatement;
+Own<TypedAST> convertAST(AST::ForStatement* ast) {
+	auto typed_for = std::make_unique<ForStatement>();
 
-	typed_for->m_declaration = get_unique(ast->m_declaration);
-	typed_for->m_condition = get_unique(ast->m_condition);
-	typed_for->m_action = get_unique(ast->m_action);
-	typed_for->m_body = get_unique(ast->m_body);
+	typed_for->m_declaration = convertAST(ast->m_declaration.get());
+	typed_for->m_condition = convertAST(ast->m_condition.get());
+	typed_for->m_action = convertAST(ast->m_action.get());
+	typed_for->m_body = convertAST(ast->m_body.get());
 
 	return typed_for;
 }
 
-TypedAST* convertAST(AST::WhileStatement* ast) {
-	auto typed_while = new WhileStatement;
+Own<TypedAST> convertAST(AST::WhileStatement* ast) {
+	auto typed_while = std::make_unique<WhileStatement>();
 
-	typed_while->m_condition = get_unique(ast->m_condition);
-	typed_while->m_body = get_unique(ast->m_body);
+	typed_while->m_condition = convertAST(ast->m_condition.get());
+	typed_while->m_body = convertAST(ast->m_body.get());
 
 	return typed_while;
 }
 
-TypedAST* convertAST(AST::AST* ast) {
+Own<TypedAST> convertAST(AST::AST* ast) {
 #define DISPATCH(type)                                                         \
 	case ASTTag::type:                                                         \
 		return convertAST(static_cast<AST::type*>(ast))

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -7,55 +7,55 @@
 
 namespace TypedAST {
 
-Own<TypedAST> convertAST(AST::IntegerLiteral* ast) {
+Own<TypedAST> convert_ast(AST::IntegerLiteral* ast) {
 	auto typed_integer = std::make_unique<IntegerLiteral>();
 	typed_integer->m_token = ast->m_token;
 	return typed_integer;
 }
 
-Own<TypedAST> convertAST(AST::NumberLiteral* ast) {
+Own<TypedAST> convert_ast(AST::NumberLiteral* ast) {
 	auto typed_number = std::make_unique<NumberLiteral>();
 	typed_number->m_token = ast->m_token;
 	return typed_number;
 }
 
-Own<TypedAST> convertAST(AST::StringLiteral* ast) {
+Own<TypedAST> convert_ast(AST::StringLiteral* ast) {
 	auto typed_string = std::make_unique<StringLiteral>();
 	typed_string->m_token = ast->m_token;
 	return typed_string;
 }
 
-Own<TypedAST> convertAST(AST::BooleanLiteral* ast) {
+Own<TypedAST> convert_ast(AST::BooleanLiteral* ast) {
 	auto typed_boolean = std::make_unique<BooleanLiteral>();
 	typed_boolean->m_token = ast->m_token;
 	return typed_boolean;
 }
 
-Own<TypedAST> convertAST(AST::NullLiteral* ast) {
+Own<TypedAST> convert_ast(AST::NullLiteral* ast) {
 	return std::make_unique<NullLiteral>();
 }
 
-Own<TypedAST> convertAST(AST::ArrayLiteral* ast) {
+Own<TypedAST> convert_ast(AST::ArrayLiteral* ast) {
 	auto typed_array = std::make_unique<ArrayLiteral>();
 
 	for (auto& element : ast->m_elements) {
-		typed_array->m_elements.push_back(convertAST(element.get()));
+		typed_array->m_elements.push_back(convert_ast(element.get()));
 	}
 
 	return typed_array;
 }
 
-Own<TypedAST> convertAST(AST::DictionaryLiteral* ast) {
+Own<TypedAST> convert_ast(AST::DictionaryLiteral* ast) {
 	auto typed_dict = std::make_unique<DictionaryLiteral>();
 
 	for (auto& element : ast->m_body) {
-		typed_dict->m_body.push_back(convertAST(element.get()));
+		typed_dict->m_body.push_back(convert_ast(element.get()));
 	}
 
 	return typed_dict;
 }
 
-Own<TypedAST> convertAST(AST::FunctionLiteral* ast) {
+Own<TypedAST> convert_ast(AST::FunctionLiteral* ast) {
 	auto typed_function = std::make_unique<FunctionLiteral>();
 
 	for (auto& arg : ast->m_args) {
@@ -65,134 +65,134 @@ Own<TypedAST> convertAST(AST::FunctionLiteral* ast) {
 		typed_function->m_args.push_back({decl->m_identifier_token});
 	}
 
-	typed_function->m_body = convertAST(ast->m_body.get());
+	typed_function->m_body = convert_ast(ast->m_body.get());
 
 	return typed_function;
 }
 
-Own<TypedAST> convertAST(AST::DeclarationList* ast) {
+Own<TypedAST> convert_ast(AST::DeclarationList* ast) {
 	auto typed_declist = std::make_unique<DeclarationList>();
 
 	for (auto& declaration : ast->m_declarations) {
-		typed_declist->m_declarations.push_back(convertAST(declaration.get()));
+		typed_declist->m_declarations.push_back(convert_ast(declaration.get()));
 	}
 
 	return typed_declist;
 }
 
-Own<TypedAST> convertAST(AST::Declaration* ast) {
+Own<TypedAST> convert_ast(AST::Declaration* ast) {
 	auto typed_dec = std::make_unique<Declaration>();
 
 	typed_dec->m_identifier_token = ast->m_identifier_token;
 	// TODO: handle type hint
 	if (ast->m_value)
-		typed_dec->m_value = convertAST(ast->m_value.get());
+		typed_dec->m_value = convert_ast(ast->m_value.get());
 
 	return typed_dec;
 }
 
-Own<TypedAST> convertAST(AST::Identifier* ast) {
+Own<TypedAST> convert_ast(AST::Identifier* ast) {
 	auto typed_id = std::make_unique<Identifier>();
 	typed_id->m_token = ast->m_token;
 	return typed_id;
 }
 
-Own<TypedAST> convertAST(AST::CallExpression* ast) {
+Own<TypedAST> convert_ast(AST::CallExpression* ast) {
 	auto typed_ce = std::make_unique<CallExpression>();
 
 	for (auto& arg : ast->m_args) {
-		typed_ce->m_args.push_back(convertAST(arg.get()));
+		typed_ce->m_args.push_back(convert_ast(arg.get()));
 	}
 
-	typed_ce->m_callee = convertAST(ast->m_callee.get());
+	typed_ce->m_callee = convert_ast(ast->m_callee.get());
 
 	return typed_ce;
 }
 
-Own<TypedAST> convertAST(AST::IndexExpression* ast) {
+Own<TypedAST> convert_ast(AST::IndexExpression* ast) {
 	auto typed_index = std::make_unique<IndexExpression>();
 
-	typed_index->m_callee = convertAST(ast->m_callee.get());
-	typed_index->m_index = convertAST(ast->m_index.get());
+	typed_index->m_callee = convert_ast(ast->m_callee.get());
+	typed_index->m_index = convert_ast(ast->m_index.get());
 
 	return typed_index;
 }
 
-Own<TypedAST> convertAST(AST::TernaryExpression* ast) {
+Own<TypedAST> convert_ast(AST::TernaryExpression* ast) {
 	auto typed_ternary = std::make_unique<TernaryExpression>();
 
-	typed_ternary->m_condition = convertAST(ast->m_condition.get());
-	typed_ternary->m_then_expr = convertAST(ast->m_then_expr.get());
-	typed_ternary->m_else_expr = convertAST(ast->m_else_expr.get());
+	typed_ternary->m_condition = convert_ast(ast->m_condition.get());
+	typed_ternary->m_then_expr = convert_ast(ast->m_then_expr.get());
+	typed_ternary->m_else_expr = convert_ast(ast->m_else_expr.get());
 
 	return typed_ternary;
 }
 
-Own<TypedAST> convertAST(AST::RecordAccessExpression* ast) {
+Own<TypedAST> convert_ast(AST::RecordAccessExpression* ast) {
 	auto typed_ast = std::make_unique<RecordAccessExpression>();
 
 	// TODO: this line is extremely disgusting
 	typed_ast->m_member = Own<Identifier>(
-	    static_cast<Identifier*>(convertAST(ast->m_member.get()).release()));
-	typed_ast->m_record = convertAST(ast->m_record.get());
+	    static_cast<Identifier*>(convert_ast(ast->m_member.get()).release()));
+	typed_ast->m_record = convert_ast(ast->m_record.get());
 
 	return typed_ast;
 }
 
-Own<TypedAST> convertAST(AST::Block* ast) {
+Own<TypedAST> convert_ast(AST::Block* ast) {
 	auto typed_block = std::make_unique<Block>();
 
 	for (auto& element : ast->m_body) {
-		typed_block->m_body.push_back(convertAST(element.get()));
+		typed_block->m_body.push_back(convert_ast(element.get()));
 	}
 
 	return typed_block;
 }
 
-Own<TypedAST> convertAST(AST::ReturnStatement* ast) {
+Own<TypedAST> convert_ast(AST::ReturnStatement* ast) {
 	auto typed_rs = std::make_unique<ReturnStatement>();
 
-	typed_rs->m_value = convertAST(ast->m_value.get());
+	typed_rs->m_value = convert_ast(ast->m_value.get());
 
 	return typed_rs;
 }
 
-Own<TypedAST> convertAST(AST::IfElseStatement* ast) {
+Own<TypedAST> convert_ast(AST::IfElseStatement* ast) {
 	auto typed_if_else = std::make_unique<IfElseStatement>();
 
-	typed_if_else->m_condition = convertAST(ast->m_condition.get());
-	typed_if_else->m_body = convertAST(ast->m_body.get());
+	typed_if_else->m_condition = convert_ast(ast->m_condition.get());
+	typed_if_else->m_body = convert_ast(ast->m_body.get());
 
 	if (ast->m_else_body)
-		typed_if_else->m_else_body = convertAST(ast->m_else_body.get());
+		typed_if_else->m_else_body = convert_ast(ast->m_else_body.get());
 
 	return typed_if_else;
 }
 
-Own<TypedAST> convertAST(AST::ForStatement* ast) {
+Own<TypedAST> convert_ast(AST::ForStatement* ast) {
 	auto typed_for = std::make_unique<ForStatement>();
 
-	typed_for->m_declaration = convertAST(ast->m_declaration.get());
-	typed_for->m_condition = convertAST(ast->m_condition.get());
-	typed_for->m_action = convertAST(ast->m_action.get());
-	typed_for->m_body = convertAST(ast->m_body.get());
+	typed_for->m_declaration = convert_ast(ast->m_declaration.get());
+	typed_for->m_condition = convert_ast(ast->m_condition.get());
+	typed_for->m_action = convert_ast(ast->m_action.get());
+	typed_for->m_body = convert_ast(ast->m_body.get());
 
 	return typed_for;
 }
 
-Own<TypedAST> convertAST(AST::WhileStatement* ast) {
+Own<TypedAST> convert_ast(AST::WhileStatement* ast) {
 	auto typed_while = std::make_unique<WhileStatement>();
 
-	typed_while->m_condition = convertAST(ast->m_condition.get());
-	typed_while->m_body = convertAST(ast->m_body.get());
+	typed_while->m_condition = convert_ast(ast->m_condition.get());
+	typed_while->m_body = convert_ast(ast->m_body.get());
 
 	return typed_while;
 }
 
-Own<TypedAST> convertAST(AST::AST* ast) {
+Own<TypedAST> convert_ast(AST::AST* ast) {
 #define DISPATCH(type)                                                         \
 	case ASTTag::type:                                                         \
-		return convertAST(static_cast<AST::type*>(ast))
+		return convert_ast(static_cast<AST::type*>(ast))
 
 #define REJECT(type)                                                           \
 	case ASTTag::type:                                                         \
@@ -224,7 +224,7 @@ Own<TypedAST> convertAST(AST::AST* ast) {
 		DISPATCH(DeclarationList);
 		DISPATCH(Declaration);
 	}
-	std::cerr << "Error: AST type not handled in convertAST: "
+	std::cerr << "Error: AST type not handled in convert_ast: "
 	          << ast_string[(int)ast->type()] << std::endl;
 	assert(0);
 

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -33,7 +33,7 @@ struct TypedAST {
 	virtual ~TypedAST() = default;
 };
 
-Own<TypedAST> convertAST(AST::AST*);
+Own<TypedAST> convert_ast(AST::AST*);
 
 // las estructuras como declaration list, index expression, block, if, for no tienen
 // tipo de valor asociado

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -33,8 +33,7 @@ struct TypedAST {
 	virtual ~TypedAST() = default;
 };
 
-TypedAST* convertAST(AST::AST*);
-Own<TypedAST> get_unique(Own<AST::AST>&);
+Own<TypedAST> convertAST(AST::AST*);
 
 // las estructuras como declaration list, index expression, block, if, for no tienen
 // tipo de valor asociado


### PR DESCRIPTION
Closes #137 

I made it so that convertAST returns a unique ptr directly, and renamed it to convert_ast, to better fit the naming convention.

Also, I got rid of conversion for object literals, as we don't really know how we want to implement that, yet.