### PR TITLE
Intern strings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,6 +15,7 @@ OBJNAMES := \
 	metacheck.o \
 	parser.o \
 	parse.o \
+	string_set.o \
 	string_view.o \
 	tarjan_solver.o \
 	token.o \

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,6 +10,7 @@ OBJNAMES := \
 	ct_eval.o \
 	desugar.o \
 	error_report.o \
+	interned_string.o \
 	lexer.o \
 	match_identifiers.o \
 	metacheck.o \

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,8 +52,11 @@ ITPR_OBJS := $(addprefix $(OBJDIR)/,$(ITPR_OBJNAMES))
 ALL_OBJS := $(OBJS) $(ITPR_OBJS) $(TEST_OBJS)
 
 LIBS := -lasan
+# LIBS := -lubsan
 
-CXXFLAGS := -std=c++14 -Wall -fsanitize=address -g
+# CXXFLAGS := -std=c++14 -Wall -O2 -g -fno-omit-frame-pointer
+CXXFLAGS := -std=c++14 -Wall -g -fno-omit-frame-pointer -fsanitize=address
+# CXXFLAGS := -std=c++14 -Wall -g -fno-omit-frame-pointer -fsanitize=undefined
 
 # maybe we should build the tests as well?
 all: interpreter

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -31,7 +31,7 @@ struct Declaration : public AST {
 	Own<AST> m_value; // can be nullptr
 
 	std::string const& identifier_text() const {
-		return m_identifier_token->m_text;
+		return m_identifier_token->m_text.str();
 	}
 
 	Declaration()
@@ -49,7 +49,7 @@ struct IntegerLiteral : public AST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	IntegerLiteral()
@@ -60,7 +60,7 @@ struct NumberLiteral : public AST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	NumberLiteral()
@@ -71,7 +71,7 @@ struct StringLiteral : public AST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	StringLiteral()
@@ -82,7 +82,7 @@ struct BooleanLiteral : public AST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	BooleanLiteral()
@@ -136,7 +136,7 @@ struct Identifier : public AST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	Identifier()
@@ -240,7 +240,7 @@ struct TypeVar : public AST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	TypeVar()

--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -13,13 +13,13 @@ Scope& CompileTimeEnvironment::current_scope() {
 }
 
 void CompileTimeEnvironment::declare(
-    std::string const& name, TypedAST::Declaration* decl) {
+    InternedString const& name, TypedAST::Declaration* decl) {
 	// current_scope().m_vars[name] = decl;
 	current_scope().m_vars.insert({name, decl});
 }
 
-TypedAST::Declaration* CompileTimeEnvironment::access(std::string const& name) {
-	auto scan_scope = [](Scope& scope, std::string const& name) -> TypedAST::Declaration* {
+TypedAST::Declaration* CompileTimeEnvironment::access(InternedString const& name) {
+	auto scan_scope = [](Scope& scope, InternedString const& name) -> TypedAST::Declaration* {
 		auto it = scope.m_vars.find(name);
 		if (it != scope.m_vars.end())
 			return it->second;

--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "interned_string.hpp"
 #include "typechecker_types.hpp"
 
 namespace TypedAST {
@@ -18,7 +19,7 @@ namespace Frontend {
 
 struct Scope {
 	bool m_nested {false};
-	std::unordered_map<std::string, TypedAST::Declaration*> m_vars;
+	std::unordered_map<InternedString, TypedAST::Declaration*> m_vars;
 	std::unordered_set<MonoId> m_type_vars;
 };
 
@@ -30,9 +31,9 @@ struct CompileTimeEnvironment {
 
 	CompileTimeEnvironment();
 
-	void declare(std::string const&, TypedAST::Declaration*);
+	void declare(InternedString const&, TypedAST::Declaration*);
 
-	TypedAST::Declaration* access(std::string const&);
+	TypedAST::Declaration* access(InternedString const&);
 
 	TypedAST::FunctionLiteral* current_function();
 	void enter_function(TypedAST::FunctionLiteral*);

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -116,7 +116,7 @@ TypeFunctionId type_func_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		int field_count = as_se->m_fields.size();
 		for (int i = 0; i < field_count; ++i){
 			MonoId mono = mono_type_from_ast(as_se->m_types[i].get(), tc);
-			std::string name = as_se->m_fields[i].text();
+			std::string name = as_se->m_fields[i].text().str();
 			assert(!fields.count(name));
 			fields[name] = mono;
 		}

--- a/src/interned_string.cpp
+++ b/src/interned_string.cpp
@@ -1,0 +1,41 @@
+#include "interned_string.hpp"
+
+#include <iostream>
+
+#include "string_set.hpp"
+
+#include <cassert>
+
+StringSet& InternedString::database() {
+	static StringSet values;
+	return values;
+}
+
+InternedString::InternedString(InternedString const& other)
+    : m_data {other.m_data} {}
+
+InternedString::InternedString(char const* other)
+    : InternedString(std::string(other)) {}
+
+InternedString::InternedString(std::string const& other) {
+	auto insertion_result = database().insert(other);
+	m_data = &(*insertion_result.first);
+}
+
+InternedString::InternedString(std::string&& other) {
+	auto insertion_result = database().insert(std::move(other));
+	m_data = &(*insertion_result.first);
+}
+
+bool InternedString::operator==(InternedString const& other) const {
+	return m_data == other.m_data;
+}
+
+std::string const& InternedString::str() const {
+	assert(m_data);
+	return *m_data;
+}
+
+std::ostream& operator<<(std::ostream& o, InternedString const& is) {
+	return o << is.str();
+}

--- a/src/interned_string.cpp
+++ b/src/interned_string.cpp
@@ -14,6 +14,11 @@ StringSet& InternedString::database() {
 InternedString::InternedString(InternedString const& other)
     : m_data {other.m_data} {}
 
+InternedString::InternedString(char const* other, size_t length) {
+	auto insertion_result = database().insert(other, length);
+	m_data = &(*insertion_result.first);
+}
+
 InternedString::InternedString(char const* other) {
 	auto insertion_result = database().insert(other);
 	m_data = &(*insertion_result.first);

--- a/src/interned_string.cpp
+++ b/src/interned_string.cpp
@@ -14,8 +14,10 @@ StringSet& InternedString::database() {
 InternedString::InternedString(InternedString const& other)
     : m_data {other.m_data} {}
 
-InternedString::InternedString(char const* other)
-    : InternedString(std::string(other)) {}
+InternedString::InternedString(char const* other) {
+	auto insertion_result = database().insert(other);
+	m_data = &(*insertion_result.first);
+}
 
 InternedString::InternedString(std::string const& other) {
 	auto insertion_result = database().insert(other);

--- a/src/interned_string.hpp
+++ b/src/interned_string.hpp
@@ -19,4 +19,11 @@ struct InternedString {
 	static StringSet& database();
 };
 
+// Specialize std::hash to implement hashing for this type
+template<> struct std::hash<InternedString> {
+	std::size_t operator()(InternedString const& str) const noexcept {
+		return std::hash<std::string const*>{}(str.m_data);
+	};
+};
+
 std::ostream& operator<<(std::ostream&, InternedString const&);

--- a/src/interned_string.hpp
+++ b/src/interned_string.hpp
@@ -9,6 +9,7 @@ struct InternedString {
 
 	InternedString(InternedString const& other);
 	InternedString(char const* other);
+	InternedString(char const* other, size_t length);
 	explicit InternedString(std::string const& other);
 	explicit InternedString(std::string&& other);
 

--- a/src/interned_string.hpp
+++ b/src/interned_string.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <iosfwd>
 #include <string>
 #include <unordered_set>

--- a/src/interned_string.hpp
+++ b/src/interned_string.hpp
@@ -1,0 +1,22 @@
+#include <iosfwd>
+#include <string>
+#include <unordered_set>
+
+struct StringSet;
+
+struct InternedString {
+	std::string const* m_data {nullptr};
+
+	InternedString(InternedString const& other);
+	InternedString(char const* other);
+	explicit InternedString(std::string const& other);
+	explicit InternedString(std::string&& other);
+
+	bool operator==(InternedString const& other) const;
+
+	std::string const& str() const;
+
+	static StringSet& database();
+};
+
+std::ostream& operator<<(std::ostream&, InternedString const&);

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -116,7 +116,7 @@ gc_ptr<Object> Environment::new_object(ObjectType declarations) {
 	return m_gc->new_object(std::move(declarations));
 }
 
-gc_ptr<Dictionary> Environment::new_dictionary(ObjectType declarations) {
+gc_ptr<Dictionary> Environment::new_dictionary(DictionaryType declarations) {
 	return m_gc->new_dictionary(std::move(declarations));
 }
 

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../interned_string.hpp"
 #include "error.hpp"
 #include "gc_ptr.hpp"
 #include "value.hpp"
@@ -54,7 +55,7 @@ struct Environment {
 	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_object(ObjectType) -> gc_ptr<Object>;
-	auto new_dictionary(ObjectType) -> gc_ptr<Dictionary>;
+	auto new_dictionary(DictionaryType) -> gc_ptr<Dictionary>;
 	auto new_function(FunctionType, ObjectType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -245,8 +245,7 @@ gc_ptr<Value> eval(TypedAST::FunctionLiteral* ast, Environment& e) {
 	auto result = e.new_function(ast, {});
 
 	for (auto const& identifier : ast->m_captures) {
-		InternedString interned_id {identifier};
-		result->m_captures[interned_id] = e.m_scope->access(interned_id);
+		result->m_captures[identifier] = e.m_scope->access(identifier);
 	}
 
 	return result;

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -13,9 +13,9 @@ namespace Interpreter {
 
 gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
 	// TODO: type and mutable check -> return error
-	e.declare(ast->identifier_text().str(), e.null());
+	e.declare(ast->identifier_text(), e.null());
 	if (ast->m_value) {
-		auto* ref = e.access(ast->identifier_text().str());
+		auto* ref = e.access(ast->identifier_text());
 		auto value = eval(ast->m_value.get(), e);
 		auto unboxed_val = unboxed(value.get());
 		ref->m_value = unboxed_val;
@@ -61,7 +61,7 @@ gc_ptr<Value> eval(TypedAST::ObjectLiteral* ast, Environment& e) {
 
 		if (decl->m_value) {
 			auto value = eval(decl->m_value.get(), e);
-			result->m_value[decl->identifier_text().str()] = value.get();
+			result->m_value[decl->identifier_text()] = value.get();
 		} else {
 			std::cerr << "ERROR: declaration in object must have a value";
 			assert(0);
@@ -102,7 +102,7 @@ gc_ptr<Value> eval(TypedAST::ArrayLiteral* ast, Environment& e) {
 };
 
 gc_ptr<Value> eval(TypedAST::Identifier* ast, Environment& e) {
-	return e.access(ast->text().str());
+	return e.access(ast->text());
 };
 
 gc_ptr<Value> eval(TypedAST::Block* ast, Environment& e) {
@@ -147,7 +147,7 @@ gc_ptr<Value> eval_call_function(
 	e.new_scope();
 	for (int i = 0; i < int(callee->m_def->m_args.size()); ++i) {
 		auto& argdecl = callee->m_def->m_args[i];
-		e.declare(argdecl.identifier_text().str(), unboxed(args[i].get()));
+		e.declare(argdecl.identifier_text(), unboxed(args[i].get()));
 	}
 	// NOTE: we could `args.clear()` at this point. Is it worth doing?
 
@@ -245,7 +245,8 @@ gc_ptr<Value> eval(TypedAST::FunctionLiteral* ast, Environment& e) {
 	auto result = e.new_function(ast, {});
 
 	for (auto const& identifier : ast->m_captures) {
-		result->m_captures[identifier] = e.m_scope->access(identifier);
+		InternedString interned_id {identifier};
+		result->m_captures[interned_id] = e.m_scope->access(interned_id);
 	}
 
 	return result;

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -13,9 +13,9 @@ namespace Interpreter {
 
 gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
 	// TODO: type and mutable check -> return error
-	e.declare(ast->identifier_text(), e.null());
+	e.declare(ast->identifier_text().str(), e.null());
 	if (ast->m_value) {
-		auto* ref = e.access(ast->identifier_text());
+		auto* ref = e.access(ast->identifier_text().str());
 		auto value = eval(ast->m_value.get(), e);
 		auto unboxed_val = unboxed(value.get());
 		ref->m_value = unboxed_val;
@@ -61,7 +61,7 @@ gc_ptr<Value> eval(TypedAST::ObjectLiteral* ast, Environment& e) {
 
 		if (decl->m_value) {
 			auto value = eval(decl->m_value.get(), e);
-			result->m_value[decl->identifier_text()] = value.get();
+			result->m_value[decl->identifier_text().str()] = value.get();
 		} else {
 			std::cerr << "ERROR: declaration in object must have a value";
 			assert(0);
@@ -81,7 +81,7 @@ gc_ptr<Value> eval(TypedAST::DictionaryLiteral* ast, Environment& e) {
 
 		if (decl->m_value) {
 			auto value = eval(decl->m_value.get(), e);
-			result->m_value[decl->identifier_text()] = value.get();
+			result->m_value[decl->identifier_text().str()] = value.get();
 		} else {
 			std::cerr << "ERROR: declaration in dictionary must have value";
 			assert(0);
@@ -102,7 +102,7 @@ gc_ptr<Value> eval(TypedAST::ArrayLiteral* ast, Environment& e) {
 };
 
 gc_ptr<Value> eval(TypedAST::Identifier* ast, Environment& e) {
-	return e.access(ast->text());
+	return e.access(ast->text().str());
 };
 
 gc_ptr<Value> eval(TypedAST::Block* ast, Environment& e) {
@@ -147,7 +147,7 @@ gc_ptr<Value> eval_call_function(
 	e.new_scope();
 	for (int i = 0; i < int(callee->m_def->m_args.size()); ++i) {
 		auto& argdecl = callee->m_def->m_args[i];
-		e.declare(argdecl.identifier_text(), unboxed(args[i].get()));
+		e.declare(argdecl.identifier_text().str(), unboxed(args[i].get()));
 	}
 	// NOTE: we could `args.clear()` at this point. Is it worth doing?
 

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -67,7 +67,7 @@ gc_ptr<Object> GC::new_object(ObjectType declarations) {
 	return result;
 }
 
-gc_ptr<Dictionary> GC::new_dictionary(ObjectType declarations) {
+gc_ptr<Dictionary> GC::new_dictionary(DictionaryType declarations) {
 	auto result = new Dictionary;
 	result->m_value = std::move(declarations);
 	m_blocks.push_back(result);

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -29,7 +29,7 @@ struct GC {
 	auto null() -> Null*;
 
 	auto new_object(ObjectType) -> gc_ptr<Object>;
-	auto new_dictionary(ObjectType) -> gc_ptr<Dictionary>;
+	auto new_dictionary(DictionaryType) -> gc_ptr<Dictionary>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_integer(int) -> gc_ptr<Integer>;
 	auto new_float(float) -> gc_ptr<Float>;

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -77,15 +77,16 @@ Value* Object::getMember(Identifier const& id) {
 
 Dictionary::Dictionary()
     : Value(ValueTag::Dictionary) {}
-Dictionary::Dictionary(ObjectType o)
+
+Dictionary::Dictionary(DictionaryType o)
     : Value(ValueTag::Dictionary)
     , m_value(std::move(o)) {}
 
-void Dictionary::addMember(Identifier const& id, Value* v) {
+void Dictionary::addMember(StringType const& id, Value* v) {
 	m_value[id] = v;
 }
 
-Value* Dictionary::getMember(Identifier const& id) {
+Value* Dictionary::getMember(StringType const& id) {
 	auto it = m_value.find(id);
 	if (it == m_value.end()) {
 		// TODO: return RangeError
@@ -95,7 +96,7 @@ Value* Dictionary::getMember(Identifier const& id) {
 	}
 }
 
-void Dictionary::removeMember(Identifier const& id) {
+void Dictionary::removeMember(StringType const& id) {
 	m_value.erase(id);
 }
 

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "../interned_string.hpp"
 #include "environment_fwd.hpp"
 #include "value_fwd.hpp"
 #include "value_tag.hpp"
@@ -14,8 +15,10 @@ struct FunctionLiteral;
 
 namespace Interpreter {
 
-using Identifier = std::string;
+using Identifier = InternedString;
+using StringType = std::string;
 using ObjectType = std::unordered_map<Identifier, Value*>;
+using DictionaryType = std::unordered_map<StringType, Value*>;
 using ArrayType = std::vector<Value*>;
 using FunctionType = TypedAST::FunctionLiteral*;
 using NativeFunctionType = auto(ArrayType, Environment&) -> Value*;
@@ -95,14 +98,14 @@ struct Object : Value {
 };
 
 struct Dictionary : Value {
-	ObjectType m_value;
+	DictionaryType m_value;
 
 	Dictionary();
-	Dictionary(ObjectType);
+	Dictionary(DictionaryType);
 
-	void addMember(Identifier const& id, Value* v);
-	Value* getMember(Identifier const& id);
-	void removeMember(Identifier const& id);
+	void addMember(StringType const& id, Value* v);
+	Value* getMember(StringType const& id);
+	void removeMember(StringType const& id);
 };
 
 struct Function : Value {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -23,13 +23,11 @@ char Lexer::char_at(int index) {
 
 void Lexer::push_token(TokenTag tt, int width) {
 
-	std::string text(width, '\0');
-	for (int i = 0; i < width; ++i)
-		text[i] = m_source[m_source_index + i];
+	char const* base_ptr = m_source.data() + m_source_index;
 
 	Token t = {
 	    tt,
-	    InternedString(std::move(text)),
+	    InternedString(base_ptr, width),
 	    m_current_line,
 	    m_current_column,
 	    m_current_line,

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -23,14 +23,13 @@ char Lexer::char_at(int index) {
 
 void Lexer::push_token(TokenTag tt, int width) {
 
-	std::string text;
-	text.resize(width);
+	std::string text(width, '\0');
 	for (int i = 0; i < width; ++i)
 		text[i] = m_source[m_source_index + i];
 
 	Token t = {
 	    tt,
-	    std::move(text),
+	    InternedString(std::move(text)),
 	    m_current_line,
 	    m_current_column,
 	    m_current_line,
@@ -386,7 +385,7 @@ void Lexer::consume_token() {
 		}
 
 		m_tokens.push_back(
-		    {TokenTag::STRING, text, l0, c0, m_current_line, m_current_column});
+		    {TokenTag::STRING, InternedString {text}, l0, c0, m_current_line, m_current_column});
 
 		m_current_column += 1;
 		m_source_index += 1;
@@ -410,7 +409,7 @@ void Lexer::consume_token() {
 
 			m_tokens.push_back(
 			    {TokenTag::IDENTIFIER,
-			     text,
+			     InternedString {text},
 			     m_current_line,
 			     m_current_column - int(text.size()),
 			     m_current_line,
@@ -462,7 +461,7 @@ bool Lexer::consume_number() {
 	m_current_column += 1;
 	m_tokens.push_back(
 	    {type,
-	     text,
+	     InternedString {text},
 	     m_current_line,
 	     m_current_column - int(text.size()),
 	     m_current_line,

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -358,7 +358,7 @@ void Lexer::consume_token() {
 		int l0 = m_current_line;
 
 		// TODO: support escape sequences
-		int len = 0;
+		size_t len = 0;
 		while ((not done()) && current_char() != '"') {
 			len += 1;
 			m_source_index += 1;
@@ -375,15 +375,9 @@ void Lexer::consume_token() {
 			assert(0);
 		}
 
-		std::string text;
-		assert(len == (m_source_index - i0));
-		text.reserve(len);
-		for (int i = i0; i != m_source_index; ++i) {
-			text.push_back(m_source[i]);
-		}
-
+		char const* base_ptr = m_source.data() + i0;
 		m_tokens.push_back(
-		    {TokenTag::STRING, InternedString {text}, l0, c0, m_current_line, m_current_column});
+		    {TokenTag::STRING, InternedString {base_ptr, len}, l0, c0, m_current_line, m_current_column});
 
 		m_current_column += 1;
 		m_source_index += 1;
@@ -394,22 +388,23 @@ void Lexer::consume_token() {
 			return;
 
 		if (is_identifier_start_char(current_char())) {
-			std::string text;
-			text.push_back(current_char());
+
+			char const* base_ptr = m_source.data() + m_source_index;
+			size_t len = 1;
 
 			while (is_identifier_char(next_char())) {
+				len += 1;
 				m_source_index += 1;
-				text.push_back(current_char());
 			}
 
 			m_source_index += 1;
-			m_current_column += text.size();
+			m_current_column += len;
 
 			m_tokens.push_back(
 			    {TokenTag::IDENTIFIER,
-			     InternedString {text},
+			     InternedString {base_ptr, len},
 			     m_current_line,
-			     m_current_column - int(text.size()),
+			     m_current_column - int(len),
 			     m_current_line,
 			     m_current_column});
 
@@ -431,26 +426,26 @@ bool Lexer::consume_number() {
 	if (!isdigit(current_char()))
 		return false;
 
-	std::string text;
-	text.push_back(current_char());
+	char const* base_ptr = m_source.data() + m_source_index;
+	size_t len = 1;
 
 	bool is_int = true;
 	while (isdigit(next_char())) {
 		m_source_index += 1;
 		m_current_column += 1;
-		text.push_back(current_char());
+		len += 1;
 	}
 
 	if (next_char() == '.') {
 		is_int = false;
 		m_source_index += 1;
 		m_current_column += 1;
-		text.push_back(current_char());
+		len += 1;
 
 		while (isdigit(next_char())) {
 			m_source_index += 1;
 			m_current_column += 1;
-			text.push_back(current_char());
+			len += 1;
 		}
 	}
 
@@ -459,9 +454,9 @@ bool Lexer::consume_number() {
 	m_current_column += 1;
 	m_tokens.push_back(
 	    {type,
-	     InternedString {text},
+	     InternedString {base_ptr, len},
 	     m_current_line,
-	     m_current_column - int(text.size()),
+	     m_current_column - int(len),
 	     m_current_line,
 	     m_current_column});
 

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -39,7 +39,7 @@ namespace TypeChecker {
 		// TODO: clean up how we build error reports
 		return {
 		    "ERROR @ line " + std::to_string(ast->m_token->m_line0 + 1) +
-		    " : accessed undeclared identifier '" + ast->text() + "'"};
+		    " : accessed undeclared identifier '" + ast->text().str() + "'"};
 	}
 
 	ast->m_declaration = declaration;
@@ -53,7 +53,7 @@ namespace TypeChecker {
 			auto* func = env.m_function_stack[i];
 			if (func == surrounding_function)
 				break;
-			func->m_captures.insert(ast->text());
+			func->m_captures.insert(ast->text().str());
 		}
 	}
 

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -53,7 +53,7 @@ namespace TypeChecker {
 			auto* func = env.m_function_stack[i];
 			if (func == surrounding_function)
 				break;
-			func->m_captures.insert(ast->text().str());
+			func->m_captures.insert(ast->text());
 		}
 	}
 

--- a/src/string_set.cpp
+++ b/src/string_set.cpp
@@ -1,7 +1,6 @@
 #include "string_set.hpp"
 
 #include "string_view.hpp"
-#include "interned_string.hpp"
 
 #include <cassert>
 #include <cstring>

--- a/src/string_set.cpp
+++ b/src/string_set.cpp
@@ -7,30 +7,22 @@
 
 #include <iostream>
 
-// compute a 64-bit hash using a simple horner hashing scheme
+// compute a 64-bit hash
 static uint64_t compute_hash(unsigned char const* data, size_t length) {
-	constexpr uint64_t base = 263;
-	// TODO find a larger prime (less than 2**64/263)
-	constexpr uint64_t mod = 1000000005721;
-
-	uint64_t result = 0;
+	// djb2 (k=33) hash function
+	uint64_t result = 5381;
 	while (length--) {
-		result *= base;
-		result += data[length];
-		result %= mod;
+		result *= 33;
+		result ^= data[length];
 	}
-
 	return result;
 }
 
-// compute a 62-bit hash using a simple horner hashing scheme
+// compute a 62-bit hash
 static uint64_t compute_effective_hash(unsigned char const* data, size_t length) {
 	uint64_t hash_bits = compute_hash(data, length);
 	// roll the two highest bits back to the low bits
-	// NOTE: due to how we implement compute_hash, the two highest bits are
-	// always off. Still, doing this is pretty much free, and it makes this
-	// function more future-proof.
-	return (hash_bits >> 62) ^ hash_bits;
+	return (hash_bits >> 62) ^ (hash_bits & ~(3 << 22));
 }
 
 // ==== ==== ==== ====

--- a/src/string_set.cpp
+++ b/src/string_set.cpp
@@ -1,0 +1,176 @@
+#include "string_set.hpp"
+
+#include "string_view.hpp"
+#include "interned_string.hpp"
+
+#include <cassert>
+#include <cstring>
+
+// compute a 64-bit hash using a simple horner hashing scheme
+static uint64_t compute_hash(unsigned char const* data, size_t length) {
+	constexpr uint64_t base = 263;
+	// TODO find a larger prime (less than 2**64/263)
+	constexpr uint64_t mod = 1000000005721;
+
+	uint64_t result = 0;
+	while (length--) {
+		result *= base;
+		result += data[length];
+		result %= mod;
+	}
+
+	return result;
+}
+
+// compute a 62-bit hash using a simple horner hashing scheme
+static uint64_t compute_effective_hash(unsigned char const* data, size_t length) {
+	uint64_t hash_bits = compute_hash(data, length);
+	// roll the two highest bits back to the low bits
+	// NOTE: due to how we implement compute_hash, the two highest bits are
+	// always off. Still, doing this is pretty much free, and it makes this
+	// function more future-proof.
+	return (hash_bits >> 62) ^ hash_bits;
+}
+
+// ==== ==== ==== ====
+
+StringSet::StringSet(){
+	m_data.resize(8);
+}
+
+void StringSet::insert(std::string const& s) {
+	uint64_t hash_bits = compute_effective_hash(
+	    reinterpret_cast<unsigned char const*>(s.data()), s.size());
+	auto pos = insertion_spot(s.data(), s.size(), hash_bits);
+
+	if (pos.second)
+		return;
+
+	if (m_size * 2 >= m_data.size())
+		rehash(m_data.size() * 2);
+
+	m_size += 1;
+	put(pos.first, std::string {s}, hash_bits);
+}
+
+void StringSet::insert(std::string&& s) {
+	uint64_t hash_bits = compute_effective_hash(
+	    reinterpret_cast<unsigned char const*>(s.data()), s.size());
+	auto pos = insertion_spot(s.data(), s.size(), hash_bits);
+
+	if (pos.second)
+		return;
+
+	if (m_size * 2 >= m_data.size())
+		rehash(m_data.size() * 2);
+
+	m_size += 1;
+	put(pos.first, std::move(s), hash_bits);
+}
+
+void StringSet::insert(char const* data, size_t length) {
+	uint64_t hash_bits = compute_effective_hash(
+	    reinterpret_cast<unsigned char const*>(data), length);
+	auto pos = insertion_spot(data, length, hash_bits);
+
+	if (pos.second)
+		return;
+
+	if (m_size * 2 >= m_data.size())
+		rehash(m_data.size() * 2);
+
+	m_size += 1;
+	put(pos.first, std::string {data, length}, hash_bits);
+}
+
+void StringSet::insert(char const* data) {
+	insert(data, strlen(data));
+}
+
+bool StringSet::includes(char const* data, size_t length) const {
+	uint64_t hash_bits = compute_effective_hash(
+	    reinterpret_cast<unsigned char const*>(data), length);
+	auto pos = find_spot(data, length, hash_bits);
+
+	return pos.second;
+}
+
+bool StringSet::includes(char const* data) const {
+	return includes(data, strlen(data));
+}
+
+bool StringSet::includes(std::string const& str) const {
+	return includes(str.data(), str.size());
+}
+
+// ==== ==== ==== ====
+
+void StringSet::rehash(size_t new_size) {
+	if (new_size < m_data.size())
+		return;
+
+	std::vector<std::pair<HashField, std::string>> old_data = std::move(m_data);
+
+	m_data.resize(0);
+	m_data.resize(new_size);
+	for (auto& slot : old_data){
+		if(slot.first.status == HashField::Occupied){
+			uint64_t hash_bits = slot.first.hash_bits;
+			auto pos = insertion_spot(
+			    slot.second.data(),
+			    slot.second.size(),
+			    hash_bits);
+			put(pos.first, std::move(slot.second), hash_bits);
+		}
+	}
+}
+
+std::pair<int, bool> StringSet::insertion_spot(char const* data, size_t length, uint64_t hash_bits) const {
+	assert(m_data.size() > m_size);
+
+	int position = hash_bits % m_data.size();
+	bool found = false;
+	while (m_data[position].first.status == HashField::Occupied) {
+
+		if (length == m_data[position].second.size() &&
+		    memcmp(data, m_data[position].second.data(), length) == 0) {
+			found = true;
+			break;
+		}
+
+		position += 1;
+		if (position == static_cast<int>(m_data.size()))
+			position = 0;
+	}
+
+	return {position, found};
+}
+
+std::pair<int, bool> StringSet::find_spot(char const* data, size_t length, uint64_t hash_bits) const {
+	assert(m_data.size() > m_size);
+
+	int position = hash_bits % m_data.size();
+	bool found = false;
+	while (m_data[position].first.status != HashField::Empty) {
+
+		if (length == m_data[position].second.size() &&
+		    memcmp(data, m_data[position].second.data(), length) == 0) {
+			found = true;
+			break;
+		}
+
+		position += 1;
+		if (position == static_cast<int>(m_data.size()))
+			position = 0;
+	}
+
+	return {position, found};
+}
+
+void StringSet::put(int position, std::string&& str, uint64_t hash_bits){
+	assert(m_data[position].first.status != HashField::Occupied);
+
+	m_data[position].first.status = HashField::Occupied;
+	m_data[position].first.hash_bits = hash_bits;
+	m_data[position].second = std::move(str);
+}

--- a/src/string_set.cpp
+++ b/src/string_set.cpp
@@ -5,6 +5,8 @@
 #include <cassert>
 #include <cstring>
 
+#include <iostream>
+
 // compute a 64-bit hash using a simple horner hashing scheme
 static uint64_t compute_hash(unsigned char const* data, size_t length) {
 	constexpr uint64_t base = 263;
@@ -37,61 +39,54 @@ StringSet::StringSet(){
 	m_data.resize(8);
 }
 
-void StringSet::insert(std::string const& s) {
+std::pair<std::string const*, bool> StringSet::insert(std::string&& s) {
 	uint64_t hash_bits = compute_effective_hash(
 	    reinterpret_cast<unsigned char const*>(s.data()), s.size());
-	auto pos = insertion_spot(s.data(), s.size(), hash_bits);
+	auto pos = scan(s.data(), s.size(), hash_bits);
 
-	if (pos.second)
-		return;
+	if (pos.found)
+		return {m_data[pos.stop_index].second.get(), false};
 
 	if (m_size * 2 >= m_data.size())
 		rehash(m_data.size() * 2);
 
 	m_size += 1;
-	put(pos.first, std::string {s}, hash_bits);
+	put(pos.free_index, std::move(s), hash_bits);
+
+	return {m_data[pos.free_index].second.get(), true};
 }
 
-void StringSet::insert(std::string&& s) {
-	uint64_t hash_bits = compute_effective_hash(
-	    reinterpret_cast<unsigned char const*>(s.data()), s.size());
-	auto pos = insertion_spot(s.data(), s.size(), hash_bits);
-
-	if (pos.second)
-		return;
-
-	if (m_size * 2 >= m_data.size())
-		rehash(m_data.size() * 2);
-
-	m_size += 1;
-	put(pos.first, std::move(s), hash_bits);
-}
-
-void StringSet::insert(char const* data, size_t length) {
+std::pair<std::string const*, bool> StringSet::insert(char const* data, size_t length) {
 	uint64_t hash_bits = compute_effective_hash(
 	    reinterpret_cast<unsigned char const*>(data), length);
-	auto pos = insertion_spot(data, length, hash_bits);
+	auto pos = scan(data, length, hash_bits);
 
-	if (pos.second)
-		return;
+	if (pos.found)
+		return {m_data[pos.stop_index].second.get(), false};
 
 	if (m_size * 2 >= m_data.size())
 		rehash(m_data.size() * 2);
 
 	m_size += 1;
-	put(pos.first, std::string {data, length}, hash_bits);
+	put(pos.free_index, std::string {data, length}, hash_bits);
+
+	return {m_data[pos.free_index].second.get(), true};
 }
 
-void StringSet::insert(char const* data) {
-	insert(data, strlen(data));
+std::pair<std::string const*, bool> StringSet::insert(std::string const& s) {
+	return insert(s.data(), s.size());
+}
+
+std::pair<std::string const*, bool> StringSet::insert(char const* data) {
+	return insert(data, strlen(data));
 }
 
 bool StringSet::includes(char const* data, size_t length) const {
 	uint64_t hash_bits = compute_effective_hash(
 	    reinterpret_cast<unsigned char const*>(data), length);
-	auto pos = find_spot(data, length, hash_bits);
+	auto pos = scan(data, length, hash_bits);
 
-	return pos.second;
+	return pos.found;
 }
 
 bool StringSet::includes(char const* data) const {
@@ -115,47 +110,35 @@ void StringSet::rehash(size_t new_size) {
 	for (auto& slot : old_data){
 		if(slot.first.status == HashField::Occupied){
 			uint64_t hash_bits = slot.first.hash_bits;
-			auto pos = insertion_spot(
-			    slot.second->data(),
-			    slot.second->size(),
-			    hash_bits);
-			put(pos.first, std::move(*slot.second), hash_bits);
+			auto pos = scan(slot.second->data(), slot.second->size(), hash_bits);
+			put(pos.free_index, std::move(*slot.second), hash_bits);
 		}
 	}
 }
 
-std::pair<int, bool> StringSet::insertion_spot(char const* data, size_t length, uint64_t hash_bits) const {
-	assert(m_data.size() > m_size);
 
-	int position = hash_bits % m_data.size();
-	bool found = false;
-	while (m_data[position].first.status == HashField::Occupied) {
+StringSet::ScanData StringSet::scan(char const* data, size_t length, uint64_t hash_bits) const {
 
-		if (length == m_data[position].second->size() &&
-		    memcmp(data, m_data[position].second->data(), length) == 0) {
-			found = true;
-			break;
-		}
-
-		position += 1;
-		if (position == static_cast<int>(m_data.size()))
-			position = 0;
+	if (m_data.size() <= m_size){
+		*(volatile int*)0 = 10;
 	}
 
-	return {position, found};
-}
-
-std::pair<int, bool> StringSet::find_spot(char const* data, size_t length, uint64_t hash_bits) const {
 	assert(m_data.size() > m_size);
 
 	int position = hash_bits % m_data.size();
+	int free_position = -1;
 	bool found = false;
 	while (m_data[position].first.status != HashField::Empty) {
 
-		if (length == m_data[position].second->size() &&
-		    memcmp(data, m_data[position].second->data(), length) == 0) {
-			found = true;
-			break;
+		if (m_data[position].first.status == HashField::Tombstone) {
+			if (free_position == -1)
+				free_position = position;
+		} else if (m_data[position].first.status == HashField::Occupied) {
+			if (length == m_data[position].second->size() &&
+			    memcmp(data, m_data[position].second->data(), length) == 0) {
+				found = true;
+				break;
+			}
 		}
 
 		position += 1;
@@ -163,10 +146,16 @@ std::pair<int, bool> StringSet::find_spot(char const* data, size_t length, uint6
 			position = 0;
 	}
 
-	return {position, found};
+	if (free_position == -1 && m_data[position].first.status == HashField::Empty) {
+		free_position = position;
+	}
+
+	return {free_position, position, found};
 }
 
 void StringSet::put(int position, std::string&& str, uint64_t hash_bits){
+	std::cerr << "PUTTING AT " << position << " -- SIZE IS " << m_data.size() << "\n";
+
 	assert(m_data[position].first.status != HashField::Occupied);
 
 	m_data[position].first.status = HashField::Occupied;

--- a/src/string_set.cpp
+++ b/src/string_set.cpp
@@ -27,7 +27,7 @@ static uint64_t compute_effective_hash(unsigned char const* data, size_t length)
 
 // ==== ==== ==== ====
 
-StringSet::StringSet(){
+StringSet::StringSet() {
 	m_data.resize(8);
 	memset(m_data.data(), 0, sizeof(m_data[0]) * m_data.size());
 }
@@ -102,9 +102,10 @@ void StringSet::rehash(size_t new_size) {
 	memset(m_data.data(), 0, sizeof(m_data[0]) * m_data.size());
 
 	m_size = 0;
-	for (auto& slot : old_data){
-		if(slot.status == HashField::Occupied){
-			auto pos = scan(slot.value->data(), slot.value->size(), slot.hash_bits);
+	for (auto& slot : old_data) {
+		if (slot.status == HashField::Occupied) {
+			auto pos =
+			    scan(slot.value->data(), slot.value->size(), slot.hash_bits);
 			assert(!pos.found);
 			m_data[pos.free_index].value = slot.value;
 			m_data[pos.free_index].status = HashField::Occupied;
@@ -114,7 +115,8 @@ void StringSet::rehash(size_t new_size) {
 	}
 }
 
-StringSet::ScanData StringSet::scan(char const* data, size_t length, uint64_t hash_bits) const {
+StringSet::ScanData StringSet::scan(
+    char const* data, size_t length, uint64_t hash_bits) const {
 	assert(m_data.size() > m_size);
 
 	int position = hash_bits % m_data.size();
@@ -123,7 +125,7 @@ StringSet::ScanData StringSet::scan(char const* data, size_t length, uint64_t ha
 
 	while (m_data[position].status != HashField::Empty) {
 		if (m_data[position].status == HashField::Tombstone) {
-			if (free_position == -1){
+			if (free_position == -1) {
 				free_position = position;
 			}
 		} else if (m_data[position].status == HashField::Occupied) {
@@ -147,7 +149,7 @@ StringSet::ScanData StringSet::scan(char const* data, size_t length, uint64_t ha
 	return {free_position, position, found};
 }
 
-void StringSet::put(int position, std::string&& str, uint64_t hash_bits){
+void StringSet::put(int position, std::string&& str, uint64_t hash_bits) {
 	assert(m_data[position].status != HashField::Occupied);
 
 	m_storage.push_back(std::move(str));

--- a/src/string_set.hpp
+++ b/src/string_set.hpp
@@ -1,6 +1,7 @@
-#include <vector>
+#include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <cstdint>
 
@@ -19,7 +20,7 @@ struct StringSet {
 		uint64_t hash_bits : 62;
 	};
 
-	std::vector<std::pair<HashField, std::string>> m_data;
+	std::vector<std::pair<HashField, std::unique_ptr<std::string>>> m_data;
 	size_t m_size;
 
 	StringSet();
@@ -32,8 +33,8 @@ struct StringSet {
 	void insert(char const*);
 
 	bool includes(std::string const&) const;
-	// bool includes(InternedString const&) const;
-	// bool includes(string_view const&) const;
+	// bool includes(InternedString const&) const; // TODO
+	// bool includes(string_view const&) const; // TODO
 	bool includes(char const*, size_t) const;
 	bool includes(char const*) const;
 

--- a/src/string_set.hpp
+++ b/src/string_set.hpp
@@ -3,6 +3,8 @@
 #include <utility>
 #include <vector>
 
+#include "chunked_array.hpp"
+
 #include <cstdint>
 
 struct string_view;
@@ -22,11 +24,14 @@ struct StringSet {
 		static constexpr uint64_t Occupied = 1;
 		static constexpr uint64_t Tombstone = 2;
 
-		uint64_t status : 2 {0};
-		uint64_t hash_bits : 62 {0};
+		std::string* value;
+		uint64_t status : 2;
+		uint64_t hash_bits : 62;
 	};
 
-	std::vector<std::pair<HashField, std::unique_ptr<std::string>>> m_data;
+	
+	ChunkedArray<std::string> m_storage;
+	std::vector<HashField> m_data;
 	size_t m_size {0};
 
 	StringSet();

--- a/src/string_set.hpp
+++ b/src/string_set.hpp
@@ -1,0 +1,45 @@
+#include <vector>
+#include <string>
+#include <utility>
+
+#include <cstdint>
+
+struct string_view;
+struct InternedString;
+
+// a flat linear hashing table
+struct StringSet {
+	struct HashField {
+		// possible status values:
+		static constexpr uint64_t Empty = 0;
+		static constexpr uint64_t Occupied = 1;
+		static constexpr uint64_t Tombstone = 2;
+
+		uint64_t status : 2;
+		uint64_t hash_bits : 62;
+	};
+
+	std::vector<std::pair<HashField, std::string>> m_data;
+	size_t m_size;
+
+	StringSet();
+
+	void insert(std::string const&);
+	void insert(std::string&&);
+	// void insert(InternedString const&); // TODO
+	// void insert(string_view const&); // TODO
+	void insert(char const*, size_t);
+	void insert(char const*);
+
+	bool includes(std::string const&) const;
+	// bool includes(InternedString const&) const;
+	// bool includes(string_view const&) const;
+	bool includes(char const*, size_t) const;
+	bool includes(char const*) const;
+
+  private:
+	std::pair<int, bool> insertion_spot(char const*, size_t, uint64_t) const;
+	std::pair<int, bool> find_spot(char const*, size_t, uint64_t) const;
+	void put(int, std::string&&, uint64_t);
+	void rehash(size_t);
+};

--- a/src/string_set.hpp
+++ b/src/string_set.hpp
@@ -29,7 +29,6 @@ struct StringSet {
 		uint64_t hash_bits : 62;
 	};
 
-	
 	ChunkedArray<std::string> m_storage;
 	std::vector<HashField> m_data;
 	size_t m_size {0};

--- a/src/string_set.hpp
+++ b/src/string_set.hpp
@@ -10,27 +10,33 @@ struct InternedString;
 
 // a flat linear hashing table
 struct StringSet {
+	struct ScanData {
+		int free_index;
+		int stop_index;
+		bool found;
+	};
+
 	struct HashField {
 		// possible status values:
 		static constexpr uint64_t Empty = 0;
 		static constexpr uint64_t Occupied = 1;
 		static constexpr uint64_t Tombstone = 2;
 
-		uint64_t status : 2;
-		uint64_t hash_bits : 62;
+		uint64_t status : 2 {0};
+		uint64_t hash_bits : 62 {0};
 	};
 
 	std::vector<std::pair<HashField, std::unique_ptr<std::string>>> m_data;
-	size_t m_size;
+	size_t m_size {0};
 
 	StringSet();
 
-	void insert(std::string const&);
-	void insert(std::string&&);
+	std::pair<std::string const*, bool> insert(std::string const&);
+	std::pair<std::string const*, bool> insert(std::string&&);
 	// void insert(InternedString const&); // TODO
 	// void insert(string_view const&); // TODO
-	void insert(char const*, size_t);
-	void insert(char const*);
+	std::pair<std::string const*, bool> insert(char const*, size_t);
+	std::pair<std::string const*, bool> insert(char const*);
 
 	bool includes(std::string const&) const;
 	// bool includes(InternedString const&) const; // TODO
@@ -39,8 +45,7 @@ struct StringSet {
 	bool includes(char const*) const;
 
   private:
-	std::pair<int, bool> insertion_spot(char const*, size_t, uint64_t) const;
-	std::pair<int, bool> find_spot(char const*, size_t, uint64_t) const;
+	ScanData scan(char const*, size_t, uint64_t) const;
 	void put(int, std::string&&, uint64_t);
 	void rehash(size_t);
 };

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -9,6 +9,8 @@
 #include "test_utils.hpp"
 #include "tester.hpp"
 
+#include "../string_set.hpp"
+
 void interpreter_tests(Test::Tester& tests) {
 	using TestCase = Test::InterpreterTestSet;
 	using Testers = std::vector<Test::Interpret>;
@@ -490,6 +492,27 @@ void tarjan_algorithm_tests(Test::Tester& tester) {
 
 		        return {TestStatusTag::Ok};
 	        }}));
+}
+
+void string_set_tests(Test::Tester& tester) {
+	tester.add_test(std::make_unique<Test::NormalTestSet>(
+	    std::vector<Test::NormalTestSet::TestFunction> {+[]() -> TestReport {
+		    StringSet s;
+		    s.insert("AAA");
+		    if (!s.includes("AAA"))
+			    return {TestStatusTag::Fail, "AAA is not in the set after inserting it"};
+
+		    s.insert("BBB");
+		    if (!s.includes("AAA"))
+			    return {
+			        TestStatusTag::Fail,
+			        "AAA is no longer in the set after inserting BBB"};
+
+		    if (!s.includes("BBB"))
+			    return {TestStatusTag::Fail, "BBB is not in the set after inserting it"};
+
+		    return {TestStatusTag::Ok};
+	    }}));
 }
 
 int main() {

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -517,7 +517,8 @@ void string_set_tests(Test::Tester& tester) {
 
 int main() {
 	Test::Tester tests;
-	interpreter_tests(tests);
 	tarjan_algorithm_tests(tests);
+	string_set_tests(tests);
+	interpreter_tests(tests);
 	tests.execute();
 }

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -3,12 +3,13 @@
 #include <string>
 
 #include "token_tag.hpp"
+#include "interned_string.hpp"
 
 struct Token {
 	/* internal representation of token */
 	TokenTag m_type;
 	/* source code representation of token */
-	std::string m_text;
+	InternedString m_text;
 
 	/* beggining of token in source */
 	int m_line0, m_col0;

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -238,7 +238,7 @@ void typecheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
 	ast->m_value_type = member_type;
 
 	TypeFunctionId dummy_tf = tc.m_core.new_dummy_type_function(
-	    TypeFunctionTag::Record, {{ast->m_member->m_text, member_type}});
+	    TypeFunctionTag::Record, {{ast->m_member->m_text.str(), member_type}});
 	MonoId term_type = tc.m_core.new_term(dummy_tf, {}, "record instance");
 
 	tc.m_core.m_mono_core.unify(ast->m_record->m_value_type, term_type);

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -174,7 +174,7 @@ MonoId TypeChecker::rule_app(std::vector<MonoId> args_types, MonoId func_type) {
 	return return_type;
 }
 
-void TypeChecker::declare_builtin(std::string const& name, MetaTypeId meta_type, PolyId poly_type){
+void TypeChecker::declare_builtin(InternedString const& name, MetaTypeId meta_type, PolyId poly_type){
 	m_builtin_declarations.push_back({});
 	TypedAST::Declaration* decl = &m_builtin_declarations.back();
 	decl->m_meta_type = meta_type;

--- a/src/typechecker.hpp
+++ b/src/typechecker.hpp
@@ -2,6 +2,7 @@
 
 #include "chunked_array.hpp"
 #include "compile_time_environment.hpp"
+#include "interned_string.hpp"
 #include "typesystem.hpp"
 
 namespace TypeChecker {
@@ -14,7 +15,7 @@ struct TypeChecker {
 
 	TypeChecker();
 
-	void declare_builtin(std::string const& name, MetaTypeId, PolyId);
+	void declare_builtin(InternedString const& name, MetaTypeId, PolyId);
 
 	MonoId new_hidden_var();
 	MonoId new_var();

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -51,7 +51,7 @@ struct Declaration : public TypedAST {
 	FunctionLiteral* m_surrounding_function {nullptr};
 
 	std::string const& identifier_text() const {
-		return m_identifier_token->m_text;
+		return m_identifier_token->m_text.str();
 	}
 
 	Declaration()
@@ -72,7 +72,7 @@ struct NumberLiteral : public TypedAST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	NumberLiteral()
@@ -83,7 +83,7 @@ struct IntegerLiteral : public TypedAST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	IntegerLiteral()
@@ -94,7 +94,7 @@ struct StringLiteral : public TypedAST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	StringLiteral()
@@ -105,7 +105,7 @@ struct BooleanLiteral : public TypedAST {
 	Token const* m_token;
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	BooleanLiteral()
@@ -157,7 +157,7 @@ struct Identifier : public TypedAST {
 	Declaration* m_declaration {nullptr};
 
 	std::string const& text() {
-		return m_token->m_text;
+		return m_token->m_text.str();
 	}
 
 	Identifier()

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -50,8 +50,8 @@ struct Declaration : public TypedAST {
 	// nullptr means global
 	FunctionLiteral* m_surrounding_function {nullptr};
 
-	std::string const& identifier_text() const {
-		return m_identifier_token->m_text.str();
+	InternedString const& identifier_text() const {
+		return m_identifier_token->m_text;
 	}
 
 	Declaration()
@@ -156,8 +156,8 @@ struct Identifier : public TypedAST {
 	Token const* m_token;
 	Declaration* m_declaration {nullptr};
 
-	std::string const& text() {
-		return m_token->m_text.str();
+	InternedString const& text() {
+		return m_token->m_text;
 	}
 
 	Identifier()

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -145,7 +145,7 @@ struct FunctionLiteral : public TypedAST {
 	MonoId m_return_type;
 	Own<TypedAST> m_body;
 	std::vector<Declaration> m_args;
-	std::unordered_set<std::string> m_captures;
+	std::unordered_set<InternedString> m_captures;
 
 	FunctionLiteral()
 	    : TypedAST {TypedASTTag::FunctionLiteral} {}


### PR DESCRIPTION
Here is the deal: we have strings all over the place. A lot of them are duplicated, which is dumb, and takes up more memory than it should. There is actually a common solution for this: string interning.

What is string interning? It is the act of putting all the strings in your program inside a hash table, and using pointers into hash table entries to refer to particular strings.

Why is this good? Since every string is de-duplicated, we can compare two interned strings by comparing their pointer, meaning all string equality comparisons are O(1). Furthermore, we can use the same pointer as a hash key, meaning string hashing is also O(1) (therefore, things that use unordered_map, like the CTEnv, etc. will be faster) .

In order to implement the string interning operations efficiently, it is necessary to write a custom hash table.