### PR TITLE
add a TypedAST node that holds a type func ID

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,7 @@ OBJDIR := ../build
 OBJNAMES := \
 	ast.o \
 	compile_time_environment.o \
+	ct_eval.o \
 	desugar.o \
 	error_report.o \
 	lexer.o \

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -1,0 +1,157 @@
+#include "ct_eval.hpp"
+
+#include "typed_ast.hpp"
+
+#include <iostream>
+
+#include <cassert>
+
+namespace TypeChecker {
+
+// literals
+
+Own<TypedAST::ArrayLiteral> ct_eval(Own<TypedAST::ArrayLiteral> ast, TypeChecker& tc) {
+	for (auto&& element : ast->m_elements)
+		element = ct_eval(std::move(element), tc);
+	return ast;
+}
+
+// expressions
+
+Own<TypedAST::FunctionLiteral> ct_eval(
+    Own<TypedAST::FunctionLiteral> ast, TypeChecker& tc) {
+
+	// TODO: type hints
+
+	assert(ast->m_body->type() == TypedASTTag::Block);
+	auto body = static_cast<TypedAST::Block*>(ast->m_body.get());
+	for (auto&& child : body->m_body)
+		child = ct_eval(std::move(child), tc);
+
+	return ast;
+}
+
+Own<TypedAST::CallExpression> ct_eval(
+    Own<TypedAST::CallExpression> ast, TypeChecker& tc) {
+
+	ast->m_callee = ct_eval(std::move(ast->m_callee), tc);
+
+	for (auto&& arg : ast->m_args)
+		arg = ct_eval(std::move(arg), tc);
+
+	return ast;
+}
+
+Own<TypedAST::IndexExpression> ct_eval(Own<TypedAST::IndexExpression> ast, TypeChecker& tc) {
+	ast->m_callee = ct_eval(std::move(ast->m_callee), tc);
+	ast->m_index = ct_eval(std::move(ast->m_index), tc);
+
+	return ast;
+}
+
+Own<TypedAST::TernaryExpression> ct_eval(Own<TypedAST::TernaryExpression> ast, TypeChecker& tc) {
+	ast->m_condition = ct_eval(std::move(ast->m_condition), tc);
+	ast->m_then_expr = ct_eval(std::move(ast->m_then_expr), tc);
+	ast->m_else_expr = ct_eval(std::move(ast->m_else_expr), tc);
+	return ast;
+}
+
+Own<TypedAST::RecordAccessExpression> ct_eval(Own<TypedAST::RecordAccessExpression> ast, TypeChecker& tc) {
+	ast->m_record = ct_eval(std::move(ast->m_record), tc);
+	return ast;
+}
+
+// statements
+
+Own<TypedAST::Block> ct_eval(Own<TypedAST::Block> ast, TypeChecker& tc) {
+	for (auto&& child : ast->m_body)
+		child = ct_eval(std::move(child), tc);
+	return ast;
+}
+
+Own<TypedAST::IfElseStatement> ct_eval(Own<TypedAST::IfElseStatement> ast, TypeChecker& tc) {
+	ast->m_condition = ct_eval(std::move(ast->m_condition), tc);
+	ast->m_body = ct_eval(std::move(ast->m_body), tc);
+	if (ast->m_else_body)
+		ast->m_else_body = ct_eval(std::move(ast->m_else_body), tc);
+	return ast;
+}
+
+Own<TypedAST::ForStatement> ct_eval(Own<TypedAST::ForStatement> ast, TypeChecker& tc) {
+	ast->m_declaration = ct_eval(std::move(ast->m_declaration), tc);
+	ast->m_condition = ct_eval(std::move(ast->m_condition), tc);
+	ast->m_action = ct_eval(std::move(ast->m_action), tc);
+	ast->m_body = ct_eval(std::move(ast->m_body), tc);
+	return ast;
+}
+
+Own<TypedAST::WhileStatement> ct_eval(Own<TypedAST::WhileStatement> ast, TypeChecker& tc) {
+	ast->m_condition = ct_eval(std::move(ast->m_condition), tc);
+	ast->m_body = ct_eval(std::move(ast->m_body), tc);
+	return ast;
+}
+
+Own<TypedAST::ReturnStatement> ct_eval(Own<TypedAST::ReturnStatement> ast, TypeChecker& tc) {
+	ast->m_value = ct_eval(std::move(ast->m_value), tc);
+	return ast;
+}
+
+// declarations
+
+Own<TypedAST::Declaration> ct_eval(Own<TypedAST::Declaration> ast, TypeChecker& tc) {
+	ast->m_value = ct_eval(std::move(ast->m_value), tc);
+	return ast;
+}
+
+Own<TypedAST::DeclarationList> ct_eval(Own<TypedAST::DeclarationList> ast, TypeChecker& tc) {
+	for (auto& decl : ast->m_declarations) {
+		auto* d = static_cast<TypedAST::Declaration*>(decl.get());
+		d->m_value = ct_eval(std::move(d->m_value), tc);
+	}
+	return ast;
+}
+
+Own<TypedAST::TypedAST> ct_eval(Own<TypedAST::TypedAST> ast, TypeChecker& tc) {
+#define DISPATCH(type)                                                         \
+	case TypedASTTag::type:                                                    \
+		return ct_eval(                                                        \
+		    Own<TypedAST::type> {static_cast<TypedAST::type*>(ast.release())}, tc)
+
+#define RETURN(type)                                                           \
+	case TypedASTTag::type:                                                    \
+		return ast;
+
+	switch (ast->type()) {
+		RETURN(IntegerLiteral);
+		RETURN(NumberLiteral);
+		RETURN(BooleanLiteral);
+		RETURN(StringLiteral);
+		RETURN(NullLiteral);
+		DISPATCH(ArrayLiteral);
+
+		RETURN(Identifier);
+		DISPATCH(FunctionLiteral);
+		DISPATCH(CallExpression);
+		DISPATCH(IndexExpression);
+		DISPATCH(TernaryExpression);
+		DISPATCH(RecordAccessExpression);
+
+		DISPATCH(Block);
+		DISPATCH(IfElseStatement);
+		DISPATCH(ForStatement);
+		DISPATCH(WhileStatement);
+		DISPATCH(ReturnStatement);
+
+		DISPATCH(Declaration);
+		DISPATCH(DeclarationList);
+	}
+
+	std::cerr << "Unhandled case in " << __PRETTY_FUNCTION__ << " : "
+	          << typed_ast_string[int(ast->type())] << "\n";
+	assert(0);
+
+#undef DISPATCH
+#undef RETURN
+}
+
+} // namespace TypeChecker

