### PR TITLE
Type hints

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -28,9 +28,9 @@ void print(Declaration* ast, int d) {
 	std::cout << stab << "[ Declaration\n"
 	          << tab << "Name: " << ast->identifier_text() << '\n';
 
-	if (ast->m_type) {
+	if (ast->m_type_hint) {
 		std::cout << tab << "Type:\n";
-		print(ast->m_type, d + 1);
+		print(ast->m_type_hint, d + 1);
 	}
 
 	if (ast->m_value) {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -25,7 +25,7 @@ struct AST {
 
 struct Declaration : public AST {
 	Token const* m_identifier_token;
-	AST* m_type {nullptr};  // can be nullptr
+	AST* m_type_hint {nullptr};  // can be nullptr
 	AST* m_value {nullptr}; // can be nullptr
 
 	std::string const& identifier_text() const {

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -221,8 +221,8 @@ MonoId mono_type_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc){
 
 TypedAST::Declaration* ct_eval(
     TypedAST::Declaration* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
-	if (ast->m_type)
-		ast->m_type = ct_eval(ast->m_type, tc, alloc);
+	if (ast->m_type_hint)
+		ast->m_type_hint = ct_eval(ast->m_type_hint, tc, alloc);
 
 	ast->m_value = ct_eval(ast->m_value, tc, alloc);
 	return ast;
@@ -264,8 +264,8 @@ TypedAST::DeclarationList* ct_eval(
 			MonoId mt = mono_type_from_ast(handle->m_syntax, tc);
 			tc.m_core.m_mono_core.unify(mt, handle->m_value);
 		} else {
-			if (decl.m_type)
-				decl.m_type = ct_eval(decl.m_type, tc, alloc);
+			if (decl.m_type_hint)
+				decl.m_type_hint = ct_eval(decl.m_type_hint, tc, alloc);
 			decl.m_value = ct_eval(decl.m_value, tc, alloc);
 		}
 	}

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -221,6 +221,9 @@ MonoId mono_type_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc){
 
 TypedAST::Declaration* ct_eval(
     TypedAST::Declaration* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
+	if (ast->m_type)
+		ast->m_type = ct_eval(ast->m_type, tc, alloc);
+
 	ast->m_value = ct_eval(ast->m_value, tc, alloc);
 	return ast;
 }
@@ -237,7 +240,7 @@ TypedAST::DeclarationList* ct_eval(
 			handle->m_value = tc.m_core.m_tf_core.new_var();
 			handle->m_syntax = decl.m_value;
 			decl.m_value = handle;
-		} else if(meta_type == tc.meta_monotype()) {
+		} else if (meta_type == tc.meta_monotype()) {
 			auto handle = alloc.make<TypedAST::MonoTypeHandle>();
 			handle->m_value = tc.new_var(); // should it be hidden?
 			handle->m_syntax = decl.m_value;
@@ -247,9 +250,11 @@ TypedAST::DeclarationList* ct_eval(
 
 	for (auto& decl : ast->m_declarations) {
 		int meta_type = tc.m_core.m_meta_core.find(decl.m_meta_type);
+		// TODO: ban type hints from type function and mono type declarations?
 		if (meta_type == tc.meta_typefunc()) {
 			auto handle =
 			    static_cast<TypedAST::TypeFunctionHandle*>(decl.m_value);
+
 			TypeFunctionId tf = type_func_from_ast(handle->m_syntax, tc);
 			tc.m_core.m_tf_core.unify(tf, handle->m_value);
 		} else if (meta_type == tc.meta_monotype()) {
@@ -259,6 +264,8 @@ TypedAST::DeclarationList* ct_eval(
 			MonoId mt = mono_type_from_ast(handle->m_syntax, tc);
 			tc.m_core.m_mono_core.unify(mt, handle->m_value);
 		} else {
+			if (decl.m_type)
+				decl.m_type = ct_eval(decl.m_type, tc, alloc);
 			decl.m_value = ct_eval(decl.m_value, tc, alloc);
 		}
 	}

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -250,14 +250,15 @@ TypedAST::DeclarationList* ct_eval(
 
 	for (auto& decl : ast->m_declarations) {
 		int meta_type = tc.m_core.m_meta_core.find(decl.m_meta_type);
-		// TODO: ban type hints from type function and mono type declarations?
 		if (meta_type == tc.meta_typefunc()) {
+			assert(!decl.m_type_hint && "type hint not allowed in type function declaration");
 			auto handle =
 			    static_cast<TypedAST::TypeFunctionHandle*>(decl.m_value);
 
 			TypeFunctionId tf = type_func_from_ast(handle->m_syntax, tc);
 			tc.m_core.m_tf_core.unify(tf, handle->m_value);
 		} else if (meta_type == tc.meta_monotype()) {
+			assert(!decl.m_type_hint && "type hint not allowed in monotype declaration");
 			auto handle =
 			    static_cast<TypedAST::MonoTypeHandle*>(decl.m_value);
 

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -9,8 +9,8 @@
 namespace AST {
 
 Declaration* desugar(Declaration* ast, Allocator& alloc) {
-	if (ast->m_type)
-		ast->m_type = desugar(ast->m_type, alloc);
+	if (ast->m_type_hint)
+		ast->m_type_hint = desugar(ast->m_type_hint, alloc);
 
 	if (ast->m_value)
 		ast->m_value = desugar(ast->m_value, alloc);

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -9,7 +9,9 @@
 namespace AST {
 
 Declaration* desugar(Declaration* ast, Allocator& alloc) {
-	// TODO: handle type hint
+	if (ast->m_type)
+		ast->m_type = desugar(ast->m_type, alloc);
+
 	if (ast->m_value)
 		ast->m_value = desugar(ast->m_value, alloc);
 

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -7,8 +7,6 @@
 #include "error_report.hpp"
 #include "typed_ast.hpp"
 
-#include "ast_tag.hpp"
-
 #include <cassert>
 
 namespace TypeChecker {

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -26,8 +26,8 @@ namespace TypeChecker {
 	ast->m_surrounding_function = env.current_function();
 	env.declare(ast->identifier_text(), ast);
 
-	if (ast->m_type)
-		CHECK_AND_RETURN(match_identifiers(ast->m_type, env));
+	if (ast->m_type_hint)
+		CHECK_AND_RETURN(match_identifiers(ast->m_type_hint, env));
 
 	if (ast->m_value)
 		CHECK_AND_RETURN(match_identifiers(ast->m_value, env));
@@ -202,8 +202,8 @@ namespace TypeChecker {
 	for (auto& decl : ast->m_declarations) {
 		env.enter_top_level_decl(&decl);
 
-		if (decl.m_type)
-			CHECK_AND_RETURN(match_identifiers(decl.m_type, env));
+		if (decl.m_type_hint)
+			CHECK_AND_RETURN(match_identifiers(decl.m_type_hint, env));
 
 		if (decl.m_value)
 			CHECK_AND_RETURN(match_identifiers(decl.m_value, env));

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -7,6 +7,8 @@
 #include "error_report.hpp"
 #include "typed_ast.hpp"
 
+#include "ast_tag.hpp"
+
 #include <cassert>
 
 namespace TypeChecker {
@@ -23,6 +25,9 @@ namespace TypeChecker {
 
 	ast->m_surrounding_function = env.current_function();
 	env.declare(ast->identifier_text(), ast);
+
+	if (ast->m_type)
+		CHECK_AND_RETURN(match_identifiers(ast->m_type, env));
 
 	if (ast->m_value)
 		CHECK_AND_RETURN(match_identifiers(ast->m_value, env));
@@ -196,6 +201,9 @@ namespace TypeChecker {
 
 	for (auto& decl : ast->m_declarations) {
 		env.enter_top_level_decl(&decl);
+
+		if (decl.m_type)
+			CHECK_AND_RETURN(match_identifiers(decl.m_type, env));
 
 		if (decl.m_value)
 			CHECK_AND_RETURN(match_identifiers(decl.m_value, env));

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -147,7 +147,7 @@ void metacheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 
 	if (ast->m_type_hint) {
 		metacheck(ast->m_type_hint, tc);
-		assert(ast->m_type_hint->m_meta_type == tc.meta_monotype() && "Type hint must be a monotype");
+		tc.m_core.m_meta_core.unify(ast->m_type_hint->m_meta_type, tc.meta_monotype());
 	}
 
 	metacheck(ast->m_value, tc);
@@ -161,7 +161,7 @@ void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 	for (auto& decl : ast->m_declarations) {
 		if (decl.m_type_hint) {
 			metacheck(decl.m_type_hint, tc);
-			assert(decl.m_type_hint->m_meta_type == tc.meta_monotype() && "Type hint must be a monotype");
+			tc.m_core.m_meta_core.unify(decl.m_type_hint->m_meta_type, tc.meta_monotype());
 		}
 		metacheck(decl.m_value, tc);
 	}

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -144,6 +144,12 @@ void metacheck(TypedAST::ReturnStatement* ast, TypeChecker& tc) {
 
 void metacheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 	ast->m_meta_type = tc.new_meta_var();
+
+	if (ast->m_type) {
+		metacheck(ast->m_type, tc);
+		assert(ast->m_type->m_meta_type != tc.meta_value() && "Type hint must not be a value");
+	}
+
 	metacheck(ast->m_value, tc);
 	tc.m_core.m_meta_core.unify(ast->m_meta_type, ast->m_value->m_meta_type);
 }
@@ -152,8 +158,13 @@ void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 	for (auto& decl : ast->m_declarations)
 		decl.m_meta_type = tc.new_meta_var();
 
-	for (auto& decl : ast->m_declarations)
+	for (auto& decl : ast->m_declarations) {
+		if (decl.m_type) {
+			metacheck(decl.m_type, tc);
+			assert(decl.m_type->m_meta_type != tc.meta_value() && "Type hint must not be a value");
+		}
 		metacheck(decl.m_value, tc);
+	}
 
 	for (auto& decl : ast->m_declarations)
 		tc.m_core.m_meta_core.unify(decl.m_meta_type, decl.m_value->m_meta_type);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -145,9 +145,9 @@ void metacheck(TypedAST::ReturnStatement* ast, TypeChecker& tc) {
 void metacheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 	ast->m_meta_type = tc.new_meta_var();
 
-	if (ast->m_type) {
-		metacheck(ast->m_type, tc);
-		assert(ast->m_type->m_meta_type != tc.meta_value() && "Type hint must not be a value");
+	if (ast->m_type_hint) {
+		metacheck(ast->m_type_hint, tc);
+		assert(ast->m_type_hint->m_meta_type != tc.meta_value() && "Type hint must not be a value");
 	}
 
 	metacheck(ast->m_value, tc);
@@ -159,9 +159,9 @@ void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 		decl.m_meta_type = tc.new_meta_var();
 
 	for (auto& decl : ast->m_declarations) {
-		if (decl.m_type) {
-			metacheck(decl.m_type, tc);
-			assert(decl.m_type->m_meta_type != tc.meta_value() && "Type hint must not be a value");
+		if (decl.m_type_hint) {
+			metacheck(decl.m_type_hint, tc);
+			assert(decl.m_type_hint->m_meta_type != tc.meta_value() && "Type hint must not be a value");
 		}
 		metacheck(decl.m_value, tc);
 	}

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -147,7 +147,7 @@ void metacheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 
 	if (ast->m_type_hint) {
 		metacheck(ast->m_type_hint, tc);
-		assert(ast->m_type_hint->m_meta_type != tc.meta_value() && "Type hint must not be a value");
+		assert(ast->m_type_hint->m_meta_type == tc.meta_monotype() && "Type hint must be a monotype");
 	}
 
 	metacheck(ast->m_value, tc);
@@ -161,7 +161,7 @@ void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 	for (auto& decl : ast->m_declarations) {
 		if (decl.m_type_hint) {
 			metacheck(decl.m_type_hint, tc);
-			assert(decl.m_type_hint->m_meta_type != tc.meta_value() && "Type hint must not be a value");
+			assert(decl.m_type_hint->m_meta_type == tc.meta_monotype() && "Type hint must be a monotype");
 		}
 		metacheck(decl.m_value, tc);
 	}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -210,7 +210,7 @@ Writer<AST::Declaration*> Parser::parse_declaration() {
 	auto p = m_ast_allocator->make<AST::Declaration>();
 
 	p->m_identifier_token = name.m_result;
-	p->m_type = type.m_result;
+	p->m_type_hint = type.m_result;
 	p->m_value = value.m_result;
 
 	return make_writer<AST::Declaration*>(p);
@@ -735,7 +735,7 @@ Writer<AST::AST*> Parser::parse_function() {
 				auto type = parse_type_term();
 				if (handle_error(result, type))
 					return result;
-				arg.m_type = type.m_result;
+				arg.m_type_hint = type.m_result;
 			}
 
 			args.push_back(std::move(arg));

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -37,7 +37,7 @@ struct Parser {
 	parse_expression_list(TokenTag, TokenTag, bool);
 
 	Writer<AST::AST*> parse_top_level();
-	Writer<AST::Identifier*> parse_identifier();
+	Writer<AST::Identifier*> parse_identifier(bool types_allowed = false);
 	Writer<AST::Declaration*> parse_declaration();
 	Writer<AST::AST*> parse_expression(int bp = 0);
 	Writer<AST::AST*> parse_terminal();

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -491,6 +491,34 @@ void interpreter_tests(Test::Tester& tests) {
 	        +[](Interpreter::Environment& env) -> ExitStatusTag {
 		        return Assert::equals(eval_expression("test2()", env), "ABA");
 		}}));
+
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	    R"(
+			a : int(<>) = 1;
+			b : string(<>) = "hello";
+			c : array(< int(<>) >) = array { 1; 2; };
+			d : array(< string(<>) >) = array { "hello"; ","; "world"; };
+			e : boolean(<>) = true;
+
+			__invoke := fn() => e;
+		)",
+	    Testers {
+	        +[](Interpreter::Environment& env) -> ExitStatusTag {
+	                return Assert::equals(eval_expression("a", env), 1);
+	        },
+	        +[](Interpreter::Environment& env) -> ExitStatusTag {
+	                return Assert::equals(eval_expression("b", env), "hello");
+	        },
+	        +[](Interpreter::Environment& env) -> ExitStatusTag {
+	                return Assert::array_of_size(eval_expression("c", env), 2);
+	        },
+	        +[](Interpreter::Environment& env) -> ExitStatusTag {
+	                return Assert::array_of_size(eval_expression("d", env), 3);
+	        },
+	        +[](Interpreter::Environment& env) -> ExitStatusTag {
+	                return Assert::is_true(eval_expression("__invoke()", env));
+	        },
+	        }));
 }
 
 void tarjan_algorithm_tests(Test::Tester& tester) {

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -497,10 +497,12 @@ void interpreter_tests(Test::Tester& tests) {
 			a : int(<>) = 1;
 			b : string(<>) = "hello";
 			c : array(< int(<>) >) = array { 1; 2; };
-			d : array(< string(<>) >) = array { "hello"; ","; "world"; };
-			e : boolean(<>) = true;
 
-			__invoke := fn() => e;
+			__invoke := fn() {
+				d : array(< string(<>) >) = array { "hello"; ","; "world"; };
+				e : boolean(<>) = true;
+				return d;
+			};
 		)",
 	    Testers {
 	        +[](Interpreter::Environment& env) -> ExitStatusTag {
@@ -513,10 +515,7 @@ void interpreter_tests(Test::Tester& tests) {
 	                return Assert::array_of_size(eval_expression("c", env), 2);
 	        },
 	        +[](Interpreter::Environment& env) -> ExitStatusTag {
-	                return Assert::array_of_size(eval_expression("d", env), 3);
-	        },
-	        +[](Interpreter::Environment& env) -> ExitStatusTag {
-	                return Assert::is_true(eval_expression("__invoke()", env));
+	                return Assert::array_of_size(eval_expression("__invoke()", env), 3);
 	        },
 	        }));
 }

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -10,8 +10,6 @@
 #include <iostream>
 #include <unordered_set>
 
-#include "typed_ast_tag.hpp"
-
 namespace TypeChecker {
 
 // NOTE: This file duplicates a bit of what match_identifiers does.

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -58,14 +58,9 @@ void typecheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 	ast->m_value_type = tc.new_var();
 
 	if (ast->m_type_hint) {
-		if (ast->m_type_hint->type() == TypedASTTag::MonoTypeHandle) {
-			auto handle = static_cast<TypedAST::MonoTypeHandle*>(ast->m_type_hint);
-			tc.m_core.m_mono_core.unify(ast->m_value_type, handle->m_value);
-		}
-		else {
-			auto handle = static_cast<TypedAST::TypeFunctionHandle*>(ast->m_type_hint);
-			tc.m_core.m_tf_core.unify(ast->m_value_type, handle->m_value);
-		}
+		assert(ast->m_type_hint->type() == TypedASTTag::MonoTypeHandle);
+		auto handle = static_cast<TypedAST::MonoTypeHandle*>(ast->m_type_hint);
+		tc.m_core.m_mono_core.unify(ast->m_value_type, handle->m_value);
 	}
 
 	// this is where we implement rec-polymorphism.
@@ -348,14 +343,9 @@ void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 			auto decl = index_to_decl[u];
 
 			if (decl->m_type_hint) {
-				if (decl->m_type_hint->type() == TypedASTTag::MonoTypeHandle) {
-					auto handle = static_cast<TypedAST::MonoTypeHandle*>(decl->m_type_hint);
-					tc.m_core.m_mono_core.unify(decl->m_value_type, handle->m_value);
-				}
-				else {
-					auto handle = static_cast<TypedAST::TypeFunctionHandle*>(decl->m_type_hint);
-					tc.m_core.m_tf_core.unify(decl->m_value_type, handle->m_value);
-				}
+				assert(decl->m_type_hint->type() == TypedASTTag::MonoTypeHandle);
+				auto handle = static_cast<TypedAST::MonoTypeHandle*>(decl->m_type_hint);
+				tc.m_core.m_mono_core.unify(decl->m_value_type, handle->m_value);
 			}
 
 			if (decl->m_value) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -10,6 +10,8 @@
 #include <iostream>
 #include <unordered_set>
 
+#include "typed_ast_tag.hpp"
+
 namespace TypeChecker {
 
 // NOTE: This file duplicates a bit of what match_identifiers does.
@@ -56,6 +58,17 @@ void typecheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 
 
 	ast->m_value_type = tc.new_var();
+
+	if (ast->m_type) {
+		if (ast->m_type->type() == TypedASTTag::MonoTypeHandle) {
+			auto handle = static_cast<TypedAST::MonoTypeHandle*>(ast->m_type);
+			tc.m_core.m_mono_core.unify(ast->m_value_type, handle->m_value);
+		}
+		else {
+			auto handle = static_cast<TypedAST::TypeFunctionHandle*>(ast->m_type);
+			tc.m_core.m_tf_core.unify(ast->m_value_type, handle->m_value);
+		}
+	}
 
 	// this is where we implement rec-polymorphism.
 	// TODO: refactor (duplication).
@@ -335,6 +348,17 @@ void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 		// decl equal to the type of their value
 		for (int u : verts) {
 			auto decl = index_to_decl[u];
+
+			if (decl->m_type) {
+				if (decl->m_type->type() == TypedASTTag::MonoTypeHandle) {
+					auto handle = static_cast<TypedAST::MonoTypeHandle*>(decl->m_type);
+					tc.m_core.m_mono_core.unify(decl->m_value_type, handle->m_value);
+				}
+				else {
+					auto handle = static_cast<TypedAST::TypeFunctionHandle*>(decl->m_type);
+					tc.m_core.m_tf_core.unify(decl->m_value_type, handle->m_value);
+				}
+			}
 
 			if (decl->m_value) {
 				typecheck(decl->m_value, tc);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -59,13 +59,13 @@ void typecheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 
 	ast->m_value_type = tc.new_var();
 
-	if (ast->m_type) {
-		if (ast->m_type->type() == TypedASTTag::MonoTypeHandle) {
-			auto handle = static_cast<TypedAST::MonoTypeHandle*>(ast->m_type);
+	if (ast->m_type_hint) {
+		if (ast->m_type_hint->type() == TypedASTTag::MonoTypeHandle) {
+			auto handle = static_cast<TypedAST::MonoTypeHandle*>(ast->m_type_hint);
 			tc.m_core.m_mono_core.unify(ast->m_value_type, handle->m_value);
 		}
 		else {
-			auto handle = static_cast<TypedAST::TypeFunctionHandle*>(ast->m_type);
+			auto handle = static_cast<TypedAST::TypeFunctionHandle*>(ast->m_type_hint);
 			tc.m_core.m_tf_core.unify(ast->m_value_type, handle->m_value);
 		}
 	}
@@ -349,13 +349,13 @@ void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 		for (int u : verts) {
 			auto decl = index_to_decl[u];
 
-			if (decl->m_type) {
-				if (decl->m_type->type() == TypedASTTag::MonoTypeHandle) {
-					auto handle = static_cast<TypedAST::MonoTypeHandle*>(decl->m_type);
+			if (decl->m_type_hint) {
+				if (decl->m_type_hint->type() == TypedASTTag::MonoTypeHandle) {
+					auto handle = static_cast<TypedAST::MonoTypeHandle*>(decl->m_type_hint);
 					tc.m_core.m_mono_core.unify(decl->m_value_type, handle->m_value);
 				}
 				else {
-					auto handle = static_cast<TypedAST::TypeFunctionHandle*>(decl->m_type);
+					auto handle = static_cast<TypedAST::TypeFunctionHandle*>(decl->m_type_hint);
 					tc.m_core.m_tf_core.unify(decl->m_value_type, handle->m_value);
 				}
 			}

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -127,6 +127,7 @@ TypeChecker::TypeChecker(TypedAST::Allocator& allocator) : m_typed_ast_allocator
 	declare_builtin("float", meta_typefunc(), BuiltinType::Float);
 	declare_builtin("string", meta_typefunc(), BuiltinType::String);
 	declare_builtin("boolean", meta_typefunc(), BuiltinType::Boolean);
+	declare_builtin("array", meta_typefunc(), BuiltinType::Array);
 }
 
 MonoId TypeChecker::new_hidden_var() {

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -80,8 +80,8 @@ TypedAST* convert_ast(AST::Declaration* ast, Allocator& alloc) {
 
 	typed_dec->m_identifier_token = ast->m_identifier_token;
 
-	if (ast->m_type)
-		typed_dec->m_type = convert_ast(ast->m_type, alloc);
+	if (ast->m_type_hint)
+		typed_dec->m_type_hint = convert_ast(ast->m_type_hint, alloc);
 
 	if (ast->m_value)
 		typed_dec->m_value = convert_ast(ast->m_value, alloc);

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -79,7 +79,10 @@ TypedAST* convert_ast(AST::Declaration* ast, Allocator& alloc) {
 	auto typed_dec = alloc.make<Declaration>();
 
 	typed_dec->m_identifier_token = ast->m_identifier_token;
-	// TODO: handle type hint
+
+	if (ast->m_type)
+		typed_dec->m_type = convert_ast(ast->m_type, alloc);
+
 	if (ast->m_value)
 		typed_dec->m_value = convert_ast(ast->m_value, alloc);
 

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -42,6 +42,7 @@ struct FunctionLiteral;
 
 struct Declaration : public TypedAST {
 	Token const* m_identifier_token;
+	TypedAST* m_type {nullptr};  // can be nullptr
 	TypedAST* m_value {nullptr}; // can be nullptr
 
 	std::unordered_set<Declaration*> m_references;

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -42,7 +42,7 @@ struct FunctionLiteral;
 
 struct Declaration : public TypedAST {
 	Token const* m_identifier_token;
-	TypedAST* m_type {nullptr};  // can be nullptr
+	TypedAST* m_type_hint {nullptr};  // can be nullptr
 	TypedAST* m_value {nullptr}; // can be nullptr
 
 	std::unordered_set<Declaration*> m_references;


### PR DESCRIPTION
Implements declaration type hints, also allows parsing some type keywords as identifiers (for type terms) and declares `array` as a possible type in typechecker.