### PR TITLE
String set improvements

### DIFF
--- a/src/string_set.cpp
+++ b/src/string_set.cpp
@@ -120,33 +120,24 @@ StringSet::ScanData StringSet::scan(
 
 	int position = hash_bits % m_data.size();
 	int free_position = -1;
-	bool found = false;
 
-	while (m_data[position].status != HashField::Empty) {
+	while (true) {
 		if (m_data[position].status == HashField::Occupied) {
 			if (m_data[position].hash_bits == hash_bits &&
 			    length == m_data[position].value->size() &&
-			    memcmp(data, m_data[position].value->data(), length) == 0) {
-				found = true;
-				break;
-			}
-		} else if (m_data[position].status == HashField::Tombstone) {
-			if (free_position == -1) {
+			    memcmp(data, m_data[position].value->data(), length) == 0)
+				return {free_position, position, true};
+		} else {
+			if (free_position == -1)
 				free_position = position;
-			}
+			if (m_data[position].status == HashField::Empty)
+				return {free_position, position, false};
 		}
 
 		position += 1;
 		if (position == static_cast<int>(m_data.size()))
 			position = 0;
 	}
-
-	if (m_data[position].status == HashField::Empty) {
-		if (free_position == -1)
-			free_position = position;
-	}
-
-	return {free_position, position, found};
 }
 
 void StringSet::put(int position, std::string&& str, uint64_t hash_bits) {


### PR DESCRIPTION
I had written this hash table, and I was pretty happy with it, but, looking at it a second time... man... it was not very nice.

It had a pretty big bug: the hashes that `compute_effective_hash` returned weren't actually 62 bit hashes (well, they were, but the 0 bits were not the highest order ones, but ones in the middle).

It also didn't use the 62 bits of hash that we store to save on string comparisons, which is a pretty massive oversight.

Other than that, there was (and still is, to a lesser degree) general clumsiness to how the code is written.

Another thing that could be improved is that `StringSet::includes` can be written more efficiently by not looking for free slots during the scan. I didn't do this because we don't use it anywhere outside of tests, so it's not really worth the extra code.