### PR TITLE
Value constructors parse and typecheck

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -185,6 +185,14 @@ struct TernaryExpression : public AST {
 	    : AST {ASTTag::TernaryExpression} {}
 };
 
+struct ConstructorExpression : public AST {
+	AST* m_constructor;
+	std::vector<AST*> m_args;
+
+	ConstructorExpression()
+	    : AST {ASTTag::ConstructorExpression} {}
+};
+
 struct Block : public AST {
 	std::vector<AST*> m_body;
 

--- a/src/ast_allocator.hpp
+++ b/src/ast_allocator.hpp
@@ -24,6 +24,7 @@ struct Allocator : public NodeAllocator<
     CallExpression,
     IndexExpression,
     RecordAccessExpression,
+    ConstructorExpression,
     Block,
     ReturnStatement,
     IfElseStatement,

--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -19,6 +19,7 @@
 	X(CallExpression) \
 	X(IndexExpression) \
 	X(RecordAccessExpression) \
+	X(ConstructorExpression) \
 	X(Block) \
 	X(ReturnStatement) \
 	X(IfElseStatement) \

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -121,6 +121,13 @@ void compute_offsets(TypedAST::RecordAccessExpression* ast, int frame_offset) {
 	compute_offsets(ast->m_record, frame_offset);
 }
 
+void compute_offsets(TypedAST::ConstructorExpression* ast, int frame_offset) {
+	compute_offsets(ast->m_constructor, frame_offset);
+
+	for (auto& arg : ast->m_args)
+		compute_offsets(arg, frame_offset);
+}
+
 void compute_offsets(TypedAST::DeclarationList* ast, int frame_offset) {
 	for (auto& decl : ast->m_declarations) {
 		if (decl.m_value)
@@ -162,6 +169,7 @@ void compute_offsets(TypedAST::TypedAST* ast, int frame_offset) {
 		DISPATCH(CallExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(RecordAccessExpression);
+		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);
 		DISPATCH(ForStatement);
@@ -174,6 +182,9 @@ void compute_offsets(TypedAST::TypedAST* ast, int frame_offset) {
 
 		DISPATCH(StructExpression);
 		DISPATCH(TypeTerm);
+
+		DO_NOTHING(TypeFunctionHandle);
+		DO_NOTHING(MonoTypeHandle);
 	}
 
 #undef DO_NOTHING

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -170,12 +170,12 @@ TypeFunctionId type_func_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc) {
 	} else if (ast->type() == TypedASTTag::StructExpression) {
 		auto as_se = static_cast<TypedAST::StructExpression*>(ast);
 
-		std::vector<std::string> fields;
-		std::unordered_map<std::string, MonoId> structure;
+		std::vector<InternedString> fields;
+		std::unordered_map<InternedString, MonoId> structure;
 		int field_count = as_se->m_fields.size();
 		for (int i = 0; i < field_count; ++i){
 			MonoId mono = mono_type_from_ast(as_se->m_types[i], tc);
-			std::string name = as_se->m_fields[i].text().str();
+			InternedString name(as_se->m_fields[i].text().str());
 			assert(!structure.count(name));
 			structure[name] = mono;
 			fields.push_back(name);
@@ -265,6 +265,14 @@ TypedAST::DeclarationList* ct_eval(
 	return ast;
 }
 
+TypedAST::MonoTypeHandle* ct_eval(
+    TypedAST::TypeTerm* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
+	auto handle = alloc.make<TypedAST::MonoTypeHandle>();
+	handle->m_value = mono_type_from_ast(ast, tc);
+	handle->m_syntax = ast;
+	return handle;
+}
+
 TypedAST::TypedAST* ct_eval(
     TypedAST::TypedAST* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
 #define DISPATCH(type)                                                         \
@@ -299,6 +307,8 @@ TypedAST::TypedAST* ct_eval(
 
 		DISPATCH(Declaration);
 		DISPATCH(DeclarationList);
+
+		DISPATCH(TypeTerm);
 	}
 
 	std::cerr << "Unhandled case in " << __PRETTY_FUNCTION__ << " : "

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -175,7 +175,7 @@ TypeFunctionId type_func_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		int field_count = as_se->m_fields.size();
 		for (int i = 0; i < field_count; ++i){
 			MonoId mono = mono_type_from_ast(as_se->m_types[i], tc);
-			InternedString name(as_se->m_fields[i].text().str());
+			InternedString name = as_se->m_fields[i].text();
 			assert(!structure.count(name));
 			structure[name] = mono;
 			fields.push_back(name);

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -66,6 +66,16 @@ TypedAST::RecordAccessExpression* ct_eval(
 	return ast;
 }
 
+TypedAST::ConstructorExpression* ct_eval(
+    TypedAST::ConstructorExpression* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
+	ast->m_constructor = ct_eval(ast->m_constructor, tc, alloc);
+
+	for (auto& arg : ast->m_args)
+		arg = ct_eval(arg, tc, alloc);
+
+	return ast;
+}
+
 // statements
 
 TypedAST::Block* ct_eval(
@@ -238,6 +248,7 @@ TypedAST::TypedAST* ct_eval(
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(RecordAccessExpression);
+		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);
 		DISPATCH(IfElseStatement);

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -142,11 +142,8 @@ TypeFunctionId type_func_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc) {
 			fields.push_back(name);
 		}
 
-		// TODO: we create a dummy typefunc then make it non-dummy. SERIOUSLY?
-		TypeFunctionId result = tc.m_core.new_dummy_type_function(
+		TypeFunctionId result = tc.m_core.new_type_function(
 		    TypeFunctionTag::Record, std::move(fields), std::move(structure));
-
-		tc.m_core.m_type_functions[result].is_dummy = false;
 
 		return result;
 	} else {

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -131,18 +131,20 @@ TypeFunctionId type_func_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc) {
 	} else if (ast->type() == TypedASTTag::StructExpression) {
 		auto as_se = static_cast<TypedAST::StructExpression*>(ast);
 
-		std::unordered_map<std::string, MonoId> fields;
+		std::vector<std::string> fields;
+		std::unordered_map<std::string, MonoId> structure;
 		int field_count = as_se->m_fields.size();
 		for (int i = 0; i < field_count; ++i){
 			MonoId mono = mono_type_from_ast(as_se->m_types[i], tc);
 			std::string name = as_se->m_fields[i].text().str();
-			assert(!fields.count(name));
-			fields[name] = mono;
+			assert(!structure.count(name));
+			structure[name] = mono;
+			fields.push_back(name);
 		}
 
 		// TODO: we create a dummy typefunc then make it non-dummy. SERIOUSLY?
 		TypeFunctionId result = tc.m_core.new_dummy_type_function(
-		    TypeFunctionTag::Record, std::move(fields));
+		    TypeFunctionTag::Record, std::move(fields), std::move(structure));
 
 		tc.m_core.m_type_functions[result].is_dummy = false;
 

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -139,6 +139,14 @@ AST* desugar(TernaryExpression* ast, Allocator& alloc) {
 	return ast;
 }
 
+AST* desugar(ConstructorExpression* ast, Allocator& alloc) {
+	ast->m_constructor = desugar(ast->m_constructor, alloc);
+	for (auto& arg : ast->m_args)
+		arg = desugar(arg, alloc);
+
+	return ast;
+}
+
 AST* desugar(Block* ast, Allocator& alloc) {
 	for (auto& element : ast->m_body) {
 		element = desugar(element, alloc);
@@ -210,6 +218,7 @@ AST* desugar(AST* ast, Allocator& alloc) {
 		DISPATCH(CallExpression);
 		DISPATCH(IndexExpression);
 		DISPATCH(RecordAccessExpression);
+		DISPATCH(ConstructorExpression);
 
 		DISPATCH(DeclarationList);
 		DISPATCH(Declaration);

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -178,6 +178,16 @@ namespace TypeChecker {
 }
 
 [[nodiscard]] ErrorReport match_identifiers(
+    TypedAST::ConstructorExpression* ast, Frontend::CompileTimeEnvironment& env) {
+	CHECK_AND_RETURN(match_identifiers(ast->m_constructor, env));
+
+	for (auto& arg : ast->m_args)
+		CHECK_AND_RETURN(match_identifiers(arg, env));
+
+	return {};
+}
+
+[[nodiscard]] ErrorReport match_identifiers(
     TypedAST::DeclarationList* ast, Frontend::CompileTimeEnvironment& env) {
 	for (auto& decl : ast->m_declarations) {
 		env.declare(decl.identifier_text(), &decl);
@@ -237,6 +247,7 @@ namespace TypeChecker {
 		DISPATCH(CallExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(RecordAccessExpression);
+		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);
 		DISPATCH(ForStatement);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -93,7 +93,7 @@ void metacheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 	ast->m_meta_type = tc.meta_value();
 
 	metacheck(ast->m_constructor, tc);
-	tc.m_core.m_meta_core.unify(ast->m_constructor->m_meta_type, tc.meta_typefunc());
+	tc.m_core.m_meta_core.unify(ast->m_constructor->m_meta_type, tc.meta_monotype());
 
 	for (auto& arg : ast->m_args) {
 		metacheck(arg, tc);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -89,6 +89,18 @@ void metacheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
 	tc.m_core.m_meta_core.unify(ast->m_record->m_meta_type, tc.meta_value());
 }
 
+void metacheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
+
+	metacheck(ast->m_constructor, tc);
+	tc.m_core.m_meta_core.unify(ast->m_constructor->m_meta_type, tc.meta_typefunc());
+
+	for (auto& arg : ast->m_args) {
+		metacheck(arg, tc);
+		tc.m_core.m_meta_core.unify(arg->m_meta_type, tc.meta_value());
+	}
+}
+
 // statements
 
 void metacheck(TypedAST::Block* ast, TypeChecker& tc) {
@@ -197,6 +209,7 @@ void metacheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(RecordAccessExpression);
+		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);
 		DISPATCH(IfElseStatement);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -227,6 +227,7 @@ bool is_binary_operator(TokenTag t) {
 	case TokenTag::PAREN_OPEN:   // a bit of a hack
 	case TokenTag::BRACKET_OPEN: // a bit of a hack
 	case TokenTag::POLY_OPEN:    // a bit of a hack
+	case TokenTag::BRACE_OPEN:   // a bit of a hack
 
 	case TokenTag::LT:
 	case TokenTag::GT:
@@ -271,6 +272,7 @@ binding_power binding_power_of(TokenTag t) {
 	case TokenTag::PAREN_OPEN:   // a bit of a hack
 	case TokenTag::BRACKET_OPEN: // a bit of a hack
 	case TokenTag::POLY_OPEN:    // a bit of a hack
+	case TokenTag::BRACE_OPEN:   // a bit of a hack
 	case TokenTag::DOT:
 		return {70, 71};
 	default:
@@ -397,6 +399,21 @@ Writer<AST::AST*> Parser::parse_expression(int bp) {
 			auto e = m_ast_allocator->make<AST::RecordAccessExpression>();
 			e->m_record = lhs.m_result;
 			e->m_member = member.m_result;
+			lhs.m_result = e;
+
+			continue;
+		}
+
+		if (consume(TokenTag::BRACE_OPEN)) {
+			auto args =
+			    parse_expression_list(TokenTag::SEMICOLON, TokenTag::BRACE_CLOSE, true);
+
+			if (handle_error(result, args))
+				return result;
+
+			auto e = m_ast_allocator->make<AST::ConstructorExpression>();
+			e->m_constructor = lhs.m_result;
+			e->m_args = std::move(args.m_result);
 			lhs.m_result = e;
 
 			continue;

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -457,23 +457,6 @@ void interpreter_tests(Test::Tester& tests) {
 	    Testers {+[](Interpreter::Environment& env) -> ExitStatusTag {
 		    return Assert::equals(eval_expression("__invoke()", env), 0);
 	    }}));
-
-	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
-	    R"(
-			pair := struct { a : int; b : string; };
-
-			pair_strings := fn(a : pair, b : pair) => a.b + " " + b.b;
-
-			__invoke := fn() {
-				first : pair = pair { 1; "hello"; };
-				second : pair = pair { 2; "world"; };
-
-				return pair_strings(first, second);
-			};
-		)",
-	    Testers {+[](Interpreter::Environment& env) -> ExitStatusTag {
-		    return Assert::equals(eval_expression("__invoke()", env), "hello world");
-	    }}));
 }
 
 void tarjan_algorithm_tests(Test::Tester& tester) {

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -85,6 +85,7 @@ void interpreter_tests(Test::Tester& tests) {
 	);
 	*/
 
+
 	tests.add_test(std::make_unique<TestCase>(
 	    R"(
 			int_val := 1 + 2 + 3 + 4;
@@ -455,6 +456,23 @@ void interpreter_tests(Test::Tester& tests) {
 		)",
 	    Testers {+[](Interpreter::Environment& env) -> ExitStatusTag {
 		    return Assert::equals(eval_expression("__invoke()", env), 0);
+	    }}));
+
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	    R"(
+			pair := struct { a : int; b : string; };
+
+			pair_strings := fn(a : pair, b : pair) => a.b + " " + b.b;
+
+			__invoke := fn() {
+				first : pair = pair { 1; "hello"; };
+				second : pair = pair { 2; "world"; };
+
+				return pair_strings(first, second);
+			};
+		)",
+	    Testers {+[](Interpreter::Environment& env) -> ExitStatusTag {
+		    return Assert::equals(eval_expression("__invoke()", env), "hello world");
 	    }}));
 }
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -237,7 +237,7 @@ void typecheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
 	ast->m_value_type = member_type;
 
 	TypeFunctionId dummy_tf = tc.m_core.new_dummy_type_function(
-	    TypeFunctionTag::Record, {{ast->m_member->m_text.str(), member_type}});
+	    TypeFunctionTag::Record, {ast->m_member->m_text.str()}, {{ast->m_member->m_text.str(), member_type}});
 	MonoId term_type = tc.m_core.new_term(dummy_tf, {}, "record instance");
 
 	tc.m_core.m_mono_core.unify(ast->m_record->m_value_type, term_type);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -230,8 +230,8 @@ void typecheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
 
 	TypeFunctionId dummy_tf = tc.m_core.new_type_function
 	    ( TypeFunctionTag::Record
-	    , {} // we don't care for fields in dummies
-	    , {{InternedString(ast->m_member->m_text.str()), member_type}}
+	    , {} // we don't care about fields in dummies
+	    , {{ast->m_member->m_text, member_type}}
 	    , true);
 	MonoId term_type = tc.m_core.new_term(dummy_tf, {}, "record instance");
 
@@ -242,7 +242,7 @@ void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 	typecheck(ast->m_constructor, tc);
 
 	auto handle = static_cast<TypedAST::MonoTypeHandle*>(ast->m_constructor);
-	assert(handle && "Error: Value constructor was not handled");
+	assert(handle->type() == TypedASTTag::MonoTypeHandle);
 
 	TypeFunctionId tf = tc.m_core.m_mono_core.find_function(handle->m_value);
 	TypeFunctionData& tf_data = tc.m_core.m_type_functions[tf];

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -252,6 +252,9 @@ void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 	TypeFunctionId tf = tc.m_core.m_tf_core.find_term(ast->m_constructor->m_value_type);
 	TypeFunctionData& tf_data = tc.m_core.m_type_functions[tf];
 
+	// TODO: match type arguments as well, we only support 0 now
+
+	// match value arguments
 	assert(tf_data.fields.size() == ast->m_args.size());
 	for (int i = 0; i < ast->m_args.size(); ++i) {
 		typecheck(ast->m_args[i], tc);
@@ -260,7 +263,11 @@ void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 		tc.m_core.m_mono_core.unify(field_type, ast->m_args[i]->m_value_type);
 	}
 
-	ast->m_value_type = ast->m_constructor->m_value_type;
+	// NOTE: this is a special case for the `name { }` syntax sugar,
+	// but perhaps the left side should only be a TypeTerm and not possibly an Identifier?
+	if (ast->m_constructor->m_meta_type == tc.meta_typefunc())
+		ast->m_value_type =
+		    tc.m_core.new_term(ast->m_constructor->m_value_type, {}, "record instance");
 }
 
 void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -236,8 +236,11 @@ void typecheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
 	MonoId member_type = tc.new_var();
 	ast->m_value_type = member_type;
 
-	TypeFunctionId dummy_tf = tc.m_core.new_dummy_type_function(
-	    TypeFunctionTag::Record, {ast->m_member->m_text.str()}, {{ast->m_member->m_text.str(), member_type}});
+	TypeFunctionId dummy_tf = tc.m_core.new_type_function
+	    ( TypeFunctionTag::Record
+	    , {ast->m_member->m_text.str()}
+	    , {{ast->m_member->m_text.str(), member_type}}
+	    , true);
 	MonoId term_type = tc.m_core.new_term(dummy_tf, {}, "record instance");
 
 	tc.m_core.m_mono_core.unify(ast->m_record->m_value_type, term_type);

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -125,6 +125,9 @@ TypeChecker::TypeChecker(TypedAST::Allocator& allocator) : m_typed_ast_allocator
 	}
 
 	declare_builtin("int", meta_typefunc(), BuiltinType::Int);
+	declare_builtin("float", meta_typefunc(), BuiltinType::Float);
+	declare_builtin("string", meta_typefunc(), BuiltinType::String);
+	declare_builtin("boolean", meta_typefunc(), BuiltinType::Boolean);
 }
 
 MonoId TypeChecker::new_hidden_var() {

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -144,6 +144,17 @@ TypedAST* convert_ast(AST::RecordAccessExpression* ast, Allocator& alloc) {
 	return typed_ast;
 }
 
+TypedAST* convert_ast(AST::ConstructorExpression* ast, Allocator& alloc) {
+	auto typed_ast = alloc.make<ConstructorExpression>();
+
+	typed_ast->m_constructor = convert_ast(ast->m_constructor, alloc);
+
+	for (auto& arg : ast->m_args)
+		typed_ast->m_args.push_back(convert_ast(arg, alloc));
+
+	return typed_ast;
+}
+
 TypedAST* convert_ast(AST::Block* ast, Allocator& alloc) {
 	auto typed_block = alloc.make<Block>();
 
@@ -245,6 +256,7 @@ TypedAST* convert_ast(AST::AST* ast, Allocator& alloc) {
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(RecordAccessExpression);
+		DISPATCH(ConstructorExpression);
 		REJECT(BinaryExpression);
 
 		DISPATCH(Block);

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -228,6 +228,14 @@ struct TernaryExpression : public TypedAST {
 	    : TypedAST {TypedASTTag::TernaryExpression} {}
 };
 
+struct ConstructorExpression : public TypedAST {
+	TypedAST* m_constructor;
+	std::vector<TypedAST*> m_args;
+
+	ConstructorExpression()
+	    : TypedAST {TypedASTTag::ConstructorExpression} {}
+};
+
 struct Block : public TypedAST {
 	std::vector<TypedAST*> m_body;
 

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -229,7 +229,7 @@ struct TernaryExpression : public TypedAST {
 };
 
 struct ConstructorExpression : public TypedAST {
-	TypedAST* m_constructor;
+	TypedAST* m_constructor; // should this be TypeTerm?
 	std::vector<TypedAST*> m_args;
 
 	ConstructorExpression()

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -229,7 +229,7 @@ struct TernaryExpression : public TypedAST {
 };
 
 struct ConstructorExpression : public TypedAST {
-	TypedAST* m_constructor; // should this be TypeTerm?
+	TypedAST* m_constructor;
 	std::vector<TypedAST*> m_args;
 
 	ConstructorExpression()

--- a/src/typed_ast_allocator.hpp
+++ b/src/typed_ast_allocator.hpp
@@ -21,6 +21,7 @@ struct Allocator : public NodeAllocator<
     IndexExpression,
     RecordAccessExpression,
     TernaryExpression,
+    ConstructorExpression,
     Block,
     ReturnStatement,
     IfElseStatement,

--- a/src/typed_ast_tag.hpp
+++ b/src/typed_ast_tag.hpp
@@ -16,6 +16,7 @@
 	X(IndexExpression)                                                         \
 	X(RecordAccessExpression)                                                  \
 	X(TernaryExpression)                                                       \
+	X(ConstructorExpression)                                                   \
 	/* All before this point are expressions */                                \
 	X(Block)                                                                   \
 	X(ReturnStatement)                                                         \

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -128,11 +128,11 @@ TypeFunctionId TypeSystemCore::new_builtin_type_function(int arguments) {
 
 TypeFunctionId TypeSystemCore::new_type_function
     ( TypeFunctionTag type
-    , std::vector<std::string> fields
-    , std::unordered_map<std::string, MonoId> structure
+    , std::vector<InternedString> fields
+    , std::unordered_map<InternedString, MonoId> structure
     , bool dummy) {
 	TypeFunctionId id = m_tf_core.new_term(m_type_functions.size());
-	m_type_functions.push_back({type, 0, fields, structure, dummy});
+	m_type_functions.push_back({type, 0, std::move(fields), std::move(structure), dummy});
 	return id;
 }
 

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -126,13 +126,13 @@ TypeFunctionId TypeSystemCore::new_builtin_type_function(int arguments) {
 	return id;
 }
 
-TypeFunctionId TypeSystemCore::new_dummy_type_function
+TypeFunctionId TypeSystemCore::new_type_function
     ( TypeFunctionTag type
     , std::vector<std::string> fields
-    , std::unordered_map<std::string
-    , MonoId> structure) {
+    , std::unordered_map<std::string, MonoId> structure
+    , bool dummy) {
 	TypeFunctionId id = m_tf_core.new_term(m_type_functions.size());
-	m_type_functions.push_back({type, 0, fields, structure, true});
+	m_type_functions.push_back({type, 0, fields, structure, dummy});
 	return id;
 }
 

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -127,12 +127,14 @@ TypeFunctionId TypeSystemCore::new_builtin_type_function(int arguments) {
 }
 
 TypeFunctionId TypeSystemCore::new_dummy_type_function
-    (TypeFunctionTag type, std::unordered_map<std::string, MonoId> structure) {
+    ( TypeFunctionTag type
+    , std::vector<std::string> fields
+    , std::unordered_map<std::string
+    , MonoId> structure) {
 	TypeFunctionId id = m_tf_core.new_term(m_type_functions.size());
-	m_type_functions.push_back({type, 0, structure, true});
+	m_type_functions.push_back({type, 0, fields, structure, true});
 	return id;
 }
-
 
 MonoId TypeSystemCore::inst_impl(
     MonoId mono, std::unordered_map<MonoId, MonoId> const& mapping) {

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -24,7 +24,10 @@ enum class TypeFunctionTag { Builtin, Sum, Product, Record };
 struct TypeFunctionData {
 	TypeFunctionTag tag;
 	int argument_count; // -1 means variadic
-	std::unordered_map<std::string, MonoId> structure; // can be nullptr
+
+	std::vector<std::string> fields;
+	std::unordered_map<std::string, MonoId> structure;
+
 	bool is_dummy {false};
 };
 
@@ -55,8 +58,10 @@ struct TypeSystemCore {
 	PolyId new_poly(MonoId mono, std::vector<MonoId> vars);
 
 	TypeFunctionId new_builtin_type_function(int arguments);
-	TypeFunctionId new_dummy_type_function(
-	    TypeFunctionTag type, std::unordered_map<std::string, MonoId> structure);
+	TypeFunctionId new_dummy_type_function
+	    ( TypeFunctionTag type
+	    , std::vector<std::string> fields
+	    , std::unordered_map<std::string, MonoId> structure);
 	
 	// qualifies all unbound variables in the given monotype
 	void gather_free_vars(MonoId mono, std::unordered_set<MonoId>& free_vars);

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -58,10 +58,11 @@ struct TypeSystemCore {
 	PolyId new_poly(MonoId mono, std::vector<MonoId> vars);
 
 	TypeFunctionId new_builtin_type_function(int arguments);
-	TypeFunctionId new_dummy_type_function
+	TypeFunctionId new_type_function
 	    ( TypeFunctionTag type
 	    , std::vector<std::string> fields
-	    , std::unordered_map<std::string, MonoId> structure);
+	    , std::unordered_map<std::string, MonoId> structure
+	    , bool dummy = false);
 	
 	// qualifies all unbound variables in the given monotype
 	void gather_free_vars(MonoId mono, std::unordered_set<MonoId>& free_vars);

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -3,10 +3,10 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <string>
 
 #include "typechecker_types.hpp"
 #include "unification.hpp"
+#include "interned_string.hpp"
 
 namespace Frontend {
 struct CompileTimeEnvironment;
@@ -25,8 +25,8 @@ struct TypeFunctionData {
 	TypeFunctionTag tag;
 	int argument_count; // -1 means variadic
 
-	std::vector<std::string> fields;
-	std::unordered_map<std::string, MonoId> structure;
+	std::vector<InternedString> fields;
+	std::unordered_map<InternedString, MonoId> structure;
 
 	bool is_dummy {false};
 };
@@ -60,8 +60,8 @@ struct TypeSystemCore {
 	TypeFunctionId new_builtin_type_function(int arguments);
 	TypeFunctionId new_type_function
 	    ( TypeFunctionTag type
-	    , std::vector<std::string> fields
-	    , std::unordered_map<std::string, MonoId> structure
+	    , std::vector<InternedString> fields
+	    , std::unordered_map<InternedString, MonoId> structure
 	    , bool dummy = false);
 	
 	// qualifies all unbound variables in the given monotype


### PR DESCRIPTION
Implements construction of values from types, like `pair { 1; 2; }` or maybe `int { 0; }`.

Also implements addition of non-dummy type functions, mentioned in issue #155.