### PR TITLE
Compute number and integer literal values during ast conversion

### DIFF
--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -35,11 +35,11 @@ gc_ptr<Value> eval(TypedAST::DeclarationList* ast, Environment& e) {
 };
 
 gc_ptr<Value> eval(TypedAST::NumberLiteral* ast, Environment& e) {
-	return e.new_float(std::stof(ast->text()));
+	return e.new_float(ast->value());
 }
 
 gc_ptr<Value> eval(TypedAST::IntegerLiteral* ast, Environment& e) {
-	return e.new_integer(std::stoi(ast->text()));
+	return e.new_integer(ast->value());
 }
 
 gc_ptr<Value> eval(TypedAST::StringLiteral* ast, Environment& e) {

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -10,12 +10,14 @@ namespace TypedAST {
 
 TypedAST* convert_ast(AST::IntegerLiteral* ast, Allocator& alloc) {
 	auto typed_integer = alloc.make<IntegerLiteral>();
+	typed_integer->m_value = std::stoi(ast->text());
 	typed_integer->m_token = ast->m_token;
 	return typed_integer;
 }
 
 TypedAST* convert_ast(AST::NumberLiteral* ast, Allocator& alloc) {
 	auto typed_number = alloc.make<NumberLiteral>();
+	typed_number->m_value = std::stof(ast->text());
 	typed_number->m_token = ast->m_token;
 	return typed_number;
 }

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -76,7 +76,12 @@ struct DeclarationList : public TypedAST {
 // las estructuras como declaration list, index expression, block, if, for no tienen
 // tipo de valor asociado
 struct NumberLiteral : public TypedAST {
+	float m_value;
 	Token const* m_token;
+
+	float value() const {
+		return m_value;
+	}
 
 	std::string const& text() {
 		return m_token->m_text.str();
@@ -87,7 +92,12 @@ struct NumberLiteral : public TypedAST {
 };
 
 struct IntegerLiteral : public TypedAST {
+	int m_value;
 	Token const* m_token;
+
+	int value() const {
+		return m_value;
+	}
 
 	std::string const& text() {
 		return m_token->m_text.str();


### PR DESCRIPTION
It's not like string to number conversions are super slow or anything, but it's plain wasteful not to do the conversions statically.

Of course, I measured.

Timings before:

    0.067384 +- 0.000311 seconds

Timings after:

    0.063496 +- 0.000713 seconds

It is a 5.77% improvement on the benchmark I've been using.