### PR TITLE
Performance optimization in the runtime

### DIFF
--- a/src/interned_string.cpp
+++ b/src/interned_string.cpp
@@ -34,10 +34,6 @@ InternedString::InternedString(std::string&& other) {
 	m_data = &(*insertion_result.first);
 }
 
-bool InternedString::operator==(InternedString const& other) const {
-	return m_data == other.m_data;
-}
-
 std::string const& InternedString::str() const {
 	assert(m_data);
 	return *m_data;

--- a/src/interned_string.hpp
+++ b/src/interned_string.hpp
@@ -15,7 +15,9 @@ struct InternedString {
 	explicit InternedString(std::string const& other);
 	explicit InternedString(std::string&& other);
 
-	bool operator==(InternedString const& other) const;
+	bool operator==(InternedString const& other) const {
+		return m_data == other.m_data;
+	}
 
 	std::string const& str() const;
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -202,6 +202,7 @@ gc_ptr<Value> eval(TypedAST::CallExpression* ast, Environment& e) {
 	auto& arglist = ast->m_args;
 
 	std::vector<gc_ptr<Value>> args;
+	args.reserve(arglist.size());
 	for (int i = 0; i < int(arglist.size()); ++i) {
 		args.push_back(eval(arglist[i].get(), e));
 	}


### PR DESCRIPTION
I felt like profiling and optimizing today. Luckily, there was some low-hanging fruit.

In my benchmarks, `InternedString::operator==` was like 10% of the execution time. Since all it does is compare a pointer, I figured the cost must have been in the function call, so I put it in the header to allow for inlining. This brought a 3.5%  improvement in mean execution time (p-value approximately `6e-7`).

After that, I noticed a large amount of calls to `std::vector<gc_ptr<Interpreter::Value>>::_M_realloc_insert` coming from `Interpreter::eval(TypedAST::CallExpression*)`. The optimization was to add a call to reserve before pushing the arguments into the argument vector. In this case, I didn't observe a performance improvement because the functions I used all took one or two arguments (thus, they only allocated memory once), but it should be faster for larger argument counts.