### PR TITLE
blow up when encountering a declaration

### DIFF
--- a/src/compile_time_environment.cpp
+++ b/src/compile_time_environment.cpp
@@ -12,8 +12,10 @@ Scope& CompileTimeEnvironment::current_scope() {
 
 void CompileTimeEnvironment::declare(
     InternedString const& name, TypedAST::Declaration* decl) {
-	// current_scope().m_vars[name] = decl;
-	current_scope().m_vars.insert({name, decl});
+	auto insert_result = current_scope().m_vars.insert({name, decl});
+
+	// TODO: do proper error handling
+	assert(insert_result.second && "redeclaration");
 }
 
 TypedAST::Declaration* CompileTimeEnvironment::access(InternedString const& name) {


### PR DESCRIPTION
We used to ignore re-declarations. Now we have an assertion to forbid them. Not a nice thing to do, but way better than failing silently.