### PR TITLE
implement stack-based local variables

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,7 @@ OBJDIR := ../build
 OBJNAMES := \
 	ast.o \
 	compile_time_environment.o \
+	compute_offsets.o \
 	ct_eval.o \
 	desugar.o \
 	error_report.o \

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -1,0 +1,163 @@
+#include "compute_offsets.hpp"
+
+#include "typed_ast.hpp"
+
+#include <iostream>
+
+#include <cassert>
+
+namespace TypeChecker {
+
+void compute_offsets(TypedAST::Declaration* ast, int frame_offset) {
+	if (ast->m_value)
+		compute_offsets(ast->m_value.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::Identifier* ast, int frame_offset) {
+	TypedAST::Declaration* decl = ast->m_declaration;
+	ast->m_frame_offset = decl->m_frame_offset;
+}
+
+//TODO
+void compute_offsets(TypedAST::Block* ast, int frame_offset) {
+	for (auto& child : ast->m_body) {
+		if (child->type() == TypedASTTag::Declaration) {
+			auto decl = static_cast<TypedAST::Declaration*>(child.get());
+			decl->m_frame_offset = frame_offset++;
+		}
+		compute_offsets(child.get(), frame_offset);
+	}
+}
+
+void compute_offsets(TypedAST::IfElseStatement* ast, int frame_offset) {
+	compute_offsets(ast->m_condition.get(), frame_offset);
+	compute_offsets(ast->m_body.get(), frame_offset);
+	if (ast->m_else_body)
+		compute_offsets(ast->m_else_body.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::CallExpression* ast, int frame_offset) {
+	compute_offsets(ast->m_callee.get(), frame_offset);
+	for (auto& arg : ast->m_args)
+		compute_offsets(arg.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::FunctionLiteral* ast, int frame_offset) {
+	// functions always start a new frame
+	frame_offset = 0;
+
+	for (auto& arg_decl : ast->m_args)
+		arg_decl.m_frame_offset = frame_offset++;
+
+	// scan body
+	assert(ast->m_body->type() == TypedASTTag::Block);
+	auto body = static_cast<TypedAST::Block*>(ast->m_body.get());
+	compute_offsets(body, frame_offset);
+}
+
+void compute_offsets(TypedAST::ArrayLiteral* ast, int frame_offset) {
+	for (auto& element : ast->m_elements)
+		compute_offsets(element.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::ForStatement* ast, int frame_offset) {
+	auto decl = static_cast<TypedAST::Declaration*>(ast->m_declaration.get());
+	decl->m_frame_offset = frame_offset++;
+	compute_offsets(ast->m_declaration.get(), frame_offset);
+	compute_offsets(ast->m_condition.get(), frame_offset+1);
+	compute_offsets(ast->m_action.get(), frame_offset+1);
+	compute_offsets(ast->m_body.get(), frame_offset+1);
+}
+
+void compute_offsets(TypedAST::WhileStatement* ast, int frame_offset) {
+	compute_offsets(ast->m_condition.get(), frame_offset);
+	compute_offsets(ast->m_body.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::ReturnStatement* ast, int frame_offset) {
+	compute_offsets(ast->m_value.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::IndexExpression* ast, int frame_offset) {
+	compute_offsets(ast->m_callee.get(), frame_offset);
+	compute_offsets(ast->m_index.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::TernaryExpression* ast, int frame_offset) {
+	compute_offsets(ast->m_condition.get(), frame_offset);
+	compute_offsets(ast->m_then_expr.get(), frame_offset);
+	compute_offsets(ast->m_else_expr.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::RecordAccessExpression* ast, int frame_offset) {
+	compute_offsets(ast->m_record.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::DeclarationList* ast, int frame_offset) {
+	for (auto& decl : ast->m_declarations) {
+		if (decl->m_value)
+			compute_offsets(decl->m_value.get(), frame_offset);
+	}
+}
+
+void compute_offsets(TypedAST::StructExpression* ast, int frame_offset) {
+	for (auto& type : ast->m_types)
+		compute_offsets(type.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::TypeTerm* ast, int frame_offset) {
+	compute_offsets(ast->m_callee.get(), frame_offset);
+	for (auto& arg : ast->m_args)
+		compute_offsets(arg.get(), frame_offset);
+}
+
+void compute_offsets(TypedAST::TypedAST* ast, int frame_offset) {
+#define DISPATCH(type)                                                         \
+	case TypedASTTag::type:                                                    \
+		return compute_offsets(static_cast<TypedAST::type*>(ast), frame_offset);
+
+#define DO_NOTHING(type)                                                       \
+	case TypedASTTag::type:                                                    \
+		return;
+
+#define REJECT(type)                                                           \
+	case TypedASTTag::type:                                                    \
+		assert(0);
+
+	switch (ast->type()) {
+		DO_NOTHING(NumberLiteral);
+		DO_NOTHING(IntegerLiteral);
+		DO_NOTHING(StringLiteral);
+		DO_NOTHING(BooleanLiteral);
+		DO_NOTHING(NullLiteral);
+		DISPATCH(ArrayLiteral);
+		DISPATCH(FunctionLiteral);
+
+		DISPATCH(Identifier);
+		DISPATCH(IndexExpression);
+		DISPATCH(CallExpression);
+		DISPATCH(TernaryExpression);
+		DISPATCH(RecordAccessExpression);
+
+		DISPATCH(Block);
+		DISPATCH(ForStatement);
+		DISPATCH(WhileStatement);
+		DISPATCH(IfElseStatement);
+		DISPATCH(ReturnStatement);
+
+		DISPATCH(Declaration);
+		DISPATCH(DeclarationList);
+
+		DISPATCH(StructExpression);
+		DISPATCH(TypeTerm);
+	}
+
+#undef REJECT
+#undef DO_NOTHING
+#undef DISPATCH
+	std::cerr << "INTERNAL ERROR: UNHANDLED CASE IN " << __PRETTY_FUNCTION__
+	          << ": " << typed_ast_string[(int)ast->type()] << '\n';
+	assert(0);
+}
+
+} // namespace TypeChecker

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -145,10 +145,6 @@ void compute_offsets(TypedAST::TypedAST* ast, int frame_offset) {
 	case TypedASTTag::type:                                                    \
 		return;
 
-#define REJECT(type)                                                           \
-	case TypedASTTag::type:                                                    \
-		assert(0);
-
 	switch (ast->type()) {
 		DO_NOTHING(NumberLiteral);
 		DO_NOTHING(IntegerLiteral);
@@ -177,7 +173,6 @@ void compute_offsets(TypedAST::TypedAST* ast, int frame_offset) {
 		DISPATCH(TypeTerm);
 	}
 
-#undef REJECT
 #undef DO_NOTHING
 #undef DISPATCH
 	std::cerr << "INTERNAL ERROR: UNHANDLED CASE IN " << __PRETTY_FUNCTION__

--- a/src/compute_offsets.hpp
+++ b/src/compute_offsets.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace TypedAST {
+
+struct TypedAST;
+
+}
+
+namespace TypeChecker {
+
+void compute_offsets(TypedAST::TypedAST* ast, int frame_offset);
+
+}

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -7,8 +7,8 @@
 namespace Interpreter {
 
 void Scope::declare(const Identifier& i, Reference* v) {
-	// TODO: check name collision
-	m_declarations[i] = v;
+	auto insertion_result = m_declarations.insert({i, v});
+	assert(insertion_result.second);
 }
 
 Reference* Scope::access(const Identifier& i) {

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -47,7 +47,7 @@ void Environment::run_gc() {
 	m_gc->sweep();
 }
 
-void Environment::global_declare(const Identifier& i, Reference* r) {
+void Environment::global_declare_direct(const Identifier& i, Reference* r) {
 	m_global_scope.declare(i, r);
 }
 
@@ -55,7 +55,7 @@ void Environment::global_declare(const Identifier& i, Value* v) {
 	if (v->type() == ValueTag::Reference)
 		assert(0 && "declared a reference!");
 	auto r = new_reference(v);
-	global_declare(i, r.get());
+	global_declare_direct(i, r.get());
 }
 
 void Environment::global_declare(const Identifier& i, gc_ptr<Value> v) {

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -47,6 +47,7 @@ void Environment::run_gc() {
 	m_gc->sweep();
 }
 
+
 void Environment::global_declare_direct(const Identifier& i, Reference* r) {
 	m_global_scope.declare(i, r);
 }
@@ -64,6 +65,33 @@ void Environment::global_declare(const Identifier& i, gc_ptr<Value> v) {
 
 Reference* Environment::global_access(const Identifier& i) {
 	return m_global_scope.access(i);
+}
+
+void Environment::start_stack_frame() {
+	m_fp_stack.push_back(m_frame_ptr);
+	m_sp_stack.push_back(m_stack_ptr);
+	m_frame_ptr = m_stack_ptr;
+}
+
+void Environment::end_stack_frame(){
+	m_frame_ptr = m_fp_stack.back();
+	m_fp_stack.pop_back();
+
+	m_stack_ptr = m_sp_stack.back();
+	m_sp_stack.pop_back();
+
+	m_stack.resize(m_stack_ptr);
+}
+
+void Environment::start_stack_region() {
+	m_sp_stack.push_back(m_stack_ptr);
+}
+
+void Environment::end_stack_region() {
+	m_stack_ptr = m_sp_stack.back();
+	m_sp_stack.pop_back();
+
+	m_stack.resize(m_stack_ptr);
 }
 
 Null* Environment::null() {

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -49,27 +49,23 @@ void Environment::run_gc() {
 	m_gc->sweep();
 }
 
-void Environment::direct_declare(const Identifier& i, Reference* r) {
-	if (r->type() != ValueTag::Reference) {
-		assert(0 && "directly declared a non-reference!");
-	}
-	m_scope->declare(i, r);
+void Environment::global_declare(const Identifier& i, Reference* r) {
+	m_global_scope.declare(i, r);
 }
 
-void Environment::declare(const Identifier& i, gc_ptr<Value> v) {
-	declare(i, v.get());
-}
-
-void Environment::declare(const Identifier& i, Value* v) {
-	if (v->type() == ValueTag::Reference) {
+void Environment::global_declare(const Identifier& i, Value* v) {
+	if (v->type() == ValueTag::Reference)
 		assert(0 && "declared a reference!");
-	}
 	auto r = new_reference(v);
-	m_scope->declare(i, r.get());
+	global_declare(i, r.get());
 }
 
-Reference* Environment::access(const Identifier& i) {
-	return m_scope->access(i);
+void Environment::global_declare(const Identifier& i, gc_ptr<Value> v) {
+	global_declare(i, v.get());
+}
+
+Reference* Environment::global_access(const Identifier& i) {
+	return m_global_scope.access(i);
 }
 
 Null* Environment::null() {

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -14,16 +14,12 @@ void Scope::declare(const Identifier& i, Reference* v) {
 Reference* Scope::access(const Identifier& i) {
 	auto v = m_declarations.find(i);
 
-	if (v != m_declarations.end()) {
-		assert(v->second->type() == ValueTag::Reference);
-		return static_cast<Reference*>(v->second);
+	if (v == m_declarations.end()) {
+		// TODO: error
+		return nullptr;
 	}
 
-	if (m_parent != nullptr)
-		return m_parent->access(i);
-
-	// TODO: ReferenceError
-	return nullptr;
+	return v->second;
 }
 
 void Environment::save_return_value(Value* v) {
@@ -42,9 +38,11 @@ void Environment::run_gc() {
 	m_gc->unmark_all();
 	m_gc->mark_roots();
 
-	for (Scope* scope_it = m_scope; scope_it != nullptr; scope_it = scope_it->m_prev)
-		for (auto& p : scope_it->m_declarations)
-			gc_visit(p.second);
+	for (auto p : m_stack)
+		gc_visit(p);
+
+	for (auto& p : m_global_scope.m_declarations)
+		gc_visit(p.second);
 
 	m_gc->sweep();
 }

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -26,22 +26,6 @@ Reference* Scope::access(const Identifier& i) {
 	return nullptr;
 }
 
-Scope* Environment::new_nested_scope() {
-	m_scope = new Scope {m_scope, m_scope};
-	return m_scope;
-}
-
-Scope* Environment::new_scope() {
-	m_scope = new Scope {&m_global_scope, m_scope};
-	return m_scope;
-}
-
-void Environment::end_scope() {
-	Scope* prev = m_scope->m_prev;
-	delete m_scope;
-	m_scope = prev;
-}
-
 void Environment::save_return_value(Value* v) {
 	// check if not stepping on another value
 	assert(!m_return_value);

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -94,6 +94,17 @@ void Environment::end_stack_region() {
 	m_stack.resize(m_stack_ptr);
 }
 
+void Environment::push_direct(Reference* ref){
+	m_stack.push_back(ref);
+	m_stack_ptr += 1;
+}
+
+void Environment::push(Value* val){
+	assert(val->type() != ValueTag::Reference);
+	auto ref = new_reference(val);
+	push_direct(ref.get());
+}
+
 Null* Environment::null() {
 	return m_gc->null();
 }

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -39,7 +39,7 @@ struct Environment {
 	void run_gc();
 
 	// Binds a global name to the given reference
-	void global_declare(const Identifier& i, Reference* v);
+	void global_declare_direct(const Identifier& i, Reference* v);
 	void global_declare(const Identifier& i, Value* v);
 	void global_declare(const Identifier& i, gc_ptr<Value> v);
 

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -42,8 +42,12 @@ struct Environment {
 	void global_declare_direct(const Identifier& i, Reference* v);
 	void global_declare(const Identifier& i, Value* v);
 	void global_declare(const Identifier& i, gc_ptr<Value> v);
-
 	Reference* global_access(const Identifier& i);
+
+	void start_stack_frame();
+	void end_stack_frame();
+	void start_stack_region();
+	void end_stack_region();
 
 	auto null() -> Null*;
 	auto new_integer(int) -> gc_ptr<Integer>;

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -43,14 +43,12 @@ struct Environment {
 
 	void run_gc();
 
-	// SHORT-HANDS
+	// Binds a global name to the given reference
+	void global_declare(const Identifier& i, Reference* v);
+	void global_declare(const Identifier& i, Value* v);
+	void global_declare(const Identifier& i, gc_ptr<Value> v);
 
-	// Binds a name to a new reference of the given value
-	void declare(const Identifier&, Value*);
-	void declare(const Identifier&, gc_ptr<Value>);
-	// Binds a name to the given reference
-	void direct_declare(const Identifier& i, Reference* v);
-	Reference* access(const Identifier&);
+	Reference* global_access(const Identifier& i);
 
 	auto null() -> Null*;
 	auto new_integer(int) -> gc_ptr<Integer>;

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -12,10 +12,7 @@ namespace Interpreter {
 struct GC;
 
 struct Scope {
-	Scope* m_parent {nullptr};
-	Scope* m_prev {nullptr};
-	// TODO: store references instead of values
-	std::map<InternedString, Value*> m_declarations;
+	std::map<InternedString, Reference*> m_declarations;
 
 	void declare(const Identifier& i, Reference* v);
 	Reference* access(const Identifier& i);

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -22,7 +22,6 @@ struct Environment {
 	GC* m_gc;
 	Scope m_global_scope;
 
-	Scope* m_scope;
 	Value* m_return_value {nullptr};
 
 	int m_frame_ptr {0};
@@ -32,8 +31,7 @@ struct Environment {
 	std::vector<int> m_sp_stack;
 
 	Environment(GC* gc)
-	    : m_gc {gc}
-	    , m_scope {&m_global_scope} {}
+	    : m_gc {gc} {}
 
 	void save_return_value(Value*);
 	Value* fetch_return_value();

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -49,6 +49,9 @@ struct Environment {
 	void start_stack_region();
 	void end_stack_region();
 
+	void push_direct(Reference* ref);
+	void push(Value* val);
+
 	auto null() -> Null*;
 	auto new_integer(int) -> gc_ptr<Integer>;
 	auto new_float(float) -> gc_ptr<Float>;

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -38,10 +38,6 @@ struct Environment {
 	    : m_gc {gc}
 	    , m_scope {&m_global_scope} {}
 
-	Scope* new_scope();
-	Scope* new_nested_scope();
-	void end_scope();
-
 	void save_return_value(Value*);
 	Value* fetch_return_value();
 

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -28,6 +28,12 @@ struct Environment {
 	Scope* m_scope;
 	Value* m_return_value {nullptr};
 
+	int m_frame_ptr {0};
+	int m_stack_ptr {0};
+	std::vector<Reference*> m_stack;
+	std::vector<int> m_fp_stack;
+	std::vector<int> m_sp_stack;
+
 	Environment(GC* gc)
 	    : m_gc {gc}
 	    , m_scope {&m_global_scope} {}

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -158,14 +158,20 @@ gc_ptr<Value> eval_call_function(
 	e.m_fp_stack.push_back(e.m_frame_ptr);
 	e.m_sp_stack.push_back(e.m_stack_ptr);
 	e.m_frame_ptr = e.m_stack_ptr;
+	e.m_stack.resize(e.m_stack_ptr);
+
+	for (auto& kv : callee->m_captures) {
+		assert(kv.second);
+		assert(kv.second->type() == ValueTag::Reference);
+		e.m_stack.push_back(static_cast<Reference*>(kv.second));
+		e.m_stack_ptr += 1;
+	}
 
 	// TODO: error handling ?
 	assert(callee->m_def->m_args.size() == args.size());
 
 	e.new_scope();
 	int arg_count = callee->m_def->m_args.size();
-	e.m_stack.resize(e.m_stack_ptr);
-	e.m_stack.reserve(e.m_stack_ptr + arg_count);
 	for (int i = 0; i < int(arg_count); ++i) {
 		auto& argdecl = callee->m_def->m_args[i];
 		assert(e.m_stack_ptr - e.m_frame_ptr == argdecl.m_frame_offset);

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -13,8 +13,7 @@ namespace Interpreter {
 
 gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
 	auto ref = e.new_reference(e.null());
-	e.m_stack.push_back(ref.get());
-	e.m_stack_ptr += 1;
+	e.push_direct(ref.get());
 	if (ast->m_value) {
 		auto value = eval(ast->m_value.get(), e);
 		auto unboxed_val = unboxed(value.get());
@@ -158,8 +157,7 @@ gc_ptr<Value> eval_call_function(
 	for (auto& kv : callee->m_captures) {
 		assert(kv.second);
 		assert(kv.second->type() == ValueTag::Reference);
-		e.m_stack.push_back(static_cast<Reference*>(kv.second));
-		e.m_stack_ptr += 1;
+		e.push_direct(static_cast<Reference*>(kv.second));
 	}
 
 	// TODO: error handling ?
@@ -169,11 +167,7 @@ gc_ptr<Value> eval_call_function(
 	for (int i = 0; i < int(arg_count); ++i) {
 		auto& argdecl = callee->m_def->m_args[i];
 		assert(e.m_stack_ptr - e.m_frame_ptr == argdecl.m_frame_offset);
-
-		auto val = unboxed(args[i].get());
-		auto ref = e.new_reference(val);
-		e.m_stack.push_back(ref.get());
-		e.m_stack_ptr += 1;
+		e.push(unboxed(args[i].get()));
 	}
 	// NOTE: we could `args.clear()` at this point. Is it worth doing?
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -27,7 +27,7 @@ gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
 gc_ptr<Value> eval(TypedAST::DeclarationList* ast, Environment& e) {
 	for (auto& decl : ast->m_declarations) {
 		auto ref = e.new_reference(e.null());
-		e.global_declare(decl->identifier_text(), ref.get());
+		e.global_declare_direct(decl->identifier_text(), ref.get());
 		auto value = eval(decl->m_value.get(), e);
 		ref->m_value = value.get();
 	}

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -27,7 +27,7 @@ gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
 gc_ptr<Value> eval(TypedAST::DeclarationList* ast, Environment& e) {
 	for (auto& decl : ast->m_declarations) {
 		auto ref = e.new_reference(e.null());
-		e.direct_declare(decl->identifier_text(), ref.get());
+		e.global_declare(decl->identifier_text(), ref.get());
 		auto value = eval(decl->m_value.get(), e);
 		ref->m_value = value.get();
 	}
@@ -114,7 +114,7 @@ gc_ptr<Value> eval(TypedAST::Identifier* ast, Environment& e) {
 		return e.m_stack[e.m_frame_ptr + ast->m_frame_offset];
 	} else {
 		// slow path
-		return e.access(ast->text());
+		return e.global_access(ast->text());
 	}
 };
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -279,7 +279,7 @@ gc_ptr<Value> eval(TypedAST::FunctionLiteral* ast, Environment& e) {
 	auto result = e.new_function(ast, {});
 
 	for (auto const& identifier : ast->m_captures) {
-		result->m_captures[identifier] = e.m_scope->access(identifier);
+		result->m_captures[identifier.first] = e.m_scope->access(identifier.first);
 	}
 
 	return result;

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -13,9 +13,9 @@ namespace Interpreter {
 
 gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
 	e.m_stack.resize(e.m_stack_ptr);
-	e.declare(ast->identifier_text(), e.null());
-	auto* ref = e.access(ast->identifier_text());
-	e.m_stack.push_back(ref);
+	auto ref = e.new_reference(e.null());
+	e.direct_declare(ast->identifier_text(), ref.get());
+	e.m_stack.push_back(ref.get());
 	e.m_stack_ptr += 1;
 	if (ast->m_value) {
 		auto value = eval(ast->m_value.get(), e);

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -1,5 +1,6 @@
 #include "execute.hpp"
 
+#include "../compute_offsets.hpp"
 #include "../ct_eval.hpp"
 #include "../desugar.hpp"
 #include "../match_identifiers.hpp"
@@ -53,6 +54,7 @@ ExitStatusTag execute(std::string const& source, bool dump_ast, Runner* runner) 
 	TypeChecker::metacheck(top_level.get(), tc);
 	top_level = TypeChecker::ct_eval(std::move(top_level), tc);
 	TypeChecker::typecheck(top_level.get(), tc);
+	TypeChecker::compute_offsets(top_level.get(), 0);
 
 	GC gc;
 	Environment env = {&gc};

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -366,52 +366,52 @@ Value* value_assign(ArrayType v, Environment& e) {
 }
 
 void declare_native_functions(Environment& env) {
-	env.declare(
+	env.global_declare(
 	    "print", env.new_native_function(static_cast<NativeFunctionType*>(&print)));
 
-	env.declare(
+	env.global_declare(
 	    "array_append",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&array_append)));
 
-	env.declare(
+	env.global_declare(
 	    "array_extend",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&array_extend)));
 
-	env.declare(
+	env.global_declare(
 	    "size", env.new_native_function(static_cast<NativeFunctionType*>(&size)));
 
-	env.declare(
+	env.global_declare(
 	    "array_join",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&array_join)));
 
-	env.declare(
+	env.global_declare(
 	    "array_at",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&array_at)));
 
-	env.declare(
+	env.global_declare(
 	    "+", env.new_native_function(static_cast<NativeFunctionType*>(&value_add)));
-	env.declare(
+	env.global_declare(
 	    "-", env.new_native_function(static_cast<NativeFunctionType*>(&value_sub)));
-	env.declare(
+	env.global_declare(
 	    "*", env.new_native_function(static_cast<NativeFunctionType*>(&value_mul)));
-	env.declare(
+	env.global_declare(
 	    "/", env.new_native_function(static_cast<NativeFunctionType*>(&value_div)));
-	env.declare(
+	env.global_declare(
 	    "<",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&value_less)));
-	env.declare(
+	env.global_declare(
 	    "=",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&value_assign)));
-	env.declare(
+	env.global_declare(
 	    "==",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&value_equals)));
-	env.declare(
+	env.global_declare(
 	    "^^",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&value_logicxor)));
-	env.declare(
+	env.global_declare(
 	    "&&",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&value_logicand)));
-	env.declare(
+	env.global_declare(
 	    "||",
 	    env.new_native_function(static_cast<NativeFunctionType*>(&value_logicor)));
 }

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -46,22 +46,20 @@ namespace TypeChecker {
 	ast->m_surrounding_function = env.current_function();
 
 	env.current_top_level_declaration()->m_references.insert(declaration);
-	TypedAST::FunctionLiteral* surrounding_function =
-	    declaration->m_surrounding_function;
 
-	if(!surrounding_function){
+	if (!declaration->m_surrounding_function) {
 		ast->m_origin = TypedAST::Identifier::Origin::Global;
-	} else if(surrounding_function != env.current_function()) {
+	} else if (declaration->m_surrounding_function != ast->m_surrounding_function) {
 		ast->m_origin = TypedAST::Identifier::Origin::Capture;
 	} else {
 		ast->m_origin = TypedAST::Identifier::Origin::Local;
 	}
 
 	// dont capture globals
-	if (surrounding_function) {
+	if (declaration->m_surrounding_function) {
 		for (int i = env.m_function_stack.size(); i--;) {
 			auto* func = env.m_function_stack[i];
-			if (func == surrounding_function)
+			if (func == declaration->m_surrounding_function)
 				break;
 			func->m_captures.insert({ast->text(), {declaration}});
 		}

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -43,6 +43,8 @@ namespace TypeChecker {
 	}
 
 	ast->m_declaration = declaration;
+	ast->m_surrounding_function = env.current_function();
+
 	env.current_top_level_declaration()->m_references.insert(declaration);
 	TypedAST::FunctionLiteral* surrounding_function =
 	    declaration->m_surrounding_function;
@@ -61,7 +63,7 @@ namespace TypeChecker {
 			auto* func = env.m_function_stack[i];
 			if (func == surrounding_function)
 				break;
-			func->m_captures.insert(ast->text());
+			func->m_captures.insert({ast->text(), {declaration}});
 		}
 	}
 
@@ -97,6 +99,8 @@ namespace TypeChecker {
 
 [[nodiscard]] ErrorReport match_identifiers(
     TypedAST::FunctionLiteral* ast, Frontend::CompileTimeEnvironment& env) {
+
+	ast->m_surrounding_function = env.current_function();
 
 	env.enter_function(ast);
 	env.new_nested_scope(); // NOTE: this is nested because of lexical scoping

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -47,6 +47,14 @@ namespace TypeChecker {
 	TypedAST::FunctionLiteral* surrounding_function =
 	    declaration->m_surrounding_function;
 
+	if(!surrounding_function){
+		ast->m_origin = TypedAST::Identifier::Origin::Global;
+	} else if(surrounding_function != env.current_function()) {
+		ast->m_origin = TypedAST::Identifier::Origin::Capture;
+	} else {
+		ast->m_origin = TypedAST::Identifier::Origin::Local;
+	}
+
 	// dont capture globals
 	if (surrounding_function) {
 		for (int i = env.m_function_stack.size(); i--;) {

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -47,6 +47,8 @@ struct Declaration : public TypedAST {
 	bool m_is_polymorphic {false};
 	PolyId m_decl_type;
 
+	int m_frame_offset {-1};
+
 	// nullptr means global
 	FunctionLiteral* m_surrounding_function {nullptr};
 
@@ -153,8 +155,13 @@ struct FunctionLiteral : public TypedAST {
 
 // the ast_vtype must be computed
 struct Identifier : public TypedAST {
+	enum class Origin { Global, Capture, Local };
+
 	Token const* m_token;
 	Declaration* m_declaration {nullptr};
+
+	Origin m_origin;
+	int m_frame_offset {-1};
 
 	InternedString const& text() {
 		return m_token->m_text;

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 #include "token.hpp"
@@ -144,10 +145,17 @@ struct DictionaryLiteral : public TypedAST {
 };
 
 struct FunctionLiteral : public TypedAST {
+	struct CaptureData {
+		Declaration* outer_declaration{nullptr};
+		int outer_frame_offset{-1};
+		int inner_frame_offset{-1};
+	};
+
 	MonoId m_return_type;
 	Own<TypedAST> m_body;
 	std::vector<Declaration> m_args;
-	std::unordered_set<InternedString> m_captures;
+	std::unordered_map<InternedString, CaptureData> m_captures;
+	FunctionLiteral* m_surrounding_function {nullptr};
 
 	FunctionLiteral()
 	    : TypedAST {TypedASTTag::FunctionLiteral} {}
@@ -159,6 +167,7 @@ struct Identifier : public TypedAST {
 
 	Token const* m_token;
 	Declaration* m_declaration {nullptr};
+	FunctionLiteral* m_surrounding_function {nullptr};
 
 	Origin m_origin;
 	int m_frame_offset {-1};


### PR DESCRIPTION
I figured that, instead of spending more work on optimizing the dictionary in Interpreter::Environment, we should do something to forego it entirely, just like in compiled languages.

This is a first pass on that concept.