--- a/src/ct_eval.hpp
+++ b/src/ct_eval.hpp
@@ -1,0 +1,13 @@
+#include "typedefs.hpp"
+
+namespace TypedAST {
+struct TypedAST;
+}
+
+namespace TypeChecker {
+
+struct TypeChecker;
+
+Own<TypedAST::TypedAST> ct_eval(Own<TypedAST::TypedAST>, TypeChecker& tc);
+
+} // namespace TypeChecker

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -1,5 +1,6 @@
 #include "execute.hpp"
 
+#include "../ct_eval.hpp"
 #include "../desugar.hpp"
 #include "../match_identifiers.hpp"
 #include "../metacheck.hpp"
@@ -48,6 +49,7 @@ ExitStatusTag execute(std::string const& source, bool dump_ast, Runner* runner) 
 	}
 
 	TypeChecker::metacheck(top_level.get(), tc);
+	top_level = TypeChecker::ct_eval(std::move(top_level), tc);
 	TypeChecker::typecheck(top_level.get(), tc);
 
 	GC gc;

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -189,6 +189,23 @@ namespace TypeChecker {
 }
 
 [[nodiscard]] ErrorReport match_identifiers(
+    TypedAST::StructExpression* ast, Frontend::CompileTimeEnvironment& env) {
+
+	for (auto& type : ast->m_types)
+		CHECK_AND_RETURN(match_identifiers(type.get(), env));
+
+	return {};
+}
+
+[[nodiscard]] ErrorReport match_identifiers(
+    TypedAST::TypeTerm* ast, Frontend::CompileTimeEnvironment& env) {
+	CHECK_AND_RETURN(match_identifiers(ast->m_callee.get(), env));
+	for (auto& arg : ast->m_args)
+		CHECK_AND_RETURN(match_identifiers(arg.get(), env));
+	return {};
+}
+
+[[nodiscard]] ErrorReport match_identifiers(
     TypedAST::TypedAST* ast, Frontend::CompileTimeEnvironment& env) {
 #define DISPATCH(type)                                                         \
 	case TypedASTTag::type:                                                    \
@@ -221,6 +238,9 @@ namespace TypeChecker {
 
 		DISPATCH(Declaration);
 		DISPATCH(DeclarationList);
+
+		DISPATCH(StructExpression);
+		DISPATCH(TypeTerm);
 	}
 
 #undef DO_NOTHING

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -508,6 +508,14 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_terminal() {
 		return array;
 	}
 
+	if (token->m_type == TokenTag::KEYWORD_STRUCT) {
+		// TODO: do the other type functions
+		auto type = parse_type_function();
+		if (handle_error(result, type))
+			return result;
+		return type;
+	}
+
 	result.m_error.m_sub_errors.push_back({make_expected_error(
 	    token_string[int(TokenTag::KEYWORD_FN)], token)});
 
@@ -1042,7 +1050,7 @@ Writer<std::pair<std::vector<AST::Identifier>, std::vector<std::unique_ptr<AST::
 			if (handle_error(result, cons))
 				return result;
 
-			if (handle_error(result, require(TokenTag::COLON)))
+			if (handle_error(result, require(TokenTag::DECLARE)))
 				return result;
 
 			identifiers.push_back(std::move(*cons.m_result));

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -278,6 +278,16 @@ void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 	auto const& comps = solver.vertices_of_components();
 	for (auto const& verts : comps) {
 
+		bool type_func_component = false;
+		for (int u : verts) {
+			auto decl = index_to_decl[u];
+			if (tc.m_meta_core.find(decl->m_meta_type) == tc.meta_typefunc())
+				type_func_component = true;
+		}
+
+		if (type_func_component)
+			continue;
+
 #if DEBUG
 		std::cerr << "@@@@ TYPECHECKING COMPONENT @@@@\n";
 		std::cerr << "@@@@ MEMBER LIST START @@@@\n";
@@ -337,6 +347,10 @@ void typecheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 	case TypedASTTag::type:                                                    \
 		return typecheck(static_cast<TypedAST::type*>(ast), tc);
 
+#define IGNORE(type)                                                           \
+	case TypedASTTag::type:                                                    \
+		return;
+
 	// TODO: Compound literals
 	switch (ast->type()) {
 		DISPATCH(NumberLiteral);
@@ -361,6 +375,8 @@ void typecheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		DISPATCH(WhileStatement);
 		DISPATCH(IfElseStatement);
 		DISPATCH(ReturnStatement);
+
+		IGNORE(TypeFunctionHandle)
 	}
 
 	std::cerr << "Error: AST type not handled in typecheck: "
@@ -368,6 +384,7 @@ void typecheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 	assert(0);
 
 #undef DISPATCH
+#undef IGNORE
 }
 
 } // namespace TypeChecker

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -176,8 +176,16 @@ void TypeChecker::declare_builtin(std::string const& name, MetaTypeId meta_type,
 	m_builtin_declarations.push_back({});
 	TypedAST::Declaration* decl = &m_builtin_declarations.back();
 	decl->m_meta_type = meta_type;
-	decl->m_decl_type = poly_type;
-	decl->m_is_polymorphic = true;
+	// BIG HACK:
+	// if we are declaring a typefunc, 'poly_type' is actually a TypeFunctionId
+	if (meta_type == meta_typefunc()) {
+		auto handle = std::make_unique<TypedAST::TypeFunctionHandle>();
+		handle->m_value = poly_type;
+		decl->m_value = std::move(handle);
+	} else {
+		decl->m_decl_type = poly_type;
+		decl->m_is_polymorphic = true;
+	}
 	m_env.declare(name, decl);
 }
 

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -10,6 +10,7 @@ namespace TypeChecker {
 TypeChecker::TypeChecker() {
 	m_meta_core.new_meta(); // 0 | value
 	m_meta_core.new_meta(); // 1 | type func
+	m_meta_core.new_meta(); // 2 | mono type
 
 	m_core.new_builtin_type_function(-1); // 0  | function
 	m_core.new_builtin_type_function(0);  // 1  | int
@@ -206,6 +207,10 @@ MetaTypeId TypeChecker::meta_value() {
 
 MetaTypeId TypeChecker::meta_typefunc() {
 	return 1;
+}
+
+MetaTypeId TypeChecker::meta_monotype() {
+	return 2;
 }
 
 } // namespace TypeChecker

--- a/src/typechecker.hpp
+++ b/src/typechecker.hpp
@@ -33,6 +33,7 @@ struct TypeChecker {
 
 	MetaTypeId meta_value();
 	MetaTypeId meta_typefunc();
+	MetaTypeId meta_monotype();
 };
 
 } // namespace TypeChecker

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -190,6 +190,32 @@ Own<TypedAST> convert_ast(AST::WhileStatement* ast) {
 	return typed_while;
 }
 
+Own<TypedAST> convert_ast(AST::StructExpression* ast) {
+	auto typed_ast = std::make_unique<StructExpression>();
+
+	for (auto& field : ast->m_fields){
+		auto ptr = convert_ast(&field);
+		typed_ast->m_fields.push_back(std::move(*static_cast<Identifier*>(ptr.get())));
+	}
+
+	for (auto& type : ast->m_types){
+		typed_ast->m_types.push_back(convert_ast(type.get()));
+	}
+
+	return typed_ast;
+};
+
+Own<TypedAST> convert_ast(AST::TypeTerm* ast) {
+	auto typed_ast = std::make_unique<TypeTerm>();
+
+	typed_ast->m_callee = convert_ast(ast->m_callee.get());
+	for (auto& arg : ast->m_args){
+		typed_ast->m_args.push_back(convert_ast(arg.get()));
+	}
+
+	return typed_ast;
+}
+
 Own<TypedAST> convert_ast(AST::AST* ast) {
 #define DISPATCH(type)                                                         \
 	case ASTTag::type:                                                         \
@@ -224,6 +250,9 @@ Own<TypedAST> convert_ast(AST::AST* ast) {
 
 		DISPATCH(DeclarationList);
 		DISPATCH(Declaration);
+
+		DISPATCH(StructExpression);
+		DISPATCH(TypeTerm);
 	}
 	std::cerr << "Error: AST type not handled in convert_ast: "
 	          << ast_string[(int)ast->type()] << std::endl;

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -247,6 +247,14 @@ struct StructExpression : public TypedAST {
 	    : TypedAST {TypedASTTag::StructExpression} {}
 };
 
+struct TypeTerm : public TypedAST {
+	Own<TypedAST> m_callee;
+	std::vector<Own<TypedAST>> m_args; // should these be TypeTerms?
+
+	TypeTerm()
+	    : TypedAST {TypedASTTag::TypeTerm} {}
+};
+
 struct TypeFunctionHandle : public TypedAST {
 	TypeFunctionId m_value;
 	// points to the ast node this one was made from

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -239,4 +239,11 @@ struct WhileStatement : public TypedAST {
 	    : TypedAST {TypedASTTag::WhileStatement} {}
 };
 
+
+struct TypeFunctionHandle : public TypedAST {
+	TypeFunctionId m_value;
+	// points to the ast node this one was made from
+	Own<TypedAST> m_syntax;
+};
+
 } // namespace TypedAST

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -239,11 +239,21 @@ struct WhileStatement : public TypedAST {
 	    : TypedAST {TypedASTTag::WhileStatement} {}
 };
 
+struct StructExpression : public TypedAST {
+	std::vector<Identifier> m_fields;
+	std::vector<Own<TypedAST>> m_types;
+
+	StructExpression()
+	    : TypedAST {TypedASTTag::StructExpression} {}
+};
 
 struct TypeFunctionHandle : public TypedAST {
 	TypeFunctionId m_value;
 	// points to the ast node this one was made from
 	Own<TypedAST> m_syntax;
+
+	TypeFunctionHandle()
+	    : TypedAST {TypedASTTag::TypeFunctionHandle} {}
 };
 
 } // namespace TypedAST

--- a/src/typed_ast_tag.hpp
+++ b/src/typed_ast_tag.hpp
@@ -27,6 +27,7 @@
 	X(Declaration)                                                             \
                                                                                \
 	X(StructExpression)                                                        \
+	X(TypeTerm)                                                                \
 	X(TypeFunctionHandle)
 
 #define X(name) #name,

--- a/src/typed_ast_tag.hpp
+++ b/src/typed_ast_tag.hpp
@@ -24,7 +24,10 @@
 	X(WhileStatement)                                                          \
                                                                                \
 	X(DeclarationList)                                                         \
-	X(Declaration)
+	X(Declaration)                                                             \
+                                                                               \
+	X(StructExpression)                                                        \
+	X(TypeFunctionHandle)
 
 #define X(name) #name,
 constexpr const char* typed_ast_string[] = {TYPED_AST_TAGS};

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -208,8 +208,6 @@ void TypeSystemCore::func_unify(TypeFunctionId a, TypeFunctionId b) {
 	if (a == b)
 		return;
 
-	assert(type_function_header[a].type == type_function_header[b].type);
-
 	// ensure a is a var if at least one of them is a var
 	if (type_function_header[b].type == TypeFunctionTag::Var)
 		std::swap(a, b);
@@ -217,6 +215,8 @@ void TypeSystemCore::func_unify(TypeFunctionId a, TypeFunctionId b) {
 	if (type_function_header[a].type == TypeFunctionTag::Var) {
 		type_function_header[a].equals = b;
 	} else {
+		assert(type_function_header[a].type == type_function_header[b].type);
+
 		// neither a nor b is a var. we will try to unify their data.
 
 		int a_data_idx = type_function_header[a].equals;


### PR DESCRIPTION
An idea: compile time is just another moment for evaluation, just that most expressions evaluate to themselves, and some evaluate to monotypes or type functions.

Example: `struct { x : int }` evaluates into a type function