### PR TITLE
Bugfix capture ordering

### DIFF
--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -150,10 +150,17 @@ void eval_call_function(
 	// TODO: error handling ?
 	assert(callee->m_def->m_args.size() == arg_count);
 
+	// TODO: This is a big hack. pushing nullptr into the
+	// stack should actually never happen.
+	for (int i = callee->m_captures.size(); i--;)
+		e.push(nullptr);
+
 	for (auto& kv : callee->m_captures) {
 		assert(kv.second);
 		assert(kv.second->type() == ValueTag::Reference);
-		e.push(kv.second);
+		auto capture_value = unboxed(kv.second);
+		auto offset = callee->m_def->m_captures[kv.first].inner_frame_offset;
+		e.m_stack[e.m_frame_ptr + offset] = kv.second;
 	}
 
 	assert(callee->m_def->m_body->type() == TypedASTTag::Block);

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -455,6 +455,18 @@ void interpreter_tests(Test::Tester& tests) {
 	    Testers {+[](Interpreter::Environment& env) -> ExitStatusTag {
 		    return Assert::equals(eval_expression("__invoke()", env), 0);
 	    }}));
+
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	    R"(
+			cat := fn(a,c,d) => fn(b) =>
+				a + b + c + d;
+
+			__invoke := fn() =>
+				cat("A","C","D")("B");
+		)",
+	    Testers {+[](Interpreter::Environment& env) -> ExitStatusTag {
+		    return Assert::equals(eval_expression("__invoke()", env), "ABCD");
+	    }}));
 }
 
 void tarjan_algorithm_tests(Test::Tester& tester) {


### PR DESCRIPTION
Fixes #184 

We were pushing captures onto the stack in an arbitrary order, and not the one generated by `compute_offsets`.