### PR TITLE
use the correct index when instanciating a type

### DIFF
--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -245,7 +245,8 @@ void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 	assert(handle->type() == TypedASTTag::MonoTypeHandle);
 
 	TypeFunctionId tf = tc.m_core.m_mono_core.find_function(handle->m_value);
-	TypeFunctionData& tf_data = tc.m_core.m_type_functions[tf];
+	int tf_data_idx = tc.m_core.m_tf_core.find_function(tf);
+	TypeFunctionData& tf_data = tc.m_core.m_type_functions[tf_data_idx];
 
 	// match value arguments
 	assert(tf_data.fields.size() == ast->m_args.size());

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -100,8 +100,9 @@ TypeSystemCore::TypeSystemCore() {
 
 MonoId TypeSystemCore::new_term(
     TypeFunctionId tf, std::vector<int> args, char const* tag) {
-	tf = m_tf_core.find_function(tf);
-	int argument_count = m_type_functions[tf].argument_count;
+	tf = m_tf_core.find(tf);
+	int tf_data_idx = m_tf_core.find_function(tf);
+	int argument_count = m_type_functions[tf_data_idx].argument_count;
 
 	if (argument_count != -1 && argument_count != args.size())
 		assert(0 && "instanciating polymorphic type with wrong argument count");


### PR DESCRIPTION
A small bug was introduced yesterday, where we used the type func id as an index into the type function data array, instead of the type function header array. This patch fixes that.

A more permanent solution would be to use more strongly typed indices with accessor functions, which would catch these mistakes at compile.

I'll work on that later today or tomorrow.