### PR TITLE
add compile time value header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ COMMON_TARGETS := \
 	utils/string_view \
 	ast \
 	compile_time_environment \
+	compile_time_value \
 	compute_offsets \
 	ct_eval \
 	desugar \

--- a/src/compile_time_value.cpp
+++ b/src/compile_time_value.cpp
@@ -1,0 +1,1 @@
+#include "compile_time_value.hpp"

--- a/src/compile_time_value.hpp
+++ b/src/compile_time_value.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+namespace TypedAST {
+struct TypedAST;
+}
+
+/* this namespace name is not very good */
+namespace TypeChecker {
+
+enum class ValueTag {
+	RuntimeExpression,
+	TypeFunctionHandle,
+	MonoTypeHandle,
+};
+
+struct Value {
+	ValueTag m_tag;
+	ValueTag tag() const {
+		return m_tag;
+	}
+};
+
+struct RuntimeExpression : public Value {
+	TypedAST::TypedAST* m_ast;
+	RuntimeExpression()
+	    : Value {ValueTag::RuntimeExpression} {}
+};
+
+struct TypeFunctionHandle : public Value {
+	int m_id;
+	TypeFunctionHandle()
+	    : Value {ValueTag::TypeFunctionHandle} {}
+};
+
+struct MonoTypeHandle : public Value {
+	int m_id;
+	MonoTypeHandle()
+	    : Value {ValueTag::MonoTypeHandle} {}
+};
+
+}


### PR DESCRIPTION
Right now, we have, essentially, a compile time interpreter for type expressions. This walks ASTs recursively and replaces some expressions with a handle to their corresponding value.

The type it uses to represent these things is `TypedAST::TypedAST`. To represent type handles, we have some `TypedAST::xxxHandle` types. I feel like this abstraction is very messy. Maybe we would benefit from rethinking how this works?

My idea is roughly as follows:

have a base type, called `CompileTimeValue`, or something like that.

Have a few different subtypes, each one responsible for storing

 - An expression (i.e. a `TypedAST` node)
 - A type function handle
 - A mono type handle