### PR TITLE
Fix a copypaste error in the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,6 @@ $(BUILD_DIR)/%.d: $(SOURCE_DIR)/%.cpp
 	@mkdir -p $(dir $@)
 	@set -e; rm -f $@; \
 	$(CXX) -MM $(CPPFLAGS) $< > $@.$$$$; \
-	sed 's,\($(*F)\)\.o[ :]*,$(OBJDIR)/$*.o $@ : ,g' < $@.$$$$ > $@; \
+	sed 's,\($(*F)\)\.o[ :]*,$(BUILD_DIR)/$*.o $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 


### PR DESCRIPTION
When I overhauled the build, I took the sed command from the old build, and it ended up with a stray $(OBJDIR) being left in.

Replacing it with $(BUILD_DIR) should do the trick.