### PR TITLE
Use the stack more

### DIFF
--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -132,10 +132,9 @@ void Environment::push_boolean(bool b) {
 	run_gc_if_needed();
 }
 
-gc_ptr<String> Environment::new_string(std::string s) {
-	auto result = m_gc->new_string(std::move(s));
+void Environment::push_string(std::string s) {
+	push(m_gc->new_string_raw(std::move(s)));
 	run_gc_if_needed();
-	return result;
 }
 
 gc_ptr<Array> Environment::new_list(ArrayType elements) {

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -117,20 +117,18 @@ Null* Environment::null() {
 	return m_gc->null();
 }
 
-gc_ptr<Integer> Environment::new_integer(int i) {
-	auto result = m_gc->new_integer(i);
+void Environment::push_integer(int i) {
+	push(m_gc->new_integer_raw(i));
 	run_gc_if_needed();
-	return result;
 }
 
-gc_ptr<Float> Environment::new_float(float f) {
-	auto result = m_gc->new_float(f);
+void Environment::push_float(float f) {
+	push(m_gc->new_float_raw(f));
 	run_gc_if_needed();
-	return result;
 }
 
 void Environment::push_boolean(bool b) {
-	m_stack.push_back(m_gc->new_boolean_raw(b));
+	push(m_gc->new_boolean_raw(b));
 	run_gc_if_needed();
 }
 

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -86,6 +86,13 @@ void Environment::push(Value* ref){
 	m_stack_ptr += 1;
 }
 
+gc_ptr<Value> Environment::pop(){
+	gc_ptr<Value> result = {m_stack.back()};
+	m_stack.pop_back();
+	m_stack_ptr -= 1;
+	return result;
+}
+
 void Environment::run_gc() {
 	m_gc->unmark_all();
 	m_gc->mark_roots();

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -129,10 +129,9 @@ gc_ptr<Float> Environment::new_float(float f) {
 	return result;
 }
 
-gc_ptr<Boolean> Environment::new_boolean(bool b) {
-	auto result = m_gc->new_boolean(b);
+void Environment::push_boolean(bool b) {
+	m_stack.push_back(m_gc->new_boolean_raw(b));
 	run_gc_if_needed();
-	return result;
 }
 
 gc_ptr<String> Environment::new_string(std::string s) {

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -52,8 +52,8 @@ struct Environment {
 	void start_stack_region();
 	void end_stack_region();
 
-	void push_direct(Reference* ref);
 	void push(Value* val);
+	gc_ptr<Value> pop();
 
 	auto null() -> Null*;
 	auto new_integer(int) -> gc_ptr<Integer>;

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -56,8 +56,8 @@ struct Environment {
 	gc_ptr<Value> pop();
 
 	auto null() -> Null*;
-	auto new_integer(int) -> gc_ptr<Integer>;
-	auto new_float(float) -> gc_ptr<Float>;
+	void push_integer(int);
+	void push_float(float);
 	void push_boolean(bool);
 	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -58,7 +58,7 @@ struct Environment {
 	auto null() -> Null*;
 	auto new_integer(int) -> gc_ptr<Integer>;
 	auto new_float(float) -> gc_ptr<Float>;
-	auto new_boolean(bool) -> gc_ptr<Boolean>;
+	void push_boolean(bool);
 	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_object(ObjectType) -> gc_ptr<Object>;

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -59,7 +59,7 @@ struct Environment {
 	void push_integer(int);
 	void push_float(float);
 	void push_boolean(bool);
-	auto new_string(std::string) -> gc_ptr<String>;
+	void push_string(std::string);
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_object(ObjectType) -> gc_ptr<Object>;
 	auto new_dictionary(DictionaryType) -> gc_ptr<Dictionary>;

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -48,7 +48,7 @@ void eval(TypedAST::IntegerLiteral* ast, Environment& e) {
 }
 
 void eval(TypedAST::StringLiteral* ast, Environment& e) {
-	e.push(e.new_string(ast->text()).get());
+	e.push_string(ast->text());
 };
 
 void eval(TypedAST::BooleanLiteral* ast, Environment& e) {

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -19,54 +19,54 @@ static bool is_expression (TypedAST::TypedAST* ast){
 	return tag_idx < static_cast<int>(TypedASTTag::Block);
 }
 
-gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
+void eval(TypedAST::Declaration* ast, Environment& e) {
 	auto ref = e.new_reference(e.null());
 	e.push(ref.get());
 	if (ast->m_value) {
-		auto value = eval(ast->m_value, e);
-		auto unboxed_val = unboxed(value.get());
-		ref->m_value = unboxed_val;
+		eval(ast->m_value, e);
+		auto value = e.pop();
+		ref->m_value = unboxed(value.get());
 	}
-	return e.null();
 };
 
-gc_ptr<Value> eval(TypedAST::DeclarationList* ast, Environment& e) {
+void eval(TypedAST::DeclarationList* ast, Environment& e) {
 	for (auto& decl : ast->m_declarations) {
 		auto ref = e.new_reference(e.null());
 		e.global_declare_direct(decl.identifier_text(), ref.get());
-		auto value = eval(decl.m_value, e);
+		eval(decl.m_value, e);
+		auto value = e.pop();
 		ref->m_value = value.get();
 	}
-	return e.null();
 };
 
-gc_ptr<Value> eval(TypedAST::NumberLiteral* ast, Environment& e) {
-	return e.new_float(std::stof(ast->text()));
+void eval(TypedAST::NumberLiteral* ast, Environment& e) {
+	e.push(e.new_float(std::stof(ast->text())).get());
 }
 
-gc_ptr<Value> eval(TypedAST::IntegerLiteral* ast, Environment& e) {
-	return e.new_integer(std::stoi(ast->text()));
+void eval(TypedAST::IntegerLiteral* ast, Environment& e) {
+	e.push(e.new_integer(std::stoi(ast->text())).get());
 }
 
-gc_ptr<Value> eval(TypedAST::StringLiteral* ast, Environment& e) {
-	return e.new_string(ast->text());
+void eval(TypedAST::StringLiteral* ast, Environment& e) {
+	e.push(e.new_string(ast->text()).get());
 };
 
-gc_ptr<Value> eval(TypedAST::BooleanLiteral* ast, Environment& e) {
+void eval(TypedAST::BooleanLiteral* ast, Environment& e) {
 	bool b = ast->m_token->m_type == TokenTag::KEYWORD_TRUE;
-	return e.new_boolean(b);
+	e.push(e.new_boolean(b).get());
 };
 
-gc_ptr<Value> eval(TypedAST::NullLiteral* ast, Environment& e) {
-	return e.null();
+void eval(TypedAST::NullLiteral* ast, Environment& e) {
+	e.push(e.null());
 };
 
-gc_ptr<Value> eval(TypedAST::ObjectLiteral* ast, Environment& e) {
+void eval(TypedAST::ObjectLiteral* ast, Environment& e) {
 	auto result = e.new_object({});
 
 	for (auto& decl : ast->m_body) {
 		if (decl.m_value) {
-			auto value = eval(decl.m_value, e);
+			eval(decl.m_value, e);
+			auto value = e.pop();
 			result->m_value[decl.identifier_text()] = value.get();
 		} else {
 			std::cerr << "ERROR: declaration in object must have a value";
@@ -74,15 +74,16 @@ gc_ptr<Value> eval(TypedAST::ObjectLiteral* ast, Environment& e) {
 		}
 	}
 
-	return result;
+	e.push(result.get());
 }
 
-gc_ptr<Value> eval(TypedAST::DictionaryLiteral* ast, Environment& e) {
+void eval(TypedAST::DictionaryLiteral* ast, Environment& e) {
 	auto result = e.new_dictionary({});
 
 	for (auto& decl : ast->m_body) {
 		if (decl.m_value) {
-			auto value = eval(decl.m_value, e);
+			eval(decl.m_value, e);
+			auto value = e.pop();
 			result->m_value[decl.identifier_text().str()] = value.get();
 		} else {
 			std::cerr << "ERROR: declaration in dictionary must have value";
@@ -90,66 +91,60 @@ gc_ptr<Value> eval(TypedAST::DictionaryLiteral* ast, Environment& e) {
 		}
 	}
 
-	return result;
+	e.push(result.get());
 }
 
-gc_ptr<Value> eval(TypedAST::ArrayLiteral* ast, Environment& e) {
+void eval(TypedAST::ArrayLiteral* ast, Environment& e) {
 	auto result = e.new_list({});
 	result->m_value.reserve(ast->m_elements.size());
 	for (auto& element : ast->m_elements) {
-		auto value = eval(element, e);
+		eval(element, e);
+		auto value = e.pop();
 		result->m_value.push_back(unboxed(value.get()));
 	}
-	return result;
-};
+	e.push(result.get());
+}
 
-gc_ptr<Value> eval(TypedAST::Identifier* ast, Environment& e) {
+void eval(TypedAST::Identifier* ast, Environment& e) {
 	if (ast->m_origin == TypedAST::Identifier::Origin::Local ||
 	    ast->m_origin == TypedAST::Identifier::Origin::Capture) {
 		if (ast->m_frame_offset == INT_MIN) {
 			std::cerr << "MISSING LAYOUT FOR IDENTIFIER " << ast->text() << "\n";
 			assert(0 && "MISSING LAYOUT FOR AN IDENTIFIER");
 		}
-		return e.m_stack[e.m_frame_ptr + ast->m_frame_offset];
+		e.push(e.m_stack[e.m_frame_ptr + ast->m_frame_offset]);
 	} else {
-		return e.global_access(ast->text());
+		e.push(e.global_access(ast->text()));
 	}
 };
 
-gc_ptr<Value> eval(TypedAST::Block* ast, Environment& e) {
-
+void eval(TypedAST::Block* ast, Environment& e) {
 	e.start_stack_region();
-
 	for (auto stmt : ast->m_body) {
 		eval(stmt, e);
+		if (is_expression(stmt))
+			e.pop();
 		if (e.m_return_value)
 			break;
 	}
-
 	e.end_stack_region();
-
-	return e.null();
 };
 
-gc_ptr<Value> eval(TypedAST::ReturnStatement* ast, Environment& e) {
+void eval(TypedAST::ReturnStatement* ast, Environment& e) {
 	// TODO: proper error handling
-	auto value = eval(ast->m_value, e);
-	auto returning = unboxed(value.get());
-	assert(returning);
-
-	e.save_return_value(returning);
-	return e.null();
+	eval(ast->m_value, e);
+	auto value = e.pop();
+	e.save_return_value(unboxed(value.get()));
 };
 
 auto is_callable_value(Value* v) -> bool {
 	if (!v)
 		return false;
-
 	auto type = v->type();
 	return type == ValueTag::Function || type == ValueTag::NativeFunction;
 }
 
-gc_ptr<Value> eval_call_function(
+void eval_call_function(
     gc_ptr<Function> callee, int arg_count, Environment& e) {
 
 	// TODO: error handling ?
@@ -161,23 +156,22 @@ gc_ptr<Value> eval_call_function(
 		e.push(kv.second);
 	}
 
-	auto* body = dynamic_cast<TypedAST::Block*>(callee->m_def->m_body);
-	assert(body);
+	assert(callee->m_def->m_body->type() == TypedASTTag::Block);
+	auto* body = static_cast<TypedAST::Block*>(callee->m_def->m_body);
 	eval(body, e);
-
-	return e.fetch_return_value();
 }
 
-gc_ptr<Value> eval_call_native_function(
+void eval_call_native_function(
     gc_ptr<NativeFunction> callee, int arg_count, Environment& e) {
 	// TODO: don't do this conversion
 	Span<Value*> args = {&e.m_stack[e.m_frame_ptr - arg_count], arg_count};
-	return callee->m_fptr(args, e);
+	e.save_return_value(callee->m_fptr(args, e));
 }
 
-gc_ptr<Value> eval(TypedAST::CallExpression* ast, Environment& e) {
+void eval(TypedAST::CallExpression* ast, Environment& e) {
 
-	auto value = eval(ast->m_callee, e);
+	eval(ast->m_callee, e);
+	gc_ptr<Value> value = e.pop();
 	auto* callee = unboxed(value.get());
 	assert(callee);
 	assert(is_callable_value(callee));
@@ -190,23 +184,21 @@ gc_ptr<Value> eval(TypedAST::CallExpression* ast, Environment& e) {
 	// arguments go before the frame pointer
 	if (callee->type() == ValueTag::Function) {
 		for (auto expr : arglist) {
-			auto value = eval(expr, e);
-			e.push(e.new_reference(unboxed(value.get())).get());
+			eval(expr, e);
+			e.m_stack.back() = e.new_reference(unboxed(e.m_stack.back())).get();
 		}
 	} else {
 		for (auto expr : arglist) {
-			auto value = eval(expr, e);
-			e.push(value.get());
+			eval(expr, e);
 		}
 	}
 
 	e.start_stack_frame();
 
-	gc_ptr<Value> result = nullptr;
 	if (callee->type() == ValueTag::Function) {
-		result = eval_call_function(static_cast<Function*>(callee), arg_count, e);
+		eval_call_function(static_cast<Function*>(callee), arg_count, e);
 	} else if (callee->type() == ValueTag::NativeFunction) {
-		result = eval_call_native_function(
+		eval_call_native_function(
 		    static_cast<NativeFunction*>(callee), arg_count, e);
 	} else {
 		assert(0);
@@ -215,18 +207,20 @@ gc_ptr<Value> eval(TypedAST::CallExpression* ast, Environment& e) {
 	e.end_stack_frame();
 	e.end_stack_region();
 
-	return result;
+	e.push(e.fetch_return_value());
 };
 
-gc_ptr<Value> eval(TypedAST::IndexExpression* ast, Environment& e) {
+void eval(TypedAST::IndexExpression* ast, Environment& e) {
 	// TODO: proper error handling
 
-	auto callee_value = eval(ast->m_callee, e);
+	eval(ast->m_callee, e);
+	auto callee_value = e.pop();
 	auto* callee = unboxed(callee_value.get());
 	assert(callee);
 	assert(callee->type() == ValueTag::Array);
 
-	auto index_value = eval(ast->m_index, e);
+	eval(ast->m_index, e);
+	auto index_value = e.pop();
 	auto* index = unboxed(index_value.get());
 	assert(index);
 	assert(index->type() == ValueTag::Integer);
@@ -234,23 +228,25 @@ gc_ptr<Value> eval(TypedAST::IndexExpression* ast, Environment& e) {
 	auto* array_callee = static_cast<Array*>(callee);
 	auto* int_index = static_cast<Integer*>(index);
 
-	return array_callee->at(int_index->m_value);
+	e.push(array_callee->at(int_index->m_value));
 };
 
-gc_ptr<Value> eval(TypedAST::TernaryExpression* ast, Environment& e) {
+void eval(TypedAST::TernaryExpression* ast, Environment& e) {
 	// TODO: proper error handling
 
-	auto condition = eval(ast->m_condition, e);
+	eval(ast->m_condition, e);
+	auto condition = e.pop();
 	auto* condition_value = unboxed(condition.get());
 	assert(condition_value);
 	assert(condition_value->type() == ValueTag::Boolean);
 
-	return static_cast<Boolean*>(condition_value)->m_value
-	       ? eval(ast->m_then_expr, e)
-	       : eval(ast->m_else_expr, e);
+	if (static_cast<Boolean*>(condition_value)->m_value)
+		eval(ast->m_then_expr, e);
+	else
+		eval(ast->m_else_expr, e);
 };
 
-gc_ptr<Value> eval(TypedAST::FunctionLiteral* ast, Environment& e) {
+void eval(TypedAST::FunctionLiteral* ast, Environment& e) {
 	auto result = e.new_function(ast, {});
 
 	for (auto const& capture : ast->m_captures) {
@@ -259,11 +255,12 @@ gc_ptr<Value> eval(TypedAST::FunctionLiteral* ast, Environment& e) {
 		    e.m_stack[e.m_frame_ptr + capture.second.outer_frame_offset];
 	}
 
-	return result;
+	e.push(result.get());
 };
 
-gc_ptr<Value> eval(TypedAST::IfElseStatement* ast, Environment& e) {
-	auto condition_result = eval(ast->m_condition, e);
+void eval(TypedAST::IfElseStatement* ast, Environment& e) {
+	eval(ast->m_condition, e);
+	auto condition_result = e.pop();
 	assert(condition_result);
 
 	assert(condition_result->type() == ValueTag::Boolean);
@@ -271,23 +268,24 @@ gc_ptr<Value> eval(TypedAST::IfElseStatement* ast, Environment& e) {
 
 	if (condition_result_b->m_value) {
 		eval(ast->m_body, e);
+		if (is_expression(ast->m_body))
+			e.pop();
 	} else if (ast->m_else_body) {
 		eval(ast->m_else_body, e);
+		if (is_expression(ast->m_else_body))
+			e.pop();
 	}
-
-	return e.null();
 };
 
-gc_ptr<Value> eval(TypedAST::ForStatement* ast, Environment& e) {
-
+void eval(TypedAST::ForStatement* ast, Environment& e) {
 	e.start_stack_region();
 
 	// NOTE: this is kinda fishy. why do we assert here?
-	auto declaration = eval(&ast->m_declaration, e);
-	assert(declaration);
+	eval(&ast->m_declaration, e);
 
 	while (1) {
-		auto condition_result = eval(ast->m_condition, e);
+		eval(ast->m_condition, e);
+		auto condition_result = e.pop();
 		auto unboxed_condition_result = unboxed(condition_result.get());
 		assert(unboxed_condition_result);
 
@@ -302,19 +300,19 @@ gc_ptr<Value> eval(TypedAST::ForStatement* ast, Environment& e) {
 		if (e.m_return_value)
 			break;
 
-		// NOTE: this is kinda fishy. why do we assert here?
-		auto loop_action = eval(ast->m_action, e);
-		assert(loop_action);
+		eval(ast->m_action, e);
+		// i think this check is always true...
+		if (is_expression(ast->m_action))
+			e.pop();
 	}
 
 	e.end_stack_region();
-
-	return e.null();
 };
 
-gc_ptr<Value> eval(TypedAST::WhileStatement* ast, Environment& e) {
+void eval(TypedAST::WhileStatement* ast, Environment& e) {
 	while (1) {
-		auto condition_result = eval(ast->m_condition, e);
+		eval(ast->m_condition, e);
+		auto condition_result = e.pop();
 		auto unboxed_condition_result = unboxed(condition_result.get());
 		assert(unboxed_condition_result);
 
@@ -329,11 +327,9 @@ gc_ptr<Value> eval(TypedAST::WhileStatement* ast, Environment& e) {
 		if (e.m_return_value)
 			break;
 	}
-
-	return e.null();
 };
 
-gc_ptr<Value> eval(TypedAST::TypedAST* ast, Environment& e) {
+void eval(TypedAST::TypedAST* ast, Environment& e) {
 
 #define DISPATCH(type)                                                         \
 	case TypedASTTag::type:                                                    \
@@ -364,8 +360,6 @@ gc_ptr<Value> eval(TypedAST::TypedAST* ast, Environment& e) {
 
 	std::cerr << "@ Internal Error: unhandled case in eval:\n";
 	std::cerr << "@   - AST type is: " << typed_ast_string[(int)ast->type()] << '\n';
-
-	return nullptr;
 }
 
 } // namespace Interpreter

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -13,6 +13,12 @@
 
 namespace Interpreter {
 
+static bool is_expression (TypedAST::TypedAST* ast){
+	auto tag = ast->type();
+	auto tag_idx = static_cast<int>(tag);
+	return tag_idx < static_cast<int>(TypedASTTag::Block);
+}
+
 gc_ptr<Value> eval(TypedAST::Declaration* ast, Environment& e) {
 	auto ref = e.new_reference(e.null());
 	e.push(ref.get());

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -53,7 +53,7 @@ void eval(TypedAST::StringLiteral* ast, Environment& e) {
 
 void eval(TypedAST::BooleanLiteral* ast, Environment& e) {
 	bool b = ast->m_token->m_type == TokenTag::KEYWORD_TRUE;
-	e.push(e.new_boolean(b).get());
+	e.push_boolean(b);
 };
 
 void eval(TypedAST::NullLiteral* ast, Environment& e) {

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -40,11 +40,11 @@ void eval(TypedAST::DeclarationList* ast, Environment& e) {
 };
 
 void eval(TypedAST::NumberLiteral* ast, Environment& e) {
-	e.push(e.new_float(std::stof(ast->text())).get());
+	e.push_float(std::stof(ast->text()));
 }
 
 void eval(TypedAST::IntegerLiteral* ast, Environment& e) {
-	e.push(e.new_integer(std::stoi(ast->text())).get());
+	e.push_integer(std::stoi(ast->text()));
 }
 
 void eval(TypedAST::StringLiteral* ast, Environment& e) {

--- a/src/interpreter/eval.hpp
+++ b/src/interpreter/eval.hpp
@@ -10,6 +10,6 @@ struct TypedAST;
 
 namespace Interpreter {
 
-gc_ptr<Value> eval(TypedAST::TypedAST*, Environment&);
+void eval(TypedAST::TypedAST*, Environment&);
 
 }

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -81,7 +81,8 @@ Value* eval_expression(const std::string& expr, Environment& env) {
 	auto top_level_call = TypedAST::convert_ast(top_level_call_ast.m_result, typed_ast_allocator);
 
 	// TODO: return a gc_ptr
-	auto value = eval(top_level_call, env);
+	eval(top_level_call, env);
+	auto value = env.pop();
 	return unboxed(value.get());
 }
 

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -112,6 +112,10 @@ Boolean* GC::new_boolean_raw(bool b) {
 }
 
 gc_ptr<String> GC::new_string(std::string s) {
+	return new_string_raw(std::move(s));
+}
+
+String* GC::new_string_raw(std::string s) {
 	auto result = new String(std::move(s));
 	m_blocks.push_back(result);
 	return result;

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -94,6 +94,10 @@ gc_ptr<Float> GC::new_float(float f) {
 }
 
 gc_ptr<Boolean> GC::new_boolean(bool b) {
+	return new_boolean_raw(b);
+}
+
+Boolean* GC::new_boolean_raw(bool b) {
 	auto result = new Boolean(b);
 	m_blocks.push_back(result);
 	return result;

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -82,12 +82,20 @@ gc_ptr<Array> GC::new_list(ArrayType elements) {
 }
 
 gc_ptr<Integer> GC::new_integer(int i) {
+	return new_integer_raw(i);
+}
+
+Integer* GC::new_integer_raw(int i) {
 	auto result = new Integer(i);
 	m_blocks.push_back(result);
 	return result;
 }
 
 gc_ptr<Float> GC::new_float(float f) {
+	return new_float_raw(f);
+}
+
+Float* GC::new_float_raw(float f) {
 	auto result = new Float(f);
 	m_blocks.push_back(result);
 	return result;

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -41,6 +41,8 @@ struct GC {
 	auto new_error(std::string) -> gc_ptr<Error>;
 	auto new_reference(Value*) -> gc_ptr<Reference>;
 
+	auto new_integer_raw(int) -> Integer*;
+	auto new_float_raw(float) -> Float*;
 	auto new_boolean_raw(bool) -> Boolean*;
 };
 

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -40,6 +40,8 @@ struct GC {
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 	auto new_reference(Value*) -> gc_ptr<Reference>;
+
+	auto new_boolean_raw(bool) -> Boolean*;
 };
 
 } // namespace Interpreter

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -44,6 +44,7 @@ struct GC {
 	auto new_integer_raw(int) -> Integer*;
 	auto new_float_raw(float) -> Float*;
 	auto new_boolean_raw(bool) -> Boolean*;
+	auto new_string_raw(std::string) -> String*;
 };
 
 } // namespace Interpreter

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -41,7 +41,8 @@ int main() {
 			    auto top_level_call_ast = parse_expression("__invoke()", ta, ast_allocator);
 			    auto top_level_call = TypedAST::convert_ast(top_level_call_ast.m_result, typed_ast_allocator);
 
-			    auto result = eval(top_level_call, env);
+				eval(top_level_call, env);
+			    auto result = env.pop();
 
 			    if (result)
 				    Interpreter::print(result.get());

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -1,5 +1,6 @@
 #include "../span.hpp"
 #include "environment.hpp"
+#include "garbage_collector.hpp"
 #include "utils.hpp"
 #include "value.hpp"
 #include "value_tag.hpp"
@@ -93,7 +94,7 @@ Value* array_at(ArgsType v, Environment& e) {
 	Array* array = static_cast<Array*>(unboxed(v[0]));
 	Integer* index = static_cast<Integer*>(unboxed(v[1]));
 	assert(index->m_value >= 0);
-	assert(index->m_value <  array->m_value.size());
+	assert(index->m_value < array->m_value.size());
 	return array->m_value[index->m_value];
 }
 
@@ -225,10 +226,9 @@ Value* value_logicand(ArgsType v, Environment& e) {
 	auto* lhs_val = unboxed(lhs);
 	auto* rhs_val = unboxed(rhs);
 
-	if (lhs_val->type() == ValueTag::Boolean and
-	    rhs_val->type() == ValueTag::Boolean)
-		return e
-		    .new_boolean(
+	if (lhs_val->type() == ValueTag::Boolean and rhs_val->type() == ValueTag::Boolean)
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<Boolean*>(lhs_val)->m_value and
 		        static_cast<Boolean*>(rhs_val)->m_value)
 		    .get();
@@ -244,10 +244,9 @@ Value* value_logicor(ArgsType v, Environment& e) {
 	auto* lhs_val = unboxed(lhs);
 	auto* rhs_val = unboxed(rhs);
 
-	if (lhs_val->type() == ValueTag::Boolean and
-	    rhs_val->type() == ValueTag::Boolean)
-		return e
-		    .new_boolean(
+	if (lhs_val->type() == ValueTag::Boolean and rhs_val->type() == ValueTag::Boolean)
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<Boolean*>(lhs_val)->m_value or
 		        static_cast<Boolean*>(rhs_val)->m_value)
 		    .get();
@@ -263,10 +262,9 @@ Value* value_logicxor(ArgsType v, Environment& e) {
 	auto* lhs_val = unboxed(lhs);
 	auto* rhs_val = unboxed(rhs);
 
-	if (lhs_val->type() == ValueTag::Boolean and
-	    rhs_val->type() == ValueTag::Boolean)
-		return e
-		    .new_boolean(
+	if (lhs_val->type() == ValueTag::Boolean and rhs_val->type() == ValueTag::Boolean)
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<Boolean*>(lhs_val)->m_value !=
 		        static_cast<Boolean*>(rhs_val)->m_value)
 		    .get();
@@ -286,28 +284,28 @@ Value* value_equals(ArgsType v, Environment& e) {
 
 	switch (lhs_val->type()) {
 	case ValueTag::Null:
-		return e.new_boolean(true).get();
+		return e.m_gc->new_boolean(true).get();
 	case ValueTag::Integer:
-		return e
-		    .new_boolean(
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<Integer*>(lhs_val)->m_value ==
 		        static_cast<Integer*>(rhs_val)->m_value)
 		    .get();
 	case ValueTag::Float:
-		return e
-		    .new_boolean(
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<Float*>(lhs_val)->m_value ==
 		        static_cast<Float*>(rhs_val)->m_value)
 		    .get();
 	case ValueTag::String:
-		return e
-		    .new_boolean(
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<String*>(lhs_val)->m_value ==
 		        static_cast<String*>(rhs_val)->m_value)
 		    .get();
 	case ValueTag::Boolean:
-		return e
-		    .new_boolean(
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<Boolean*>(lhs_val)->m_value ==
 		        static_cast<Boolean*>(rhs_val)->m_value)
 		    .get();
@@ -330,20 +328,20 @@ Value* value_less(ArgsType v, Environment& e) {
 
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
-		return e
-		    .new_boolean(
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<Integer*>(lhs_val)->m_value <
 		        static_cast<Integer*>(rhs_val)->m_value)
 		    .get();
 	case ValueTag::Float:
-		return e
-		    .new_boolean(
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<Float*>(lhs_val)->m_value <
 		        static_cast<Float*>(rhs_val)->m_value)
 		    .get();
 	case ValueTag::String:
-		return e
-		    .new_boolean(
+		return e.m_gc
+		    ->new_boolean(
 		        static_cast<String*>(lhs_val)->m_value <
 		        static_cast<String*>(rhs_val)->m_value)
 		    .get();

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -59,7 +59,7 @@ Value* size(ArgsType v, Environment& e) {
 	Array* array = static_cast<Array*>(unboxed(v[0]));
 
 	// TODO: don't get()
-	return e.new_integer(array->m_value.size()).get();
+	return e.m_gc->new_integer(array->m_value.size()).get();
 }
 
 // array_join(array, string) returns a string with
@@ -112,14 +112,14 @@ Value* value_add(ArgsType v, Environment& e) {
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
 		//TODO: don't get()
-		return e
-		    .new_integer(
+		return e.m_gc
+		    ->new_integer(
 		        static_cast<Integer*>(lhs_val)->m_value +
 		        static_cast<Integer*>(rhs_val)->m_value)
 		    .get();
 	case ValueTag::Float:
-		return e
-		    .new_float(
+		return e.m_gc
+		    ->new_float(
 		        static_cast<Float*>(lhs_val)->m_value +
 		        static_cast<Float*>(rhs_val)->m_value)
 		    .get();
@@ -146,14 +146,14 @@ Value* value_sub(ArgsType v, Environment& e) {
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
 		// TODO: don't get()
-		return e
-		    .new_integer(
+		return e.m_gc
+		    ->new_integer(
 		        static_cast<Integer*>(lhs_val)->m_value -
 		        static_cast<Integer*>(rhs_val)->m_value)
 		    .get();
 	case ValueTag::Float:
-		return e
-		    .new_float(
+		return e.m_gc
+		    ->new_float(
 		        static_cast<Float*>(lhs_val)->m_value -
 		        static_cast<Float*>(rhs_val)->m_value)
 		    .get();
@@ -174,14 +174,14 @@ Value* value_mul(ArgsType v, Environment& e) {
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
 		// TODO: don't get()
-		return e
-		    .new_integer(
+		return e.m_gc
+		    ->new_integer(
 		        static_cast<Integer*>(lhs_val)->m_value *
 		        static_cast<Integer*>(rhs_val)->m_value)
 		    .get();
 	case ValueTag::Float:
-		return e
-		    .new_float(
+		return e.m_gc
+		    ->new_float(
 		        static_cast<Float*>(lhs_val)->m_value *
 		        static_cast<Float*>(rhs_val)->m_value)
 		    .get();
@@ -202,14 +202,14 @@ Value* value_div(ArgsType v, Environment& e) {
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
 		// TODO: don't get()
-		return e
-		    .new_integer(
+		return e.m_gc
+		    ->new_integer(
 		        static_cast<Integer*>(lhs_val)->m_value /
 		        static_cast<Integer*>(rhs_val)->m_value)
 		    .get();
 	case ValueTag::Float:
-		return e
-		    .new_float(
+		return e.m_gc
+		    ->new_float(
 		        static_cast<Float*>(lhs_val)->m_value /
 		        static_cast<Float*>(rhs_val)->m_value)
 		    .get();

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -82,7 +82,7 @@ Value* array_join(ArgsType v, Environment& e) {
 		if (i < array->m_value.size() - 1)
 			result << string->m_value;
 	}
-	return e.new_string(result.str()).get();
+	return e.m_gc->new_string_raw(result.str());
 }
 
 // array_at(array, int i) returns the i-th element of the given array
@@ -120,11 +120,9 @@ Value* value_add(ArgsType v, Environment& e) {
 		    static_cast<Float*>(lhs_val)->m_value +
 		    static_cast<Float*>(rhs_val)->m_value);
 	case ValueTag::String:
-		return e
-		    .new_string(
-		        static_cast<String*>(lhs_val)->m_value +
-		        static_cast<String*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_string_raw(
+		    static_cast<String*>(lhs_val)->m_value +
+		    static_cast<String*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_string[static_cast<int>(lhs_val->type())];

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -59,7 +59,7 @@ Value* size(ArgsType v, Environment& e) {
 	Array* array = static_cast<Array*>(unboxed(v[0]));
 
 	// TODO: don't get()
-	return e.m_gc->new_integer(array->m_value.size()).get();
+	return e.m_gc->new_integer_raw(array->m_value.size());
 }
 
 // array_join(array, string) returns a string with
@@ -112,17 +112,13 @@ Value* value_add(ArgsType v, Environment& e) {
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
 		//TODO: don't get()
-		return e.m_gc
-		    ->new_integer(
-		        static_cast<Integer*>(lhs_val)->m_value +
-		        static_cast<Integer*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_integer_raw(
+		    static_cast<Integer*>(lhs_val)->m_value +
+		    static_cast<Integer*>(rhs_val)->m_value);
 	case ValueTag::Float:
-		return e.m_gc
-		    ->new_float(
-		        static_cast<Float*>(lhs_val)->m_value +
-		        static_cast<Float*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_float_raw(
+		    static_cast<Float*>(lhs_val)->m_value +
+		    static_cast<Float*>(rhs_val)->m_value);
 	case ValueTag::String:
 		return e
 		    .new_string(
@@ -146,17 +142,13 @@ Value* value_sub(ArgsType v, Environment& e) {
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
 		// TODO: don't get()
-		return e.m_gc
-		    ->new_integer(
-		        static_cast<Integer*>(lhs_val)->m_value -
-		        static_cast<Integer*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_integer_raw(
+		    static_cast<Integer*>(lhs_val)->m_value -
+		    static_cast<Integer*>(rhs_val)->m_value);
 	case ValueTag::Float:
-		return e.m_gc
-		    ->new_float(
-		        static_cast<Float*>(lhs_val)->m_value -
-		        static_cast<Float*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_float_raw(
+		    static_cast<Float*>(lhs_val)->m_value -
+		    static_cast<Float*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_string[static_cast<int>(lhs_val->type())];
@@ -174,17 +166,13 @@ Value* value_mul(ArgsType v, Environment& e) {
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
 		// TODO: don't get()
-		return e.m_gc
-		    ->new_integer(
-		        static_cast<Integer*>(lhs_val)->m_value *
-		        static_cast<Integer*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_integer_raw(
+		    static_cast<Integer*>(lhs_val)->m_value *
+		    static_cast<Integer*>(rhs_val)->m_value);
 	case ValueTag::Float:
-		return e.m_gc
-		    ->new_float(
-		        static_cast<Float*>(lhs_val)->m_value *
-		        static_cast<Float*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_float_raw(
+		    static_cast<Float*>(lhs_val)->m_value *
+		    static_cast<Float*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't multiply values of type "
 		          << value_string[static_cast<int>(lhs_val->type())];
@@ -202,17 +190,13 @@ Value* value_div(ArgsType v, Environment& e) {
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
 		// TODO: don't get()
-		return e.m_gc
-		    ->new_integer(
-		        static_cast<Integer*>(lhs_val)->m_value /
-		        static_cast<Integer*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_integer_raw(
+		    static_cast<Integer*>(lhs_val)->m_value /
+		    static_cast<Integer*>(rhs_val)->m_value);
 	case ValueTag::Float:
-		return e.m_gc
-		    ->new_float(
-		        static_cast<Float*>(lhs_val)->m_value /
-		        static_cast<Float*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_float_raw(
+		    static_cast<Float*>(lhs_val)->m_value /
+		    static_cast<Float*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't divide values of type "
 		          << value_string[static_cast<int>(lhs_val->type())];
@@ -227,11 +211,9 @@ Value* value_logicand(ArgsType v, Environment& e) {
 	auto* rhs_val = unboxed(rhs);
 
 	if (lhs_val->type() == ValueTag::Boolean and rhs_val->type() == ValueTag::Boolean)
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<Boolean*>(lhs_val)->m_value and
-		        static_cast<Boolean*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<Boolean*>(lhs_val)->m_value and
+		    static_cast<Boolean*>(rhs_val)->m_value);
 	std::cerr << "ERROR: logical and operator not defined for types "
 	          << value_string[static_cast<int>(lhs_val->type())] << " and "
 	          << value_string[static_cast<int>(rhs_val->type())];
@@ -245,11 +227,9 @@ Value* value_logicor(ArgsType v, Environment& e) {
 	auto* rhs_val = unboxed(rhs);
 
 	if (lhs_val->type() == ValueTag::Boolean and rhs_val->type() == ValueTag::Boolean)
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<Boolean*>(lhs_val)->m_value or
-		        static_cast<Boolean*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<Boolean*>(lhs_val)->m_value or
+		    static_cast<Boolean*>(rhs_val)->m_value);
 	std::cerr << "ERROR: logical or operator not defined for types "
 	          << value_string[static_cast<int>(lhs_val->type())] << " and "
 	          << value_string[static_cast<int>(rhs_val->type())];
@@ -263,11 +243,9 @@ Value* value_logicxor(ArgsType v, Environment& e) {
 	auto* rhs_val = unboxed(rhs);
 
 	if (lhs_val->type() == ValueTag::Boolean and rhs_val->type() == ValueTag::Boolean)
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<Boolean*>(lhs_val)->m_value !=
-		        static_cast<Boolean*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<Boolean*>(lhs_val)->m_value !=
+		    static_cast<Boolean*>(rhs_val)->m_value);
 	std::cerr << "ERROR: exclusive or operator not defined for types "
 	          << value_string[static_cast<int>(lhs_val->type())] << " and "
 	          << value_string[static_cast<int>(rhs_val->type())];
@@ -284,31 +262,23 @@ Value* value_equals(ArgsType v, Environment& e) {
 
 	switch (lhs_val->type()) {
 	case ValueTag::Null:
-		return e.m_gc->new_boolean(true).get();
+		return e.m_gc->new_boolean_raw(true);
 	case ValueTag::Integer:
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<Integer*>(lhs_val)->m_value ==
-		        static_cast<Integer*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<Integer*>(lhs_val)->m_value ==
+		    static_cast<Integer*>(rhs_val)->m_value);
 	case ValueTag::Float:
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<Float*>(lhs_val)->m_value ==
-		        static_cast<Float*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<Float*>(lhs_val)->m_value ==
+		    static_cast<Float*>(rhs_val)->m_value);
 	case ValueTag::String:
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<String*>(lhs_val)->m_value ==
-		        static_cast<String*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<String*>(lhs_val)->m_value ==
+		    static_cast<String*>(rhs_val)->m_value);
 	case ValueTag::Boolean:
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<Boolean*>(lhs_val)->m_value ==
-		        static_cast<Boolean*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<Boolean*>(lhs_val)->m_value ==
+		    static_cast<Boolean*>(rhs_val)->m_value);
 	default: {
 		std::cerr << "ERROR: can't compare equality of types "
 		          << value_string[static_cast<int>(lhs_val->type())] << " and "
@@ -328,23 +298,17 @@ Value* value_less(ArgsType v, Environment& e) {
 
 	switch (lhs_val->type()) {
 	case ValueTag::Integer:
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<Integer*>(lhs_val)->m_value <
-		        static_cast<Integer*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<Integer*>(lhs_val)->m_value <
+		    static_cast<Integer*>(rhs_val)->m_value);
 	case ValueTag::Float:
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<Float*>(lhs_val)->m_value <
-		        static_cast<Float*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<Float*>(lhs_val)->m_value <
+		    static_cast<Float*>(rhs_val)->m_value);
 	case ValueTag::String:
-		return e.m_gc
-		    ->new_boolean(
-		        static_cast<String*>(lhs_val)->m_value <
-		        static_cast<String*>(rhs_val)->m_value)
-		    .get();
+		return e.m_gc->new_boolean_raw(
+		    static_cast<String*>(lhs_val)->m_value <
+		    static_cast<String*>(rhs_val)->m_value);
 	default:
 		std::cerr << "ERROR: can't compare values of type "
 		          << value_string[static_cast<int>(lhs_val->type())];

--- a/src/typed_ast_tag.hpp
+++ b/src/typed_ast_tag.hpp
@@ -10,13 +10,13 @@
 	X(ArrayLiteral)                                                            \
 	X(DictionaryLiteral)                                                       \
 	X(FunctionLiteral)                                                         \
-                                                                               \
+	/* All before this point are literals */                                   \
 	X(Identifier)                                                              \
 	X(CallExpression)                                                          \
 	X(IndexExpression)                                                         \
 	X(RecordAccessExpression)                                                  \
 	X(TernaryExpression)                                                       \
-                                                                               \
+	/* All before this point are expressions */                                \
 	X(Block)                                                                   \
 	X(ReturnStatement)                                                         \
 	X(IfElseStatement)                                                         \


### PR DESCRIPTION
So, I figured things would be simpler if we put the result of evaluating expressions on the stack, instead of returning them from eval.

I still think this is the case, we just can't see it yet because it needs some refactoring. Right now, we do use the stack, but then immediately pop values and put them in `gc_ptr`s, which is what we were doing before, but worse.

I'll keep working on this for a bit, I'm sure it only got worse before it gets better.