### PR TITLE
remove superfluous includes

### DIFF
--- a/src/algorithms/unification.cpp
+++ b/src/algorithms/unification.cpp
@@ -76,7 +76,7 @@ int Core::new_var(char const* debug) {
 
 int Core::new_term(int f, std::vector<int> args, char const* debug) {
 	int id = node_header.size();
-	node_header.push_back({Tag::Term, term_data.size(), debug});
+	node_header.push_back({Tag::Term, static_cast<int>(term_data.size()), debug});
 	term_data.push_back({f, std::move(args)});
 	return id;
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2,8 +2,6 @@
 
 #include <iostream>
 
-#include <cassert>
-
 namespace AST {
 
 namespace {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <memory>
 #include <string>
 #include <vector>
 
 #include "ast_tag.hpp"
 #include "token.hpp"
-#include "utils/typedefs.hpp"
 
 namespace AST {
 

--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -1,7 +1,5 @@
 #include "compile_time_environment.hpp"
 
-#include "typed_ast.hpp"
-
 #include <cassert>
 
 namespace Frontend {

--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -2,6 +2,7 @@
 
 #include "typechecker.hpp"
 #include "typed_ast.hpp"
+#include "typed_ast_allocator.hpp"
 
 #include <iostream>
 

--- a/src/ct_eval.hpp
+++ b/src/ct_eval.hpp
@@ -1,8 +1,8 @@
-#include "utils/typedefs.hpp"
-#include "typed_ast_allocator.hpp"
+#pragma once
 
 namespace TypedAST {
 struct TypedAST;
+struct Allocator;
 }
 
 namespace TypeChecker {

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -2,7 +2,6 @@
 
 #include "ast.hpp"
 #include "ast_allocator.hpp"
-#include "utils/typedefs.hpp"
 
 #include <cassert>
 #include <iostream>

--- a/src/desugar.hpp
+++ b/src/desugar.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <memory>
-
-#include "ast_allocator.hpp"
-
 namespace AST {
+
+struct AST;
+struct Allocator;
 
 AST* desugar(AST*, Allocator&);
 

--- a/src/interpreter/environment.cpp
+++ b/src/interpreter/environment.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 
+#include "error.hpp"
 #include "garbage_collector.hpp"
 
 namespace Interpreter {

--- a/src/interpreter/environment.hpp
+++ b/src/interpreter/environment.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../utils/interned_string.hpp"
-#include "error.hpp"
 #include "gc_ptr.hpp"
 #include "value.hpp"
 
@@ -10,6 +9,7 @@
 namespace Interpreter {
 
 struct GC;
+struct Error;
 
 struct Scope {
 	std::map<InternedString, Reference*> m_declarations;

--- a/src/interpreter/eval.hpp
+++ b/src/interpreter/eval.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
-#include "environment_fwd.hpp"
-#include "gc_ptr.hpp"
-#include "value_fwd.hpp"
-
 namespace TypedAST {
 struct TypedAST;
 }
 
 namespace Interpreter {
+
+struct Environment;
 
 void eval(TypedAST::TypedAST*, Environment&);
 

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -1,5 +1,6 @@
 #include "execute.hpp"
 
+#include "../ast_allocator.hpp"
 #include "../compute_offsets.hpp"
 #include "../ct_eval.hpp"
 #include "../desugar.hpp"
@@ -10,13 +11,12 @@
 #include "../typecheck.hpp"
 #include "../typechecker.hpp"
 #include "../typed_ast.hpp"
+#include "../typed_ast_allocator.hpp"
 #include "environment.hpp"
 #include "eval.hpp"
 #include "garbage_collector.hpp"
 #include "native.hpp"
 #include "utils.hpp"
-
-#include <iostream>
 
 namespace Interpreter {
 

--- a/src/interpreter/execute.hpp
+++ b/src/interpreter/execute.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "environment_fwd.hpp"
 #include "exit_status_tag.hpp"
-#include "value.hpp"
 #include <string>
 
 namespace Interpreter {
+
+struct Environment;
+struct Value;
 
 using Runner = auto(Environment&) -> ExitStatusTag;
 

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -1,8 +1,9 @@
 #include "garbage_collector.hpp"
 
+#include "error.hpp"
+
 #include <algorithm>
 #include <string>
-#include <unordered_map>
 
 namespace Interpreter {
 

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -2,11 +2,12 @@
 
 #include <vector>
 
-#include "error.hpp"
 #include "gc_ptr.hpp"
 #include "value.hpp"
 
 namespace Interpreter {
+
+struct Error;
 
 struct GC {
   private:

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -2,9 +2,10 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <vector>
 
+#include "../ast_allocator.hpp"
 #include "../parse.hpp"
+#include "../parser.hpp"
 #include "../token_array.hpp"
 #include "../typed_ast.hpp"
 #include "../typed_ast_allocator.hpp"
@@ -12,6 +13,7 @@
 #include "eval.hpp"
 #include "execute.hpp"
 #include "exit_status_tag.hpp"
+#include "gc_ptr.hpp"
 #include "value.hpp"
 
 int main() {

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -2,9 +2,6 @@
 
 #include <iostream>
 
-#include <cassert>
-
-#include "environment.hpp"
 #include "error.hpp"
 
 namespace Interpreter {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,6 +1,5 @@
 #include "lexer.hpp"
 
-#include <string>
 #include <vector>
 
 #include <cassert>

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -1,6 +1,5 @@
 #include "parse.hpp"
 
-#include "ast.hpp"
 #include "lexer.hpp"
 #include "parser.hpp"
 

--- a/src/parse.hpp
+++ b/src/parse.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
-#include <memory>
-#include <utility>
+#include <string>
 
 #include "parser.hpp"
 #include "token_array.hpp"
-#include "ast_allocator.hpp"
+
+namespace AST {
+struct Allocator;
+}
 
 Writer<AST::AST*> parse_program(std::string const&, TokenArray&, AST::Allocator&);
 Writer<AST::AST*> parse_expression(std::string const&, TokenArray&, AST::Allocator&);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,6 +1,7 @@
 #include "parser.hpp"
 
 #include "utils/string_view.hpp"
+#include "ast_allocator.hpp"
 
 #include <sstream>
 #include <utility>

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
-#include <memory>
-#include <string>
 #include <vector>
 
-#include "ast.hpp"
 #include "error_report.hpp"
 #include "lexer.hpp"
-#include "ast_allocator.hpp"
+
+namespace AST {
+struct AST;
+struct Allocator;
+struct Identifier;
+struct Declaration;
+}
 
 template <typename T>
 struct Writer {

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <string>
-
 #include "token_tag.hpp"
 #include "utils/interned_string.hpp"
 

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -2,8 +2,7 @@
 
 #include "typechecker_types.hpp"
 #include "typed_ast.hpp"
-
-#include <cassert>
+#include "typed_ast_allocator.hpp"
 
 namespace TypeChecker {
 

--- a/src/typechecker.hpp
+++ b/src/typechecker.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
 #include "compile_time_environment.hpp"
-#include "typed_ast_allocator.hpp"
 #include "typesystem.hpp"
 #include "utils/chunked_array.hpp"
 #include "utils/interned_string.hpp"
+
+namespace TypedAST {
+struct Allocator;
+struct Declaration;
+}
 
 namespace TypeChecker {
 

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -4,7 +4,6 @@
 #include "ast.hpp"
 #include "typed_ast.hpp"
 #include "typed_ast_allocator.hpp"
-#include "utils/typedefs.hpp"
 
 namespace TypedAST {
 

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <string>
 #include <unordered_set>
 #include <unordered_map>
@@ -9,10 +8,8 @@
 #include <climits>
 
 #include "token.hpp"
-#include "token_tag.hpp"
 #include "typechecker_types.hpp"
 #include "typed_ast_tag.hpp"
-#include "utils/typedefs.hpp"
 
 namespace AST {
 struct AST;

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -1,10 +1,6 @@
 #include "typesystem.hpp"
 
-#include <iostream>
-
 #include <cassert>
-
-#include "compile_time_environment.hpp"
 
 TypeSystemCore::TypeSystemCore() {
 	m_tf_core.unify_function = [this](Unification::Core& core, int a, int b) {

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -8,10 +8,6 @@
 #include "utils/interned_string.hpp"
 #include "typechecker_types.hpp"
 
-namespace Frontend {
-struct CompileTimeEnvironment;
-}
-
 enum class TypeFunctionTag { Builtin, Sum, Product, Record };
 // Concrete type function. If it's a built-in, we use argument_count
 // to tell how many arguments it takes. Else, for sum, product and record,

--- a/src/utils/interned_string.cpp
+++ b/src/utils/interned_string.cpp
@@ -1,7 +1,5 @@
 #include "interned_string.hpp"
 
-#include <iostream>
-
 #include "string_set.hpp"
 
 #include <cassert>

--- a/src/utils/interned_string.hpp
+++ b/src/utils/interned_string.hpp
@@ -2,7 +2,6 @@
 
 #include <iosfwd>
 #include <string>
-#include <unordered_set>
 
 struct StringSet;
 

--- a/src/utils/node_allocator.hpp
+++ b/src/utils/node_allocator.hpp
@@ -2,8 +2,6 @@
 
 #include "chunked_array.hpp"
 
-#include <iostream>
-
 #include <type_traits>
 
 template <typename T>

--- a/src/utils/string_set.cpp
+++ b/src/utils/string_set.cpp
@@ -1,11 +1,7 @@
 #include "string_set.hpp"
 
-#include "string_view.hpp"
-
 #include <cassert>
 #include <cstring>
-
-#include <iostream>
 
 // compute a 64-bit hash
 static uint64_t compute_hash(unsigned char const* data, size_t length) {

--- a/src/utils/string_set.hpp
+++ b/src/utils/string_set.hpp
@@ -1,4 +1,3 @@
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -6,9 +5,6 @@
 #include "chunked_array.hpp"
 
 #include <cstdint>
-
-struct string_view;
-struct InternedString;
 
 // a flat linear hashing table
 // if rehashing occurs, references are not invalidated


### PR DESCRIPTION
I shaved like a second or two off of the build time by removing superfluous includes.

A large piece of time (~30%) is spent instanciating `std::vector` for all the different types of `AST` and `TypedAST` nodes. (because we use `std::vector` in `ChunkedArray`, which is itself the core piece of `NodeAllocator`)... I have some ideas to replace it with something that's less compile-time intensive, but that's better left for tomorrow.
