### PR TITLE
Have the GC manage its own memory

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,7 +37,10 @@ ITPR_OBJNAMES := \
 	interpreter/gc_ptr.o \
 	interpreter/value.o \
 	interpreter/native.o \
-	interpreter/utils.o
+	interpreter/utils.o \
+	interpreter/garbage_collector/block.o \
+	interpreter/garbage_collector/heap.o \
+	interpreter/garbage_collector/slot.o
 
 TEST_OBJNAMES := \
 	test/tester.o \
@@ -82,6 +85,7 @@ $(BINDIR):
 $(OBJDIR):
 	mkdir $(OBJDIR)
 	mkdir $(OBJDIR)/interpreter
+	mkdir $(OBJDIR)/interpreter/garbage_collector
 	mkdir $(OBJDIR)/test
 
 include $(ENTRY_POINTS:.o=.d)

--- a/src/interpreter/garbage_collector/block.cpp
+++ b/src/interpreter/garbage_collector/block.cpp
@@ -1,0 +1,56 @@
+#include "block.hpp"
+
+#include <cassert>
+
+namespace Interpreter {
+namespace GarbageCollector {
+
+struct FreeList : public Slot {
+	FreeList* next;
+};
+
+Block::Block(int slot_size)
+    : m_block {std::make_unique<Buffer>()}
+    , m_slot_size {slot_size} {
+	m_block->fill(0);
+
+	assert(slot_size >= sizeof(FreeList));
+	for (int i = 0; i < slot_count(); ++i) {
+		auto node = static_cast<FreeList*>(slot(i));
+		node->next = (i == slot_count() - 1)
+		                 ? nullptr
+		                 : static_cast<FreeList*>(slot(i + 1));
+	}
+	m_freelist = static_cast<FreeList*>(slot(0));
+}
+
+Slot* Block::allocate() {
+	if (!m_freelist)
+		return nullptr;
+	return std::exchange(m_freelist, m_freelist->next);
+}
+
+void Block::free(Slot* s) {
+	auto node = reinterpret_cast<FreeList*>(s);
+	node->next = m_freelist;
+	m_freelist = node;
+}
+
+bool Block::contains(Slot* s) {
+	return slot(0) <= s && s < slot(slot_count());
+}
+
+int Block::slot_count() const {
+	return block_size / m_slot_size;
+}
+
+int Block::slot_size() const {
+	return m_slot_size;
+}
+
+Slot* Block::slot(size_t index) {
+	return reinterpret_cast<Slot*>(&(*m_block)[index * m_slot_size]);
+}
+
+} // namespace GarbageCollector
+} // namespace Interpreter

--- a/src/interpreter/garbage_collector/block.hpp
+++ b/src/interpreter/garbage_collector/block.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "slot.hpp"
+
+#include <array>
+#include <memory>
+
+namespace Interpreter {
+namespace GarbageCollector {
+
+struct FreeList;
+
+struct Block {
+	using Byte = unsigned char;
+
+	constexpr static int block_size = 4 * 1024; // 4kiB
+	using Buffer = std::array<Byte, block_size>;
+
+	explicit Block(int slot_size);
+
+	Slot* allocate();
+	void free(Slot* s);
+	bool contains(Slot* s);
+
+	int slot_count() const;
+	int slot_size() const;
+
+  private:
+	Slot* slot(size_t index);
+
+	FreeList* m_freelist;
+	std::unique_ptr<Buffer> m_block;
+	int m_slot_size;
+};
+
+} // namespace GarbageCollector
+} // namespace Interpreter

--- a/src/interpreter/garbage_collector/heap.cpp
+++ b/src/interpreter/garbage_collector/heap.cpp
@@ -1,0 +1,27 @@
+#include "heap.hpp"
+
+namespace Interpreter {
+namespace GarbageCollector {
+
+Heap::Heap() {
+	m_allocators.emplace_back(16);
+	m_allocators.emplace_back(32);
+	m_allocators.emplace_back(128);
+	m_allocators.emplace_back(512);
+}
+
+void Heap::free(Slot* s) {
+	for (auto& allocator : m_allocators)
+		if (allocator.contains(s))
+			allocator.free(s);
+}
+
+Slot* Heap::allocate_impl(size_t size) {
+	for (auto& allocator : m_allocators)
+		if (allocator.slot_size() >= size)
+			return allocator.allocate();
+	return nullptr;
+}
+
+} // namespace GarbageCollector
+} // namespace Interpreter

--- a/src/interpreter/garbage_collector/heap.hpp
+++ b/src/interpreter/garbage_collector/heap.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "block.hpp"
+
+#include <vector>
+
+namespace Interpreter {
+namespace GarbageCollector {
+
+struct Heap {
+	Heap();
+
+	template <typename T, typename... Args>
+	T* allocate(Args&&... args) {
+		static_assert(
+		    std::is_base_of<Slot, T>::value,
+		    "You must inherit from Slot to allocate from here");
+		Slot* memory = allocate_impl(sizeof(T));
+		return new (memory) T(std::forward<Args>(args)...);
+	}
+
+	void free(Slot* s);
+
+  private:
+	Slot* allocate_impl(size_t size);
+
+	std::vector<Block> m_allocators;
+};
+
+struct Integer : public Slot {
+	int m_value;
+	Integer() {}
+	Integer(int value)
+	    : m_value(value) {}
+	int value() const {
+		return m_value;
+	}
+};
+
+} // namespace GarbageCollector
+} // namespace Interpreter

--- a/src/interpreter/garbage_collector/slot.cpp
+++ b/src/interpreter/garbage_collector/slot.cpp
@@ -1,0 +1,1 @@
+#include "slot.hpp"

--- a/src/interpreter/garbage_collector/slot.hpp
+++ b/src/interpreter/garbage_collector/slot.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace Interpreter {
+namespace GarbageCollector {
+
+// derive from this class if you want your type to be GC-able
+struct Slot {
+	bool m_occupied {false};
+	bool m_marked {false};
+
+	virtual ~Slot() = default;
+};
+
+} // namespace GarbageCollector
+} // namespace Intepreter


### PR DESCRIPTION
Right now, we put every object on its own system-level allocation (i.e. we use `new T` to allocate it). Instead, we could have our own slab block allocators that put many objects on the same buffer. This should be a lot more efficient.

I started working towards that, but it's still in very early stages.