### PR TITLE
Parser cleanup

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -25,6 +25,26 @@ struct AST {
 	virtual ~AST() = default;
 };
 
+struct Declaration : public AST {
+	Token const* m_identifier_token;
+	Own<AST> m_type;  // can be nullptr
+	Own<AST> m_value; // can be nullptr
+
+	std::string const& identifier_text() const {
+		return m_identifier_token->m_text;
+	}
+
+	Declaration()
+	    : AST {ASTTag::Declaration} {}
+};
+
+struct DeclarationList : public AST {
+	std::vector<Own<Declaration>> m_declarations;
+
+	DeclarationList()
+	    : AST {ASTTag::DeclarationList} {}
+};
+
 struct IntegerLiteral : public AST {
 	Token const* m_token;
 
@@ -76,7 +96,7 @@ struct NullLiteral : public AST {
 };
 
 struct ObjectLiteral : public AST {
-	std::vector<Own<AST>> m_body;
+	std::vector<Own<Declaration>> m_body;
 
 	ObjectLiteral()
 	    : AST {ASTTag::ObjectLiteral} {}
@@ -90,7 +110,7 @@ struct ArrayLiteral : public AST {
 };
 
 struct DictionaryLiteral : public AST {
-	std::vector<Own<AST>> m_body;
+	std::vector<Own<Declaration>> m_body;
 
 	DictionaryLiteral()
 	    : AST {ASTTag::DictionaryLiteral} {}
@@ -110,26 +130,6 @@ struct ShortFunctionLiteral : public AST {
 
 	ShortFunctionLiteral()
 	    : AST {ASTTag::ShortFunctionLiteral} {}
-};
-
-struct DeclarationList : public AST {
-	std::vector<Own<AST>> m_declarations;
-
-	DeclarationList()
-	    : AST {ASTTag::DeclarationList} {}
-};
-
-struct Declaration : public AST {
-	Token const* m_identifier_token;
-	Own<AST> m_type;  // can be nullptr
-	Own<AST> m_value; // can be nullptr
-
-	std::string const& identifier_text() const {
-		return m_identifier_token->m_text;
-	}
-
-	Declaration()
-	    : AST {ASTTag::Declaration} {}
 };
 
 struct Identifier : public AST {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -249,7 +249,7 @@ struct TypeVar : public AST {
 
 struct UnionExpression : public AST {
 	// TODO: better storage?
-	std::vector<Own<AST>> m_constructors;
+	std::vector<Identifier> m_constructors;
 	std::vector<Own<AST>> m_types;
 
 	UnionExpression()
@@ -265,7 +265,7 @@ struct TupleExpression : public AST {
 
 struct StructExpression : public AST {
 	// TODO: better storage?
-	std::vector<Own<AST>> m_fields;
+	std::vector<Identifier> m_fields;
 	std::vector<Own<AST>> m_types;
 
 	StructExpression()

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -8,6 +8,21 @@
 
 namespace AST {
 
+Own<Declaration> desugar(Own<Declaration> ast) {
+	// TODO: handle type hint
+	if (ast->m_value)
+		ast->m_value = desugar(std::move(ast->m_value));
+
+	return ast;
+}
+
+Own<AST> desugar(Own<DeclarationList> ast) {
+	for (auto&& declaration : ast->m_declarations)
+		declaration = desugar(std::move(declaration));
+
+	return ast;
+}
+
 Own<AST> desugar(Own<ObjectLiteral> ast) {
 	// TODO: convert
 	// obt { x : t1 = e1; y : t2 = e2; }
@@ -56,21 +71,6 @@ Own<AST> desugar(Own<ShortFunctionLiteral> ast) {
 	func->m_body = std::move(block);
 
 	return func;
-}
-
-Own<AST> desugar(Own<DeclarationList> ast) {
-	for (auto&& declaration : ast->m_declarations)
-		declaration = desugar(std::move(declaration));
-
-	return ast;
-}
-
-Own<AST> desugar(Own<Declaration> ast) {
-	// TODO: handle type hint
-	if (ast->m_value)
-		ast->m_value = desugar(std::move(ast->m_value));
-
-	return ast;
 }
 
 Own<AST> desugarPizza(Own<BinaryExpression> ast) {

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -11,14 +11,6 @@
 
 namespace Interpreter {
 
-gc_ptr<Value> eval(TypedAST::DeclarationList* ast, Environment& e) {
-	for (auto& decl : ast->m_declarations) {
-		assert(decl->type() == TypedASTTag::Declaration);
-		eval(static_cast<TypedAST::Declaration*>(decl.get()), e);
-	}
-	return e.null();
-};
-
 gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
 	// TODO: type and mutable check -> return error
 	e.declare(ast->identifier_text(), e.null());
@@ -27,6 +19,13 @@ gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
 		auto value = eval(ast->m_value.get(), e);
 		auto unboxed_val = unboxed(value.get());
 		ref->m_value = unboxed_val;
+	}
+	return e.null();
+};
+
+gc_ptr<Value> eval(TypedAST::DeclarationList* ast, Environment& e) {
+	for (auto& decl : ast->m_declarations) {
+		eval(decl.get(), e);
 	}
 	return e.null();
 };

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -172,17 +172,15 @@ namespace TypeChecker {
 [[nodiscard]] ErrorReport match_identifiers(
     TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment& env) {
 	for (auto& decl : ast->m_declarations) {
-		auto d = static_cast<TypedAST::Declaration*>(decl.get());
-		env.declare(d->identifier_text(), d);
-		d->m_surrounding_function = env.current_function();
+		env.declare(decl->identifier_text(), decl.get());
+		decl->m_surrounding_function = env.current_function();
 	}
 
 	for (auto& decl : ast->m_declarations) {
-		auto d = static_cast<TypedAST::Declaration*>(decl.get());
-		env.enter_top_level_decl(d);
+		env.enter_top_level_decl(decl.get());
 
-		if (d->m_value)
-			CHECK_AND_RETURN(match_identifiers(d->m_value.get(), env));
+		if (decl->m_value)
+			CHECK_AND_RETURN(match_identifiers(decl->m_value.get(), env));
 
 		env.exit_top_level_decl();
 	}

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -142,23 +142,17 @@ void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 	for (auto& decl : ast->m_declarations)
 		decl->m_meta_type = tc.new_meta_var();
 
-	for (auto& decl : ast->m_declarations) {
-		auto* d = static_cast<TypedAST::Declaration*>(decl.get());
-		metacheck(d->m_value.get(), tc);
-	}
+	for (auto& decl : ast->m_declarations)
+		metacheck(decl->m_value.get(), tc);
 
-	for (auto& decl : ast->m_declarations){
-		auto* d = static_cast<TypedAST::Declaration*>(decl.get());
-		tc.m_meta_core.unify(d->m_meta_type, d->m_value->m_meta_type);
-	}
+	for (auto& decl : ast->m_declarations)
+		tc.m_meta_core.unify(decl->m_meta_type, decl->m_value->m_meta_type);
 
-	for (auto& decl : ast->m_declarations){
-		auto* d = static_cast<TypedAST::Declaration*>(decl.get());
-		if (tc.m_meta_core.find(d->m_meta_type) == tc.meta_typefunc())
-			for (auto* other : d->m_references)
+	for (auto& decl : ast->m_declarations)
+		if (tc.m_meta_core.find(decl->m_meta_type) == tc.meta_typefunc())
+			for (auto* other : decl->m_references)
 				if (tc.m_meta_core.find(other->m_meta_type) == tc.meta_value())
 					assert(0 && "value referenced in a type definition");
-	}
 }
 
 void metacheck(TypedAST::TypedAST* ast, TypeChecker& tc) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -554,8 +554,8 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_ternary_expression() {
 	return make_writer<std::unique_ptr<AST::AST>>(std::move(e));
 }
 
-Writer<std::unique_ptr<AST::AST>> Parser::parse_identifier() {
-	Writer<std::unique_ptr<AST::AST>> result = {
+Writer<std::unique_ptr<AST::Identifier>> Parser::parse_identifier() {
+	Writer<std::unique_ptr<AST::Identifier>> result = {
 	    {"Parse Error: Failed to parse identifier"}};
 
 	auto token = require(TokenTag::IDENTIFIER);
@@ -564,7 +564,7 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_identifier() {
 
 	auto e = std::make_unique<AST::Identifier>();
 	e->m_token = token.m_result;
-	return make_writer<std::unique_ptr<AST::AST>>(std::move(e));
+	return make_writer<std::unique_ptr<AST::Identifier>>(std::move(e));
 }
 
 Writer<std::unique_ptr<AST::AST>> Parser::parse_array_literal() {
@@ -1045,9 +1045,7 @@ Writer<std::pair<std::vector<AST::Identifier>, std::vector<std::unique_ptr<AST::
 			if (handle_error(result, require(TokenTag::COLON)))
 				return result;
 
-			// beware the cursed line -- lol imagine having type safety
-			identifiers.push_back(
-			    std::move(*static_cast<AST::Identifier*>(cons.m_result.get())));
+			identifiers.push_back(std::move(*cons.m_result));
 		}
 
 		auto type = parse_type_term();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -173,8 +173,8 @@ Writer<std::vector<std::unique_ptr<AST::AST>>> Parser::parse_expression_list(
 	return make_writer(std::move(expressions));
 }
 
-Writer<std::unique_ptr<AST::AST>> Parser::parse_declaration() {
-	Writer<std::unique_ptr<AST::AST>> result = {
+Writer<std::unique_ptr<AST::Declaration>> Parser::parse_declaration() {
+	Writer<std::unique_ptr<AST::Declaration>> result = {
 	    {"Parse Error: Failed to parse declaration"}};
 
 	Writer<Token const*> name = require(TokenTag::IDENTIFIER);
@@ -212,7 +212,7 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_declaration() {
 	p->m_type = std::move(type.m_result);
 	p->m_value = std::move(value.m_result);
 
-	return make_writer<std::unique_ptr<AST::AST>>(std::move(p));
+	return make_writer<std::unique_ptr<AST::Declaration>>(std::move(p));
 }
 
 // These are important for infix expression parsing.
@@ -942,7 +942,7 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_statement() {
 				return result;
 			}
 
-			return declaration;
+			return make_writer<std::unique_ptr<AST::AST>>(std::unique_ptr<AST::AST>(declaration.m_result.release()));
 		} else {
 
 			// TODO: wrap in an ExpressionStatement ?

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1025,12 +1025,12 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_type_term() {
 	return make_writer<std::unique_ptr<AST::AST>>(std::move(e));
 }
 
-Writer<std::pair<std::vector<std::unique_ptr<AST::AST>>,std::vector<std::unique_ptr<AST::AST>>>>
-    Parser::parse_type_list(bool with_identifiers = false) {
-	Writer<std::pair<std::vector<std::unique_ptr<AST::AST>>,std::vector<std::unique_ptr<AST::AST>>>>
+Writer<std::pair<std::vector<AST::Identifier>, std::vector<std::unique_ptr<AST::AST>>>> Parser::parse_type_list(
+    bool with_identifiers = false) {
+	Writer<std::pair<std::vector<AST::Identifier>, std::vector<std::unique_ptr<AST::AST>>>>
 	    result = {{"Parse Error: Failed to parse type list"}};
 
-	std::vector<std::unique_ptr<AST::AST>> identifiers;
+	std::vector<AST::Identifier> identifiers;
 	std::vector<std::unique_ptr<AST::AST>> types;
 
 	if (handle_error(result, require(TokenTag::BRACE_OPEN)))
@@ -1044,8 +1044,10 @@ Writer<std::pair<std::vector<std::unique_ptr<AST::AST>>,std::vector<std::unique_
 
 			if (handle_error(result, require(TokenTag::COLON)))
 				return result;
-			
-			identifiers.push_back(std::move(cons.m_result));
+
+			// beware the cursed line -- lol imagine having type safety
+			identifiers.push_back(
+			    std::move(*static_cast<AST::Identifier*>(cons.m_result.get())));
 		}
 
 		auto type = parse_type_term();
@@ -1058,8 +1060,9 @@ Writer<std::pair<std::vector<std::unique_ptr<AST::AST>>,std::vector<std::unique_
 		types.push_back(std::move(type.m_result));
 	}
 
-	return make_writer<std::pair<std::vector<std::unique_ptr<AST::AST>>,std::vector<std::unique_ptr<AST::AST>>>>
-	    (make_pair(std::move(identifiers), std::move(types)));
+	return make_writer<
+	    std::pair<std::vector<AST::Identifier>, std::vector<std::unique_ptr<AST::AST>>>>(
+	    make_pair(std::move(identifiers), std::move(types)));
 }
 
 Writer<std::unique_ptr<AST::AST>> Parser::parse_type_var() {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -80,12 +80,12 @@ Writer<std::unique_ptr<AST::AST>> Parser::parse_top_level() {
 	return make_writer<std::unique_ptr<AST::AST>>(std::move(e));
 }
 
-Writer<std::vector<std::unique_ptr<AST::AST>>>
+Writer<std::vector<std::unique_ptr<AST::Declaration>>>
 Parser::parse_declaration_list(TokenTag terminator) {
-	Writer<std::vector<std::unique_ptr<AST::AST>>> result = {
+	Writer<std::vector<std::unique_ptr<AST::Declaration>>> result = {
 	    {"Parse Error: Failed to parse declaration list"}};
 
-	std::vector<std::unique_ptr<AST::AST>> declarations;
+	std::vector<std::unique_ptr<AST::Declaration>> declarations;
 
 	while (1) {
 		auto p0 = peek();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -33,7 +33,7 @@ struct Parser {
 
 	Writer<std::unique_ptr<AST::AST>> parse_top_level();
 	Writer<std::unique_ptr<AST::Identifier>> parse_identifier();
-	Writer<std::unique_ptr<AST::AST>> parse_declaration();
+	Writer<std::unique_ptr<AST::Declaration>> parse_declaration();
 	Writer<std::unique_ptr<AST::AST>> parse_expression(int bp = 0);
 	Writer<std::unique_ptr<AST::AST>> parse_terminal();
 	Writer<std::unique_ptr<AST::AST>> parse_ternary_expression();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -49,7 +49,7 @@ struct Parser {
 	Writer<std::unique_ptr<AST::AST>> parse_for_statement();
 	Writer<std::unique_ptr<AST::AST>> parse_while_statement();
 	Writer<std::unique_ptr<AST::AST>> parse_type_term();
-	Writer<std::pair<std::vector<std::unique_ptr<AST::AST>>,std::vector<std::unique_ptr<AST::AST>>>>
+	Writer<std::pair<std::vector<AST::Identifier>,std::vector<std::unique_ptr<AST::AST>>>>
 	    parse_type_list(bool);
 	Writer<std::unique_ptr<AST::AST>> parse_type_var();
 	Writer<std::unique_ptr<AST::AST>> parse_type_function();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -32,7 +32,7 @@ struct Parser {
 	parse_expression_list(TokenTag, TokenTag, bool);
 
 	Writer<std::unique_ptr<AST::AST>> parse_top_level();
-	Writer<std::unique_ptr<AST::AST>> parse_identifier();
+	Writer<std::unique_ptr<AST::Identifier>> parse_identifier();
 	Writer<std::unique_ptr<AST::AST>> parse_declaration();
 	Writer<std::unique_ptr<AST::AST>> parse_expression(int bp = 0);
 	Writer<std::unique_ptr<AST::AST>> parse_terminal();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -27,7 +27,7 @@ struct Parser {
 	/* token handler */
 	Lexer* m_lexer;
 
-	Writer<std::vector<std::unique_ptr<AST::AST>>> parse_declaration_list(TokenTag);
+	Writer<std::vector<std::unique_ptr<AST::Declaration>>> parse_declaration_list(TokenTag);
 	Writer<std::vector<std::unique_ptr<AST::AST>>>
 	parse_expression_list(TokenTag, TokenTag, bool);
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -245,9 +245,8 @@ void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 	// assign a unique int to every top level declaration
 	int i = 0;
 	for (auto& decl : ast->m_declarations) {
-		auto d = static_cast<TypedAST::Declaration*>(decl.get());
-		index_to_decl.push_back(d);
-		decl_to_index.insert({d, i});
+		index_to_decl.push_back(decl.get());
+		decl_to_index.insert({decl.get(), i});
 		++i;
 	}
 

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -73,17 +73,7 @@ Own<TypedAST> convert_ast(AST::FunctionLiteral* ast) {
 	return typed_function;
 }
 
-Own<TypedAST> convert_ast(AST::DeclarationList* ast) {
-	auto typed_declist = std::make_unique<DeclarationList>();
-
-	for (auto& declaration : ast->m_declarations) {
-		typed_declist->m_declarations.push_back(convert_ast(declaration.get()));
-	}
-
-	return typed_declist;
-}
-
-Own<TypedAST> convert_ast(AST::Declaration* ast) {
+Own<Declaration> convert_ast(AST::Declaration* ast) {
 	auto typed_dec = std::make_unique<Declaration>();
 
 	typed_dec->m_identifier_token = ast->m_identifier_token;
@@ -92,6 +82,16 @@ Own<TypedAST> convert_ast(AST::Declaration* ast) {
 		typed_dec->m_value = convert_ast(ast->m_value.get());
 
 	return typed_dec;
+}
+
+Own<TypedAST> convert_ast(AST::DeclarationList* ast) {
+	auto typed_declist = std::make_unique<DeclarationList>();
+
+	for (auto& declaration : ast->m_declarations) {
+		typed_declist->m_declarations.push_back(convert_ast(declaration.get()));
+	}
+
+	return typed_declist;
 }
 
 Own<TypedAST> convert_ast(AST::Identifier* ast) {

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -38,14 +38,6 @@ Own<TypedAST> convert_ast(AST::AST*);
 
 struct FunctionLiteral;
 
-// doesnt have a ast_vtype
-struct DeclarationList : public TypedAST {
-	std::vector<Own<TypedAST>> m_declarations;
-
-	DeclarationList()
-	    : TypedAST {TypedASTTag::DeclarationList} {}
-};
-
 struct Declaration : public TypedAST {
 	Token const* m_identifier_token;
 	Own<TypedAST> m_value; // can be nullptr
@@ -64,6 +56,14 @@ struct Declaration : public TypedAST {
 
 	Declaration()
 	    : TypedAST {TypedASTTag::Declaration} {}
+};
+
+// doesnt have a ast_vtype
+struct DeclarationList : public TypedAST {
+	std::vector<Own<Declaration>> m_declarations;
+
+	DeclarationList()
+	    : TypedAST {TypedASTTag::DeclarationList} {}
 };
 
 // las estructuras como declaration list, index expression, block, if, for no tienen


### PR DESCRIPTION
I wanted to do some work on the type system, but the weak-typedness of the AST is getting too unbearable to work with for me.

I originally did it this way to avoid having to think about it too much while the structure of the ast was constantly changing. I feel like it has stabilized enough that it's no longer an advantage. Rather, having to explicitly check types that should be known at compile time 'just in case' has gotten too annoying to keep bearing with.

There are a lot of parts of the AST whose types can be specified in more detail (`DeclarationList::m_declarations` is an obvious example), but I think this is a good start.

I chose this node because it's the part that I am working on integrating with the type systems, and it makes some code simpler to have explicit types