### PR TITLE
Store typefuncs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,7 @@ OBJNAMES := \
 	error_report.o \
 	lexer.o \
 	match_identifiers.o \
+	metacheck.o \
 	metatypesystem.o \
 	parser.o \
 	parse.o \

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,7 @@ OBJNAMES := \
 	error_report.o \
 	lexer.o \
 	match_identifiers.o \
+	metatypesystem.o \
 	parser.o \
 	parse.o \
 	string_view.o \

--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -18,9 +18,10 @@ void CompileTimeEnvironment::declare(
 	current_scope().m_vars.insert({name, decl});
 }
 
-void CompileTimeEnvironment::declare_builtin(std::string const& name, PolyId poly) {
+void CompileTimeEnvironment::declare_builtin(std::string const& name, MetaTypeId meta_type, PolyId poly) {
 	m_builtin_declarations.push_back({});
 	TypedAST::Declaration* decl = &m_builtin_declarations.back();
+	decl->m_meta_type = meta_type;
 	decl->m_decl_type = poly;
 	decl->m_is_polymorphic = true;
 	declare(name, decl);

--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -18,15 +18,6 @@ void CompileTimeEnvironment::declare(
 	current_scope().m_vars.insert({name, decl});
 }
 
-void CompileTimeEnvironment::declare_builtin(std::string const& name, MetaTypeId meta_type, PolyId poly) {
-	m_builtin_declarations.push_back({});
-	TypedAST::Declaration* decl = &m_builtin_declarations.back();
-	decl->m_meta_type = meta_type;
-	decl->m_decl_type = poly;
-	decl->m_is_polymorphic = true;
-	declare(name, decl);
-}
-
 TypedAST::Declaration* CompileTimeEnvironment::access(std::string const& name) {
 	auto scan_scope = [](Scope& scope, std::string const& name) -> TypedAST::Declaration* {
 		auto it = scope.m_vars.find(name);

--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -5,7 +5,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "chunked_array.hpp"
 #include "typechecker_types.hpp"
 
 namespace TypedAST {
@@ -29,12 +28,9 @@ struct CompileTimeEnvironment {
 	std::vector<TypedAST::FunctionLiteral*> m_function_stack;
 	TypedAST::Declaration* m_current_decl {nullptr};
 
-	ChunkedArray<TypedAST::Declaration> m_builtin_declarations;
-
 	CompileTimeEnvironment();
 
 	void declare(std::string const&, TypedAST::Declaration*);
-	void declare_builtin(std::string const&, MetaTypeId, PolyId);
 
 	TypedAST::Declaration* access(std::string const&);
 

--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -34,7 +34,7 @@ struct CompileTimeEnvironment {
 	CompileTimeEnvironment();
 
 	void declare(std::string const&, TypedAST::Declaration*);
-	void declare_builtin(std::string const&, PolyId);
+	void declare_builtin(std::string const&, MetaTypeId, PolyId);
 
 	TypedAST::Declaration* access(std::string const&);
 

--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "chunked_array.hpp"
-#include "typesystem_types.hpp"
+#include "typechecker_types.hpp"
 
 namespace TypedAST {
 

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -2,6 +2,7 @@
 
 #include "../desugar.hpp"
 #include "../match_identifiers.hpp"
+#include "../metacheck.hpp"
 #include "../parse.hpp"
 #include "../token_array.hpp"
 #include "../typecheck.hpp"
@@ -46,6 +47,7 @@ ExitStatusTag execute(std::string const& source, bool dump_ast, Runner* runner) 
 		}
 	}
 
+	TypeChecker::metacheck(top_level.get(), tc);
 	TypeChecker::typecheck(top_level.get(), tc);
 
 	GC gc;

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -42,7 +42,6 @@ namespace TypeChecker {
 		    " : accessed undeclared identifier '" + ast->text() + "'"};
 	}
 
-	// TODO: refactor
 	ast->m_declaration = declaration;
 	env.current_top_level_declaration()->m_references.insert(declaration);
 	TypedAST::FunctionLiteral* surrounding_function =
@@ -194,14 +193,13 @@ namespace TypeChecker {
 [[nodiscard]] ErrorReport match_identifiers(
     TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment& env) {
 #define DISPATCH(type)                                                         \
-	case TypedASTTag::type:                                                       \
+	case TypedASTTag::type:                                                    \
 		return match_identifiers(static_cast<TypedAST::type*>(ast), env);
 
 #define DO_NOTHING(type)                                                       \
-	case TypedASTTag::type:                                                       \
+	case TypedASTTag::type:                                                    \
 		return {};
 
-	// TODO: Compound literals
 	switch (ast->type()) {
 		DO_NOTHING(NumberLiteral);
 		DO_NOTHING(IntegerLiteral);
@@ -233,5 +231,7 @@ namespace TypeChecker {
 	          << ": " << typed_ast_string[(int)ast->type()] << '\n';
 	assert(0);
 }
+
+#undef CHECK_AND_RETURN
 
 } // namespace TypeChecker

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -1,0 +1,206 @@
+#include "metacheck.hpp"
+
+#include "typechecker.hpp"
+#include "typed_ast.hpp"
+
+#include <iostream>
+#include <cassert>
+
+namespace TypeChecker {
+
+// literals
+
+void metacheck_literal(TypedAST::TypedAST* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
+}
+
+void metacheck(TypedAST::ArrayLiteral* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
+
+	for (auto& element : ast->m_elements) {
+		metacheck(element.get(), tc);
+		tc.m_meta_core.unify(element->m_meta_type, tc.meta_value());
+	}
+}
+
+// expressions
+
+void metacheck(TypedAST::Identifier* ast, TypeChecker& tc) {
+	assert(ast->m_declaration);
+	ast->m_meta_type = ast->m_declaration->m_meta_type;
+}
+
+void metacheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
+
+	int arg_count = ast->m_args.size();
+	for (int i = 0; i < arg_count; ++i) {
+		// TODO: metacheck type hints
+		auto& arg_decl = ast->m_args[i];
+		arg_decl.m_meta_type = tc.meta_value();
+	}
+
+	assert(ast->m_body->type() == TypedASTTag::Block);
+	auto body = static_cast<TypedAST::Block*>(ast->m_body.get());
+	for (auto& child : body->m_body)
+		metacheck(child.get(), tc);
+}
+
+void metacheck(TypedAST::CallExpression* ast, TypeChecker& tc) {
+	// TODO? maybe we would like to support compile time functions that return types eventually?
+	ast->m_meta_type = tc.meta_value();
+
+	metacheck(ast->m_callee.get(), tc);
+	tc.m_meta_core.unify(ast->m_callee->m_meta_type, tc.meta_value());
+
+	for (auto& arg : ast->m_args) {
+		metacheck(arg.get(), tc);
+		tc.m_meta_core.unify(arg->m_meta_type, tc.meta_value());
+	}
+}
+
+void metacheck(TypedAST::IndexExpression* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
+
+	metacheck(ast->m_callee.get(), tc);
+	tc.m_meta_core.unify(ast->m_callee->m_meta_type, tc.meta_value());
+
+	metacheck(ast->m_index.get(), tc);
+	tc.m_meta_core.unify(ast->m_index->m_meta_type, tc.meta_value());
+}
+
+void metacheck(TypedAST::TernaryExpression* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
+
+	metacheck(ast->m_condition.get(), tc);
+	tc.m_meta_core.unify(ast->m_condition->m_meta_type, tc.meta_value());
+
+	metacheck(ast->m_then_expr.get(), tc);
+	tc.m_meta_core.unify(ast->m_then_expr->m_meta_type, tc.meta_value());
+
+	metacheck(ast->m_else_expr.get(), tc);
+	tc.m_meta_core.unify(ast->m_else_expr->m_meta_type, tc.meta_value());
+}
+
+void metacheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
+	// TODO: we would like to support static records with
+	// typefunc members in the future
+	ast->m_meta_type = tc.meta_value();
+
+	metacheck(ast->m_record.get(), tc);
+	tc.m_meta_core.unify(ast->m_record->m_meta_type, tc.meta_value());
+}
+
+// statements
+
+void metacheck(TypedAST::Block* ast, TypeChecker& tc) {
+	for (auto& child : ast->m_body)
+		metacheck(child.get(), tc);
+}
+
+void metacheck(TypedAST::IfElseStatement* ast, TypeChecker& tc) {
+	metacheck(ast->m_condition.get(), tc);
+	tc.m_meta_core.unify(ast->m_condition->m_meta_type, tc.meta_value());
+
+	metacheck(ast->m_body.get(), tc);
+
+	if (ast->m_else_body)
+		metacheck(ast->m_else_body.get(), tc);
+}
+
+void metacheck(TypedAST::ForStatement* ast, TypeChecker& tc) {
+	metacheck(ast->m_declaration.get(), tc);
+	metacheck(ast->m_condition.get(), tc);
+	tc.m_meta_core.unify(
+	    ast->m_condition->m_meta_type, tc.meta_value());
+
+	metacheck(ast->m_action.get(), tc);
+	metacheck(ast->m_body.get(), tc);
+}
+
+void metacheck(TypedAST::WhileStatement* ast, TypeChecker& tc) {
+	metacheck(ast->m_condition.get(), tc);
+	tc.m_meta_core.unify(
+	    ast->m_condition->m_meta_type, tc.meta_value());
+
+	metacheck(ast->m_body.get(), tc);
+}
+
+void metacheck(TypedAST::ReturnStatement* ast, TypeChecker& tc) {
+	metacheck(ast->m_value.get(), tc);
+}
+
+// declarations
+
+void metacheck(TypedAST::Declaration* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.new_meta_var();
+	metacheck(ast->m_value.get(), tc);
+	tc.m_meta_core.unify(ast->m_meta_type, ast->m_value->m_meta_type);
+}
+
+void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
+	for (auto& decl : ast->m_declarations)
+		decl->m_meta_type = tc.new_meta_var();
+
+	for (auto& decl : ast->m_declarations) {
+		auto* d = static_cast<TypedAST::Declaration*>(decl.get());
+		metacheck(d->m_value.get(), tc);
+	}
+
+	for (auto& decl : ast->m_declarations){
+		auto* d = static_cast<TypedAST::Declaration*>(decl.get());
+		tc.m_meta_core.unify(d->m_meta_type, d->m_value->m_meta_type);
+	}
+
+	for (auto& decl : ast->m_declarations){
+		auto* d = static_cast<TypedAST::Declaration*>(decl.get());
+		if (tc.m_meta_core.find(d->m_meta_type) == tc.meta_typefunc())
+			for (auto* other : d->m_references)
+				if (tc.m_meta_core.find(other->m_meta_type) == tc.meta_value())
+					assert(0 && "value referenced in a type definition");
+	}
+}
+
+void metacheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
+#define DISPATCH(type)                                                         \
+	case TypedASTTag::type:                                                    \
+		return void(metacheck(static_cast<TypedAST::type*>(ast), tc))
+
+#define LITERAL(type)                                                          \
+	case TypedASTTag::type:                                                    \
+		return void(metacheck_literal(ast, tc))
+
+	switch (ast->type()) {
+		LITERAL(IntegerLiteral);
+		LITERAL(NumberLiteral);
+		LITERAL(BooleanLiteral);
+		LITERAL(StringLiteral);
+		LITERAL(NullLiteral);
+		DISPATCH(ArrayLiteral);
+
+		DISPATCH(Identifier);
+		DISPATCH(FunctionLiteral);
+		DISPATCH(CallExpression);
+		DISPATCH(IndexExpression);
+		DISPATCH(TernaryExpression);
+		DISPATCH(RecordAccessExpression);
+
+		DISPATCH(Block);
+		DISPATCH(IfElseStatement);
+		DISPATCH(ForStatement);
+		DISPATCH(WhileStatement);
+		DISPATCH(ReturnStatement);
+
+		DISPATCH(Declaration);
+		DISPATCH(DeclarationList);
+	}
+
+	std::cerr << "Unhandled case in " << __PRETTY_FUNCTION__ << " : "
+	          << typed_ast_string[int(ast->type())] << "\n";
+	assert(0);
+
+#undef DISPATCH
+#undef LITERAL
+}
+
+} // namespace TypeChecker

--- a/src/metacheck.hpp
+++ b/src/metacheck.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace TypedAST {
+struct TypedAST;
+}
+
+namespace TypeChecker {
+
+struct TypeChecker;
+
+void metacheck(TypedAST::TypedAST* ast, TypeChecker& tc);
+
+}

--- a/src/metatypesystem.cpp
+++ b/src/metatypesystem.cpp
@@ -68,7 +68,7 @@ MetaTypeId MetaTypeSystem::new_var(char const* debug_data) {
 MetaTypeId MetaTypeSystem::new_meta(char const* debug_data) {
 	int result = m_metatype_header.size();
 	m_metatype_header.push_back(
-	    {MetaTypeTag::Var, result, debug_data ? debug_data : "meta"});
+	    {MetaTypeTag::Meta, result, debug_data ? debug_data : "meta"});
 	return result;
 }
 

--- a/src/metatypesystem.cpp
+++ b/src/metatypesystem.cpp
@@ -1,0 +1,75 @@
+#include "metatypesystem.hpp"
+
+#include <cassert>
+#include <utility>
+
+#define DEBUG 1
+
+#if DEBUG
+#include <iostream>
+#endif
+
+namespace TypeChecker {
+
+MetaTypeId MetaTypeSystem::find(MetaTypeId i) {
+	if (m_metatype_header[i].tag != MetaTypeTag::Var)
+		return i;
+
+	if (m_metatype_header[i].equals == i)
+		return i;
+
+	return m_metatype_header[i].equals = find(m_metatype_header[i].equals);
+}
+
+void MetaTypeSystem::unify(MetaTypeId i, MetaTypeId j) {
+	i = find(i);
+	j = find(j);
+
+	if (i == j)
+		return;
+
+	if (m_metatype_header[j].tag == MetaTypeTag::Var)
+		std::swap(i, j);
+
+	if (m_metatype_header[i].tag == MetaTypeTag::Var) {
+		m_metatype_header[i].equals = j;
+	} else {
+
+#if DEBUG
+		{
+			char const* empty = "(no data)";
+
+			char const* data_i = m_metatype_header[i].debug_data
+			                         ? m_metatype_header[i].debug_data
+			                         : empty;
+
+			char const* data_j = m_metatype_header[j].debug_data
+			                         ? m_metatype_header[j].debug_data
+			                         : empty;
+
+			std::cerr << "Tried to unify different metatypes.\n"
+			          << "Debug data:\n"
+			          << "i: " << data_i << '\n'
+			          << "j: " << data_j << '\n';
+		}
+#endif
+
+		assert(0 && "unified two different metatypes");
+	}
+}
+
+MetaTypeId MetaTypeSystem::new_var(char const* debug_data) {
+	int result = m_metatype_header.size();
+	m_metatype_header.push_back(
+	    {MetaTypeTag::Var, result, debug_data ? debug_data : "var"});
+	return result;
+}
+
+MetaTypeId MetaTypeSystem::new_meta(char const* debug_data) {
+	int result = m_metatype_header.size();
+	m_metatype_header.push_back(
+	    {MetaTypeTag::Var, result, debug_data ? debug_data : "meta"});
+	return result;
+}
+
+} // namespace TypeChecker

--- a/src/metatypesystem.hpp
+++ b/src/metatypesystem.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <vector>
+
+#include "typechecker_types.hpp"
+
+namespace TypeChecker {
+
+// TODO: add monotypes and polytypes?
+enum class MetaTypeTag {
+	Var, // unification variable
+	Meta, // a meta type, like "type function", "mono type" or "value"
+};
+
+struct MetaTypeHeader {
+	MetaTypeTag tag;
+	int equals;
+	// NOTE(SMestre): i dislike the name 'equals' but let's
+	// keep it consistent with the rest of the type system
+	char const* debug_data;
+};
+
+struct MetaTypeSystem {
+	std::vector<MetaTypeHeader> m_metatype_header;
+
+	MetaTypeSystem() = default;
+
+	void unify(MetaTypeId, MetaTypeId);
+	MetaTypeId find(MetaTypeId);
+
+	MetaTypeId new_var(char const* debug_data = nullptr);
+	MetaTypeId new_meta(char const* debug_data = nullptr);
+};
+
+} // namespace TypeChecker

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -4,7 +4,7 @@
 #include "tarjan_solver.hpp"
 #include "typechecker.hpp"
 #include "typed_ast.hpp"
-#include "typesystem_types.hpp"
+#include "typechecker_types.hpp"
 
 #include <cassert>
 #include <iostream>

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -86,7 +86,6 @@ void typecheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 		std::cerr << "@@ Has " << poly_data.vars.size() << " variables\n";
 		std::cerr << "@@ It is equal to:\n";
 		tc.m_core.print_type(poly_data.base);
-
 	}
 #endif
 }
@@ -104,9 +103,11 @@ void typecheck(TypedAST::Identifier* ast, TypeChecker& tc) {
 		else
 			ast->m_value_type = declaration->m_value_type;
 	} else if(meta_type == tc.meta_typefunc()){
+		assert(0 && "Accessed a typefunc by name (not implemented)");
 		// we are a type function.
 		// TODO: not too sure what needs to be done...
 	} else {
+		assert(0 && "Accessed a name with unknown metatype (not implemented)");
 		// meta type var
 		// TODO: not too sure what needs to be done...
 	}
@@ -165,6 +166,7 @@ void typecheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
 			int mono = tc.new_var();
 
 			arg_types.push_back(mono);
+			arg_decl.m_meta_type = tc.meta_value();
 			arg_decl.m_value_type = mono;
 		}
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -17,32 +17,26 @@ namespace TypeChecker {
 // At least, the alternative just sucks.
 
 void typecheck(TypedAST::NumberLiteral* ast, TypeChecker& tc) {
-	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_float();
 }
 
 void typecheck(TypedAST::IntegerLiteral* ast, TypeChecker& tc) {
-	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_int();
 }
 
 void typecheck(TypedAST::StringLiteral* ast, TypeChecker& tc) {
-	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_string();
 }
 
 void typecheck(TypedAST::BooleanLiteral* ast, TypeChecker& tc) {
-	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_boolean();
 }
 
 void typecheck(TypedAST::NullLiteral* ast, TypeChecker& tc) {
-	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_unit();
 }
 
 void typecheck(TypedAST::ArrayLiteral* ast, TypeChecker& tc) {
-	ast->m_meta_type = tc.meta_value();
 	auto element_type = tc.new_var();
 	for (auto& element : ast->m_elements) {
 		typecheck(element.get(), tc);
@@ -60,8 +54,6 @@ void typecheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 	std::cerr << "Typechecking " << ast->identifier_text() << '\n';
 #endif
 
-	// FIXME: we should get our meta type from ast->m_value
-	ast->m_meta_type = tc.meta_value();
 
 	ast->m_value_type = tc.new_var();
 
@@ -95,6 +87,7 @@ void typecheck(TypedAST::Identifier* ast, TypeChecker& tc) {
 	assert(declaration && "accessed an unmatched identifier");
 
 	MetaTypeId meta_type = tc.m_meta_core.find(declaration->m_meta_type);
+
 	ast->m_meta_type = meta_type;
 	if (meta_type == tc.meta_value()) {
 		// here we implement the [var] rule
@@ -132,9 +125,6 @@ void typecheck(TypedAST::IfElseStatement* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::CallExpression* ast, TypeChecker& tc) {
-	// TODO: do we want to do something special with the meta type?
-	ast->m_meta_type = tc.meta_value();
-
 	typecheck(ast->m_callee.get(), tc);
 	for (auto& arg : ast->m_args)
 		typecheck(arg.get(), tc);
@@ -148,8 +138,6 @@ void typecheck(TypedAST::CallExpression* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
-	ast->m_meta_type = tc.meta_value();
-
 	tc.m_env.enter_function(ast);
 	tc.m_env.new_nested_scope(); // NOTE: this is nested because of lexical scoping
 
@@ -162,11 +150,8 @@ void typecheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
 
 		for (int i = 0; i < arg_count; ++i) {
 			auto& arg_decl = ast->m_args[i];
-
 			int mono = tc.new_var();
-
 			arg_types.push_back(mono);
-			arg_decl.m_meta_type = tc.meta_value();
 			arg_decl.m_value_type = mono;
 		}
 
@@ -219,16 +204,12 @@ void typecheck(TypedAST::ReturnStatement* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::IndexExpression* ast, TypeChecker& tc) {
-	ast->m_meta_type = tc.meta_value();
-
 	// TODO: put the monotype in the ast
 	typecheck(ast->m_callee.get(), tc);
 	typecheck(ast->m_index.get(), tc);
 }
 
 void typecheck(TypedAST::TernaryExpression* ast, TypeChecker& tc) {
-	ast->m_meta_type = tc.meta_value();
-
 	typecheck(ast->m_condition.get(), tc);
 	tc.m_core.unify(
 	    ast->m_condition->m_value_type, tc.mono_boolean());
@@ -243,10 +224,6 @@ void typecheck(TypedAST::TernaryExpression* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
-	// TODO: we want to support static record fields that
-	// contain monotypes and type functions, eventually.
-	ast->m_meta_type = tc.meta_value();
-
 	typecheck(ast->m_record.get(), tc);
 
 	// should this be a hidden type var?
@@ -317,7 +294,6 @@ void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 		for (int u : verts) {
 			auto decl = index_to_decl[u];
 			// FIXME: we should get our metatype from decl->m_value
-			decl->m_meta_type = tc.meta_value();
 			decl->m_value_type = tc.new_hidden_var();
 		}
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -91,12 +91,11 @@ void typecheck(TypedAST::Identifier* ast, TypeChecker& tc) {
 	ast->m_meta_type = meta_type;
 	if (meta_type == tc.meta_value()) {
 		// here we implement the [var] rule
-		if (declaration->m_is_polymorphic)
-			ast->m_value_type = tc.m_core.inst_fresh(declaration->m_decl_type);
-		else
-			ast->m_value_type = declaration->m_value_type;
-	} else if(meta_type == tc.meta_typefunc()){
-		assert(0 && "Accessed a typefunc by name (not implemented)");
+		ast->m_value_type = declaration->m_is_polymorphic
+		                        ? tc.m_core.inst_fresh(declaration->m_decl_type)
+		                        : declaration->m_value_type;
+	} else if (meta_type == tc.meta_typefunc()) {
+		assert(0 && "Accessed a name of a typefunc (not implemented)");
 		// we are a type function.
 		// TODO: not too sure what needs to be done...
 	} else {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -95,20 +95,21 @@ void typecheck(TypedAST::Identifier* ast, TypeChecker& tc) {
 	TypedAST::Declaration* declaration = ast->m_declaration;
 	assert(declaration && "accessed an unmatched identifier");
 
-	// FIXME: we should get our meta type from ast->m_declaration
-	ast->m_meta_type = tc.meta_value();
-
-	// here we implement the [var] rule
-	// TODO: refactor
-	MonoId mono = -1;
-	if (declaration->m_is_polymorphic) {
-		mono = tc.m_core.inst_fresh(declaration->m_decl_type);
+	MetaTypeId meta_type = tc.m_meta_core.find(declaration->m_meta_type);
+	ast->m_meta_type = meta_type;
+	if (meta_type == tc.meta_value()) {
+		// here we implement the [var] rule
+		if (declaration->m_is_polymorphic)
+			ast->m_value_type = tc.m_core.inst_fresh(declaration->m_decl_type);
+		else
+			ast->m_value_type = declaration->m_value_type;
+	} else if(meta_type == tc.meta_typefunc()){
+		// we are a type function.
+		// TODO: not too sure what needs to be done...
 	} else {
-		mono = declaration->m_value_type;
+		// meta type var
+		// TODO: not too sure what needs to be done...
 	}
-	assert(mono != -1);
-
-	ast->m_value_type = mono;
 }
 
 void typecheck(TypedAST::Block* ast, TypeChecker& tc) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -17,26 +17,32 @@ namespace TypeChecker {
 // At least, the alternative just sucks.
 
 void typecheck(TypedAST::NumberLiteral* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_float();
 }
 
 void typecheck(TypedAST::IntegerLiteral* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_int();
 }
 
 void typecheck(TypedAST::StringLiteral* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_string();
 }
 
 void typecheck(TypedAST::BooleanLiteral* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_boolean();
 }
 
 void typecheck(TypedAST::NullLiteral* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
 	ast->m_value_type = tc.mono_unit();
 }
 
 void typecheck(TypedAST::ArrayLiteral* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
 	auto element_type = tc.new_var();
 	for (auto& element : ast->m_elements) {
 		typecheck(element.get(), tc);
@@ -53,6 +59,9 @@ void typecheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 #if DEBUG
 	std::cerr << "Typechecking " << ast->identifier_text() << '\n';
 #endif
+
+	// FIXME: we should get our meta type from ast->m_value
+	ast->m_meta_type = tc.meta_value();
 
 	ast->m_value_type = tc.new_var();
 
@@ -86,6 +95,9 @@ void typecheck(TypedAST::Identifier* ast, TypeChecker& tc) {
 	TypedAST::Declaration* declaration = ast->m_declaration;
 	assert(declaration && "accessed an unmatched identifier");
 
+	// FIXME: we should get our meta type from ast->m_declaration
+	ast->m_meta_type = tc.meta_value();
+
 	// here we implement the [var] rule
 	// TODO: refactor
 	MonoId mono = -1;
@@ -118,6 +130,9 @@ void typecheck(TypedAST::IfElseStatement* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::CallExpression* ast, TypeChecker& tc) {
+	// TODO: do we want to do something special with the meta type?
+	ast->m_meta_type = tc.meta_value();
+
 	typecheck(ast->m_callee.get(), tc);
 	for (auto& arg : ast->m_args)
 		typecheck(arg.get(), tc);
@@ -131,6 +146,7 @@ void typecheck(TypedAST::CallExpression* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
 
 	tc.m_env.enter_function(ast);
 	tc.m_env.new_nested_scope(); // NOTE: this is nested because of lexical scoping
@@ -200,11 +216,16 @@ void typecheck(TypedAST::ReturnStatement* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::IndexExpression* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
+
+	// TODO: put the monotype in the ast
 	typecheck(ast->m_callee.get(), tc);
 	typecheck(ast->m_index.get(), tc);
 }
 
 void typecheck(TypedAST::TernaryExpression* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
+
 	typecheck(ast->m_condition.get(), tc);
 	tc.m_core.unify(
 	    ast->m_condition->m_value_type, tc.mono_boolean());
@@ -219,6 +240,10 @@ void typecheck(TypedAST::TernaryExpression* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
+	// TODO: we want to support static record fields that
+	// contain monotypes and type functions, eventually.
+	ast->m_meta_type = tc.meta_value();
+
 	typecheck(ast->m_record.get(), tc);
 
 	// should this be a hidden type var?
@@ -288,6 +313,8 @@ void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 		// set up some dummy types on every decl
 		for (int u : verts) {
 			auto decl = index_to_decl[u];
+			// FIXME: we should get our metatype from decl->m_value
+			decl->m_meta_type = tc.meta_value();
 			decl->m_value_type = tc.new_hidden_var();
 		}
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -55,7 +55,6 @@ void typecheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 #endif
 
 	ast->m_value_type = tc.new_var();
-	tc.m_env.declare(ast->identifier_text(), ast);
 
 	// this is where we implement rec-polymorphism.
 	// TODO: refactor (duplication).
@@ -150,8 +149,6 @@ void typecheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
 
 			arg_types.push_back(mono);
 			arg_decl.m_value_type = mono;
-
-			tc.m_env.declare(arg_decl.identifier_text(), &arg_decl);
 		}
 
 		// return type

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -1,5 +1,6 @@
 #include "typechecker.hpp"
 
+#include "typechecker_types.hpp"
 #include "typed_ast.hpp"
 
 #include <cassert>
@@ -34,7 +35,7 @@ TypeChecker::TypeChecker() {
 
 		{
 			auto poly = m_core.new_poly(var_id, {var_id});
-			m_env.declare_builtin("print", meta_value(), poly);
+			declare_builtin("print", meta_value(), poly);
 		}
 
 		{
@@ -48,7 +49,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<a>), a) -> unit");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {var_id});
-				m_env.declare_builtin("array_append", meta_value(), poly_id);
+				declare_builtin("array_append", meta_value(), poly_id);
 			}
 			{
 				auto term_mono_id = m_core.new_term(
@@ -57,7 +58,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<a>)) -> int");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {var_id});
-				m_env.declare_builtin("size", meta_value(), poly_id);
+				declare_builtin("size", meta_value(), poly_id);
 			}
 			{
 				auto term_mono_id = m_core.new_term(
@@ -66,7 +67,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<a>), array(<a>)) -> array(<a>)");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {var_id});
-				m_env.declare_builtin("array_extend", meta_value(), poly_id);
+				declare_builtin("array_extend", meta_value(), poly_id);
 			}
 			{
 				auto array_mono_id = m_core.new_term(
@@ -78,7 +79,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<int>), string)) -> string");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {});
-				m_env.declare_builtin("array_join", meta_value(), poly_id);
+				declare_builtin("array_join", meta_value(), poly_id);
 			}
 			{
 				auto term_mono_id = m_core.new_term(
@@ -87,7 +88,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<a>), int) -> a");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {var_id});
-				m_env.declare_builtin("array_at", meta_value(), poly_id);
+				declare_builtin("array_at", meta_value(), poly_id);
 			}
 		}
 
@@ -99,12 +100,12 @@ TypeChecker::TypeChecker() {
 
 			auto poly_id = m_core.new_poly(term_mono_id, {var_id});
 
-			m_env.declare_builtin("+", meta_value(), poly_id);
-			m_env.declare_builtin("-", meta_value(), poly_id);
-			m_env.declare_builtin("*", meta_value(), poly_id);
-			m_env.declare_builtin("/", meta_value(), poly_id);
-			m_env.declare_builtin(".", meta_value(), poly_id);
-			m_env.declare_builtin("=", meta_value(), poly_id);
+			declare_builtin("+", meta_value(), poly_id);
+			declare_builtin("-", meta_value(), poly_id);
+			declare_builtin("*", meta_value(), poly_id);
+			declare_builtin("/", meta_value(), poly_id);
+			declare_builtin(".", meta_value(), poly_id);
+			declare_builtin("=", meta_value(), poly_id);
 		}
 
 		{
@@ -115,8 +116,8 @@ TypeChecker::TypeChecker() {
 
 			auto poly_id = m_core.new_poly(term_mono_id, {var_id});
 
-			m_env.declare_builtin( "<", meta_value(), poly_id);
-			m_env.declare_builtin("==", meta_value(), poly_id);
+			declare_builtin( "<", meta_value(), poly_id);
+			declare_builtin("==", meta_value(), poly_id);
 		}
 	}
 }
@@ -162,6 +163,15 @@ MonoId TypeChecker::rule_app(std::vector<MonoId> args_types, MonoId func_type) {
 	m_core.unify(func_type, deduced_func_type);
 
 	return return_type;
+}
+
+void TypeChecker::declare_builtin(std::string const& name, MetaTypeId meta_type, PolyId poly_type){
+	m_builtin_declarations.push_back({});
+	TypedAST::Declaration* decl = &m_builtin_declarations.back();
+	decl->m_meta_type = meta_type;
+	decl->m_decl_type = poly_type;
+	decl->m_is_polymorphic = true;
+	m_env.declare(name, decl);
 }
 
 MonoId TypeChecker::mono_int() {

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -134,6 +134,10 @@ MonoId TypeChecker::new_var() {
 	return result;
 }
 
+MetaTypeId TypeChecker::new_meta_var() {
+	return m_meta_core.new_var();
+}
+
 // qualifies all free variables in the given monotype
 PolyId TypeChecker::generalize(MonoId mono) {
 	std::unordered_set<MonoId> free_vars;

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -7,6 +7,9 @@
 namespace TypeChecker {
 
 TypeChecker::TypeChecker() {
+	m_meta_core.new_meta(); // 0 | value
+	m_meta_core.new_meta(); // 1 | type func
+
 	m_core.new_builtin_type_function(-1); // 0  | function
 	m_core.new_builtin_type_function(0);  // 1  | int
 	m_core.new_builtin_type_function(0);  // 2  | float
@@ -179,6 +182,14 @@ MonoId TypeChecker::mono_boolean() {
 
 MonoId TypeChecker::mono_unit() {
 	return 4;
+}
+
+MetaTypeId TypeChecker::meta_value() {
+	return 0;
+}
+
+MetaTypeId TypeChecker::meta_typefunc() {
+	return 1;
 }
 
 } // namespace TypeChecker

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -120,6 +120,8 @@ TypeChecker::TypeChecker() {
 			declare_builtin("==", meta_value(), poly_id);
 		}
 	}
+
+	declare_builtin("int", meta_typefunc(), BuiltinType::Int);
 }
 
 MonoId TypeChecker::new_hidden_var() {

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -34,7 +34,7 @@ TypeChecker::TypeChecker() {
 
 		{
 			auto poly = m_core.new_poly(var_id, {var_id});
-			m_env.declare_builtin("print", poly);
+			m_env.declare_builtin("print", meta_value(), poly);
 		}
 
 		{
@@ -48,7 +48,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<a>), a) -> unit");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {var_id});
-				m_env.declare_builtin("array_append", poly_id);
+				m_env.declare_builtin("array_append", meta_value(), poly_id);
 			}
 			{
 				auto term_mono_id = m_core.new_term(
@@ -57,7 +57,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<a>)) -> int");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {var_id});
-				m_env.declare_builtin("size", poly_id);
+				m_env.declare_builtin("size", meta_value(), poly_id);
 			}
 			{
 				auto term_mono_id = m_core.new_term(
@@ -66,7 +66,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<a>), array(<a>)) -> array(<a>)");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {var_id});
-				m_env.declare_builtin("array_extend", poly_id);
+				m_env.declare_builtin("array_extend", meta_value(), poly_id);
 			}
 			{
 				auto array_mono_id = m_core.new_term(
@@ -78,7 +78,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<int>), string)) -> string");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {});
-				m_env.declare_builtin("array_join", poly_id);
+				m_env.declare_builtin("array_join", meta_value(), poly_id);
 			}
 			{
 				auto term_mono_id = m_core.new_term(
@@ -87,7 +87,7 @@ TypeChecker::TypeChecker() {
 				    "[builtin] (array(<a>), int) -> a");
 
 				auto poly_id = m_core.new_poly(term_mono_id, {var_id});
-				m_env.declare_builtin("array_at", poly_id);
+				m_env.declare_builtin("array_at", meta_value(), poly_id);
 			}
 		}
 
@@ -99,12 +99,12 @@ TypeChecker::TypeChecker() {
 
 			auto poly_id = m_core.new_poly(term_mono_id, {var_id});
 
-			m_env.declare_builtin("+", poly_id);
-			m_env.declare_builtin("-", poly_id);
-			m_env.declare_builtin("*", poly_id);
-			m_env.declare_builtin("/", poly_id);
-			m_env.declare_builtin(".", poly_id);
-			m_env.declare_builtin("=", poly_id);
+			m_env.declare_builtin("+", meta_value(), poly_id);
+			m_env.declare_builtin("-", meta_value(), poly_id);
+			m_env.declare_builtin("*", meta_value(), poly_id);
+			m_env.declare_builtin("/", meta_value(), poly_id);
+			m_env.declare_builtin(".", meta_value(), poly_id);
+			m_env.declare_builtin("=", meta_value(), poly_id);
 		}
 
 		{
@@ -115,8 +115,8 @@ TypeChecker::TypeChecker() {
 
 			auto poly_id = m_core.new_poly(term_mono_id, {var_id});
 
-			m_env.declare_builtin("<", poly_id);
-			m_env.declare_builtin("==", poly_id);
+			m_env.declare_builtin( "<", meta_value(), poly_id);
+			m_env.declare_builtin("==", meta_value(), poly_id);
 		}
 	}
 }

--- a/src/typechecker.hpp
+++ b/src/typechecker.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "chunked_array.hpp"
 #include "compile_time_environment.hpp"
-#include "typesystem.hpp"
 #include "metatypesystem.hpp"
+#include "typesystem.hpp"
 
 namespace TypeChecker {
 
@@ -11,14 +12,15 @@ struct TypeChecker {
 	TypeSystemCore m_core;
 	MetaTypeSystem m_meta_core;
 	Frontend::CompileTimeEnvironment m_env;
+	ChunkedArray<TypedAST::Declaration> m_builtin_declarations;
 
 	TypeChecker();
 
-	PolyId generalize(MonoId mono);
+	void declare_builtin(std::string const& name, MetaTypeId, PolyId);
 
 	MonoId new_hidden_var();
 	MonoId new_var();
-
+	PolyId generalize(MonoId mono);
 	MonoId rule_app(std::vector<MonoId> args_types, MonoId func_type);
 
 	MonoId mono_int();

--- a/src/typechecker.hpp
+++ b/src/typechecker.hpp
@@ -2,12 +2,14 @@
 
 #include "compile_time_environment.hpp"
 #include "typesystem.hpp"
+#include "metatypesystem.hpp"
 
 namespace TypeChecker {
 
 struct TypeChecker {
 
 	TypeSystemCore m_core;
+	MetaTypeSystem m_meta_core;
 	Frontend::CompileTimeEnvironment m_env;
 
 	TypeChecker();
@@ -25,6 +27,8 @@ struct TypeChecker {
 	MonoId mono_boolean();
 	MonoId mono_unit();
 
+	MetaTypeId meta_value();
+	MetaTypeId meta_typefunc();
 };
 
 } // namespace TypeChecker

--- a/src/typechecker.hpp
+++ b/src/typechecker.hpp
@@ -23,6 +23,8 @@ struct TypeChecker {
 	PolyId generalize(MonoId mono);
 	MonoId rule_app(std::vector<MonoId> args_types, MonoId func_type);
 
+	MetaTypeId new_meta_var();
+
 	MonoId mono_int();
 	MonoId mono_float();
 	MonoId mono_string();

--- a/src/typechecker_types.hpp
+++ b/src/typechecker_types.hpp
@@ -7,6 +7,8 @@ using MonoId = int;
 using PolyId = int;
 using TypeVarId = int;
 
+using MetaTypeId = int;
+
 namespace TypeChecker {
 
 struct BuiltinType {

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -25,8 +25,9 @@ struct TypedAST {
 	TypedAST(TypedASTTag type)
 	    : m_type {type} {}
 
-	// is not set on polymorphic declarations
-	MonoId m_value_type{-1};
+	MetaTypeId m_meta_type {-1};
+	// is not set on polymorphic declarations and typefuncs (TODO: refactor)
+	MonoId m_value_type {-1};
 	TypedASTTag type() const {
 		return m_type;
 	}
@@ -48,7 +49,9 @@ struct DeclarationList : public TypedAST {
 struct Declaration : public TypedAST {
 	Token const* m_identifier_token;
 	Own<TypedAST> m_value; // can be nullptr
+
 	std::unordered_set<Declaration*> m_references;
+
 	bool m_is_polymorphic {false};
 	PolyId m_decl_type;
 

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -9,7 +9,7 @@
 #include "token_tag.hpp"
 #include "typed_ast_tag.hpp"
 #include "typedefs.hpp"
-#include "typesystem_types.hpp"
+#include "typechecker_types.hpp"
 
 namespace AST {
 struct AST;

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include <string>
 
-#include "typesystem_types.hpp"
+#include "typechecker_types.hpp"
 
 namespace Frontend {
 struct CompileTimeEnvironment;


### PR DESCRIPTION
Some preliminary work before we start evaluating typefuncs

EDIT:

Plans: implement the notion of metatypes.

this lets us do some rudimentary 'typechecking' that informs how to handle a compile time value during actual typechecking.

Why? typecheck needs to do different things depending on whether an expression is a monomorphic value, a polymorphic value or a typefunc.