### PR TITLE
Union integration

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -153,13 +153,13 @@ void print(IndexExpression* ast, int d) {
 	std::cout << stab << "]\n";
 }
 
-void print(RecordAccessExpression* ast, int d) {
+void print(AccessExpression* ast, int d) {
 	print_indentation(d - 1);
-	std::cout << "[ RecordAccessExpression\n";
+	std::cout << "[ AccessExpression\n";
 
 	print_indentation(d);
-	std::cout << "Record:\n";
-	print(ast->m_record, d + 1);
+	std::cout << "Object:\n";
+	print(ast->m_object, d + 1);
 
 	print_indentation(d);
 	std::cout << "Member: " << ast->m_member->m_text << "\n";
@@ -265,8 +265,8 @@ void print(AST* ast, int d) {
 		return print(static_cast<IndexExpression*>(ast), d);
 	case ASTTag::TernaryExpression:
 		return print(static_cast<TernaryExpression*>(ast), d);
-	case ASTTag::RecordAccessExpression:
-		return print(static_cast<RecordAccessExpression*>(ast), d);
+	case ASTTag::AccessExpression:
+		return print(static_cast<AccessExpression*>(ast), d);
 
 	case ASTTag::DeclarationList:
 		return print(static_cast<DeclarationList*>(ast), d);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -166,12 +166,12 @@ struct IndexExpression : public AST {
 	    : AST {ASTTag::IndexExpression} {}
 };
 
-struct RecordAccessExpression : public AST {
-	AST* m_record;
+struct AccessExpression : public AST {
+	AST* m_object;
 	Token const* m_member;
 
-	RecordAccessExpression()
-	    : AST {ASTTag::RecordAccessExpression} {}
+	AccessExpression()
+	    : AST {ASTTag::AccessExpression} {}
 };
 
 struct TernaryExpression : public AST {

--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -18,7 +18,7 @@
 	X(BinaryExpression) \
 	X(CallExpression) \
 	X(IndexExpression) \
-	X(RecordAccessExpression) \
+	X(AccessExpression) \
 	X(ConstructorExpression) \
 	X(Block) \
 	X(ReturnStatement) \

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -185,6 +185,7 @@ void compute_offsets(TypedAST::TypedAST* ast, int frame_offset) {
 
 		DO_NOTHING(TypeFunctionHandle);
 		DO_NOTHING(MonoTypeHandle);
+		DO_NOTHING(Constructor);
 	}
 
 #undef DO_NOTHING

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -117,8 +117,8 @@ void compute_offsets(TypedAST::TernaryExpression* ast, int frame_offset) {
 	compute_offsets(ast->m_else_expr, frame_offset);
 }
 
-void compute_offsets(TypedAST::RecordAccessExpression* ast, int frame_offset) {
-	compute_offsets(ast->m_record, frame_offset);
+void compute_offsets(TypedAST::AccessExpression* ast, int frame_offset) {
+	compute_offsets(ast->m_object, frame_offset);
 }
 
 void compute_offsets(TypedAST::ConstructorExpression* ast, int frame_offset) {
@@ -168,7 +168,7 @@ void compute_offsets(TypedAST::TypedAST* ast, int frame_offset) {
 		DISPATCH(IndexExpression);
 		DISPATCH(CallExpression);
 		DISPATCH(TernaryExpression);
-		DISPATCH(RecordAccessExpression);
+		DISPATCH(AccessExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -173,7 +173,6 @@ TypeFunctionId type_func_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc) {
 	} else if (ast->type() == TypedASTTag::UnionExpression) {
 		auto as_ue = static_cast<TypedAST::UnionExpression*>(ast);
 
-		std::vector<InternedString> constructors;
 		std::unordered_map<InternedString, MonoId> structure;
 		int constructor_count = as_ue->m_constructors.size();
 		for (int i = 0; i < constructor_count; ++i){
@@ -181,11 +180,10 @@ TypeFunctionId type_func_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc) {
 			InternedString name = as_ue->m_constructors[i].text();
 			assert(!structure.count(name));
 			structure[name] = mono;
-			constructors.push_back(name);
 		}
 
 		TypeFunctionId result = tc.m_core.new_type_function(
-		    TypeFunctionTag::Sum, std::move(constructors), std::move(structure));
+		    TypeFunctionTag::Sum, {}, std::move(structure));
 
 		return result;
 	} else if (ast->type() == TypedASTTag::StructExpression) {

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -247,7 +247,19 @@ TypedAST::Constructor* constructor_from_ast(
 		assert(ast->type() == TypedASTTag::AccessExpression);
 
 		auto access = static_cast<TypedAST::AccessExpression*>(ast);
-		constructor->m_mono = mono_type_from_ast(access->m_object, tc);
+
+		// dummy with one constructor, the one used
+		std::unordered_map<InternedString, MonoId> structure;
+		structure[access->m_member->m_text] = tc.new_var();
+		TypeFunctionId dummy_tf = tc.m_core.new_type_function(
+		    TypeFunctionTag::Sum, {}, std::move(structure), true);
+
+		MonoId monotype = mono_type_from_ast(access->m_object, tc);
+		TypeFunctionId tf = tc.m_core.m_mono_core.find_function(monotype);
+
+		tc.m_core.m_tf_core.unify(dummy_tf, tf);
+
+		constructor->m_mono = monotype;
 		constructor->m_id = access->m_member;
 	} else {
 		assert(0 && "wrong constructor metatype");

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -96,9 +96,9 @@ TypedAST::TernaryExpression* ct_eval(
 	return ast;
 }
 
-TypedAST::RecordAccessExpression* ct_eval(
-    TypedAST::RecordAccessExpression* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
-	ast->m_record = ct_eval(ast->m_record, tc, alloc);
+TypedAST::AccessExpression* ct_eval(
+    TypedAST::AccessExpression* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
+	ast->m_object = ct_eval(ast->m_object, tc, alloc);
 	return ast;
 }
 
@@ -243,11 +243,11 @@ TypedAST::Constructor* constructor_from_ast(
 		    ct_eval(ast, tc, alloc));
 		constructor->m_mono = mono_handle;
 	} else if (meta == tc.meta_constructor()) {
-		assert(ast->type() == TypedASTTag::RecordAccessExpression);
+		assert(ast->type() == TypedASTTag::AccessExpression);
 
-		auto access = static_cast<TypedAST::RecordAccessExpression*>(ast);
+		auto access = static_cast<TypedAST::AccessExpression*>(ast);
 		auto mono_handle = static_cast<TypedAST::MonoTypeHandle*>(
-		    ct_eval(access->m_record, tc, alloc));
+		    ct_eval(access->m_object, tc, alloc));
 
 		constructor->m_mono = mono_handle;
 		constructor->m_id = access->m_member;
@@ -346,7 +346,7 @@ TypedAST::TypedAST* ct_eval(
 		DISPATCH(CallExpression);
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
-		DISPATCH(RecordAccessExpression);
+		DISPATCH(AccessExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -96,8 +96,13 @@ TypedAST::TernaryExpression* ct_eval(
 	return ast;
 }
 
-TypedAST::AccessExpression* ct_eval(
+TypedAST::TypedAST* ct_eval(
     TypedAST::AccessExpression* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
+	MetaTypeId metatype = tc.m_core.m_meta_core.find(ast->m_meta_type);
+	// TODO: support vars
+	if (metatype == tc.meta_constructor())
+		return constructor_from_ast(ast, tc, alloc);
+
 	ast->m_object = ct_eval(ast->m_object, tc, alloc);
 	return ast;
 }

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -239,17 +239,12 @@ TypedAST::Constructor* constructor_from_ast(
 	constructor->m_syntax = ast;
 
 	if (meta == tc.meta_monotype()) {
-		auto mono_handle = static_cast<TypedAST::MonoTypeHandle*>(
-		    ct_eval(ast, tc, alloc));
-		constructor->m_mono = mono_handle;
+		constructor->m_mono = mono_type_from_ast(ast, tc);
 	} else if (meta == tc.meta_constructor()) {
 		assert(ast->type() == TypedASTTag::AccessExpression);
 
 		auto access = static_cast<TypedAST::AccessExpression*>(ast);
-		auto mono_handle = static_cast<TypedAST::MonoTypeHandle*>(
-		    ct_eval(access->m_object, tc, alloc));
-
-		constructor->m_mono = mono_handle;
+		constructor->m_mono = mono_type_from_ast(access->m_object, tc);
 		constructor->m_id = access->m_member;
 	} else {
 		assert(0 && "wrong constructor metatype");

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -89,8 +89,8 @@ AST* desugarPizza(BinaryExpression* ast, Allocator& alloc) {
 	return rhs;
 }
 
-AST* desugar(RecordAccessExpression* ast, Allocator& alloc) {
-	ast->m_record = desugar(ast->m_record, alloc);
+AST* desugar(AccessExpression* ast, Allocator& alloc) {
+	ast->m_object = desugar(ast->m_object, alloc);
 	return ast;
 }
 
@@ -218,7 +218,7 @@ AST* desugar(AST* ast, Allocator& alloc) {
 		DISPATCH(TernaryExpression);
 		DISPATCH(CallExpression);
 		DISPATCH(IndexExpression);
-		DISPATCH(RecordAccessExpression);
+		DISPATCH(AccessExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(DeclarationList);

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -267,8 +267,8 @@ void eval(TypedAST::FunctionLiteral* ast, Interpreter& e) {
 	e.m_env.push(result.get());
 };
 
-void eval(TypedAST::RecordAccessExpression* ast, Interpreter& e) {
-	eval(ast->m_record, e);
+void eval(TypedAST::AccessExpression* ast, Interpreter& e) {
+	eval(ast->m_object, e);
 	auto rec = e.m_env.pop();
 	auto rec_val = unboxed(rec.get());
 	assert(rec_val->type() == ValueTag::Object);
@@ -438,7 +438,7 @@ void eval(TypedAST::TypedAST* ast, Interpreter& e) {
 		DISPATCH(CallExpression);
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
-		DISPATCH(RecordAccessExpression);
+		DISPATCH(AccessExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(DeclarationList);

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -403,8 +403,7 @@ void eval(TypedAST::MonoTypeHandle* ast, Interpreter& e) {
 }
 
 void eval(TypedAST::Constructor* ast, Interpreter& e) {
-	TypeFunctionId tf_header =
-	    e.m_tc->m_core.m_mono_core.find_function(ast->m_mono->m_value);
+	TypeFunctionId tf_header = e.m_tc->m_core.m_mono_core.find_function(ast->m_mono);
 	int tf = e.m_tc->m_core.m_tf_core.find_function(tf_header);
 	auto& tf_data = e.m_tc->m_core.m_type_functions[tf];
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -280,29 +280,40 @@ void eval(TypedAST::ConstructorExpression* ast, Interpreter& e) {
 	eval(ast->m_constructor, e);
 	auto constructor = e.m_env.pop();
 	auto constructor_value = unboxed(constructor.get());
-	assert(constructor_value->type() == ValueTag::StructConstructor);
 
-	auto constructor_actually = static_cast<StructConstructor*>(constructor_value);
+	if (constructor_value->type() == ValueTag::StructConstructor) {
+		auto constructor_actually = static_cast<StructConstructor*>(constructor_value);
 
-	assert(ast->m_args.size() == constructor_actually->m_keys.size());
+		assert(ast->m_args.size() == constructor_actually->m_keys.size());
 
-	int storage_point = e.m_env.m_stack_ptr;
-	ObjectType record;
-	for (int i = 0; i < ast->m_args.size(); ++i)
-		eval(ast->m_args[i], e);
+		int storage_point = e.m_env.m_stack_ptr;
+		ObjectType record;
+		for (int i = 0; i < ast->m_args.size(); ++i)
+			eval(ast->m_args[i], e);
 
-	for (int i = 0; i < ast->m_args.size(); ++i) {
-		record[constructor_actually->m_keys[i]] = e.m_env.m_stack[storage_point + i];
-	}
-	
-	auto result = e.m_gc->new_object(std::move(record));
+		for (int i = 0; i < ast->m_args.size(); ++i) {
+			record[constructor_actually->m_keys[i]] =
+			    e.m_env.m_stack[storage_point + i];
+		}
+		
+		auto result = e.m_gc->new_object(std::move(record));
 
-	while (e.m_env.m_stack_ptr > storage_point)
+		while (e.m_env.m_stack_ptr > storage_point)
+			e.m_env.pop();
+
+		e.m_env.push(result.get());
+	} else if (constructor_value->type() == ValueTag::UnionConstructor) {
+		auto constructor_actually = static_cast<UnionConstructor*>(constructor_value);
+
+		assert(ast->m_args.size() == 1);
+
+		eval(ast->m_args[0], e);
+		auto result = e.m_gc->new_union(
+		    constructor_actually->m_constructor, e.m_env.m_stack.back());
 		e.m_env.pop();
 
-	// e.m_env.pop();
-
-	e.m_env.push(result.get());
+		e.m_env.push(result.get());
+	}
 }
 
 void eval(TypedAST::IfElseStatement* ast, Interpreter& e) {
@@ -376,6 +387,7 @@ void eval(TypedAST::WhileStatement* ast, Interpreter& e) {
 	}
 };
 
+// TODO: include union implementations? if so, remove duplication
 void eval(TypedAST::TypeFunctionHandle* ast, Interpreter& e) {
 	int type_function = e.m_tc->m_core.m_tf_core.find_function(ast->m_value);
 	auto& type_function_data = e.m_tc->m_core.m_type_functions[type_function];
@@ -388,6 +400,21 @@ void eval(TypedAST::MonoTypeHandle* ast, Interpreter& e) {
 	int type_function = e.m_tc->m_core.m_tf_core.find_function(type_function_header);
 	auto& type_function_data = e.m_tc->m_core.m_type_functions[type_function];
 	e.push_struct_constructor(type_function_data.fields);
+}
+
+void eval(TypedAST::Constructor* ast, Interpreter& e) {
+	TypeFunctionId tf_header =
+	    e.m_tc->m_core.m_mono_core.find_function(ast->m_mono->m_value);
+	int tf = e.m_tc->m_core.m_tf_core.find_function(tf_header);
+	auto& tf_data = e.m_tc->m_core.m_type_functions[tf];
+
+	if (tf_data.tag == TypeFunctionTag::Record) {
+		e.push_struct_constructor(tf_data.fields);
+	} else if (tf_data.tag == TypeFunctionTag::Sum) {
+		e.push_union_constructor(ast->m_id->m_text);
+	} else {
+		assert(0 && "not implemented this type function for construction");
+	}
 }
 
 void eval(TypedAST::TypedAST* ast, Interpreter& e) {
@@ -425,6 +452,7 @@ void eval(TypedAST::TypedAST* ast, Interpreter& e) {
 
 		DISPATCH(TypeFunctionHandle);
 		DISPATCH(MonoTypeHandle);
+		DISPATCH(Constructor);
 	}
 
 	std::cerr << "@ Internal Error: unhandled case in eval:\n";

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -61,6 +61,12 @@ Null* GC::null() {
 	return m_null;
 }
 
+gc_ptr<Union> GC::new_union(InternedString constructor, Value* v) {
+	auto result = new Union(constructor, v);
+	m_blocks.push_back(result);
+	return result;
+}
+
 gc_ptr<Object> GC::new_object(ObjectType declarations) {
 	auto result = new Object;
 	result->m_value = std::move(declarations);
@@ -146,7 +152,13 @@ gc_ptr<Reference> GC::new_reference(Value* v) {
 	return result;
 }
 
-StructConstructor* GC::new_struct_constructor_raw(std::vector<InternedString> keys){
+UnionConstructor* GC::new_union_constructor_raw(InternedString constructor) {
+	auto result = new UnionConstructor(constructor);
+	m_blocks.push_back(result);
+	return result;
+}
+
+StructConstructor* GC::new_struct_constructor_raw(std::vector<InternedString> keys) {
 	auto result = new StructConstructor(std::move(keys));
 	m_blocks.push_back(result);
 	return result;

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -30,6 +30,7 @@ struct GC {
 
 	auto null() -> Null*;
 
+	auto new_union(InternedString constructor, Value* v) -> gc_ptr<Union>;
 	auto new_object(ObjectType) -> gc_ptr<Object>;
 	auto new_dictionary(DictionaryType) -> gc_ptr<Dictionary>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;
@@ -46,6 +47,7 @@ struct GC {
 	auto new_float_raw(float) -> Float*;
 	auto new_boolean_raw(bool) -> Boolean*;
 	auto new_string_raw(std::string) -> String*;
+	auto new_union_constructor_raw(InternedString) -> UnionConstructor*;
 	auto new_struct_constructor_raw(std::vector<InternedString>) -> StructConstructor*;
 };
 

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -101,6 +101,11 @@ void Interpreter::push_string(std::string s) {
 	run_gc_if_needed();
 }
 
+void Interpreter::push_union_constructor(InternedString constructor) {
+	m_env.push(m_gc->new_union_constructor_raw(constructor));
+	run_gc_if_needed();
+}
+
 void Interpreter::push_struct_constructor(std::vector<InternedString> keys) {
 	m_env.push(m_gc->new_struct_constructor_raw(std::move(keys)));
 	run_gc_if_needed();

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -52,6 +52,7 @@ struct Interpreter {
 	void push_float(float);
 	void push_boolean(bool);
 	void push_string(std::string);
+	void push_union_constructor(InternedString constructor);
 	void push_struct_constructor(std::vector<InternedString>);
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_object(ObjectType) -> gc_ptr<Object>;

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -97,6 +97,15 @@ void Dictionary::removeMember(StringType const& id) {
 	m_value.erase(id);
 }
 
+Union::Union(InternedString constructor)
+    : Value(ValueTag::Dictionary)
+    , m_constructor(constructor) {}
+
+Union::Union(InternedString constructor, Value* v)
+    : Value(ValueTag::Dictionary)
+    , m_constructor(constructor)
+    , m_inner_value(v) {}
+
 Function::Function(FunctionType def, ObjectType captures)
     : Value(ValueTag::Function)
     , m_def(def)
@@ -167,6 +176,14 @@ void gc_visit(Dictionary* d) {
 		gc_visit(child.second);
 }
 
+void gc_visit(Union* u) {
+	if (u->m_visited)
+		return;
+
+	u->m_visited = true;
+	gc_visit(u->m_inner_value);
+}
+
 void gc_visit(Function* f) {
 	if (f->m_visited)
 		return;
@@ -205,6 +222,8 @@ void gc_visit(Value* v) {
 		return gc_visit(static_cast<Object*>(v));
 	case ValueTag::Dictionary:
 		return gc_visit(static_cast<Dictionary*>(v));
+	case ValueTag::Union:
+		return gc_visit(static_cast<Union*>(v));
 	case ValueTag::Function:
 		return gc_visit(static_cast<Function*>(v));
 	case ValueTag::NativeFunction:
@@ -271,6 +290,12 @@ void print(Dictionary* m, int d) {
 	std::cout << value_string[int(m->type())] << '\n';
 }
 
+void print(Union* m, int d) {
+	// TODO
+	print_spaces(d);
+	std::cout << value_string[int(m->type())] << '\n';
+}
+
 void print(Function* f, int d) {
 	// TODO
 	print_spaces(d);
@@ -323,6 +348,8 @@ void print(Value* v, int d) {
 		return print(static_cast<Object*>(v), d);
 	case ValueTag::Dictionary:
 		return print(static_cast<Dictionary*>(v), d);
+	case ValueTag::Union:
+		return print(static_cast<Union*>(v), d);
 	case ValueTag::Function:
 		return print(static_cast<Function*>(v), d);
 	case ValueTag::NativeFunction:

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -300,9 +300,9 @@ void print(Dictionary* m, int d) {
 }
 
 void print(Union* m, int d) {
-	// TODO
 	print_spaces(d);
-	std::cout << value_string[int(m->type())] << '\n';
+	std::cout << value_string[int(m->type())] << " " << m->m_constructor << '\n';
+	print(m->m_inner_value, d);
 }
 
 void print(Function* f, int d) {

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -98,11 +98,11 @@ void Dictionary::removeMember(StringType const& id) {
 }
 
 Union::Union(InternedString constructor)
-    : Value(ValueTag::Dictionary)
+    : Value(ValueTag::Union)
     , m_constructor(constructor) {}
 
 Union::Union(InternedString constructor, Value* v)
-    : Value(ValueTag::Dictionary)
+    : Value(ValueTag::Union)
     , m_constructor(constructor)
     , m_inner_value(v) {}
 
@@ -237,6 +237,8 @@ void gc_visit(Value* v) {
 		return gc_visit(static_cast<NativeFunction*>(v));
 	case ValueTag::Reference:
 		return gc_visit(static_cast<Reference*>(v));
+	case ValueTag::UnionConstructor:
+		return gc_visit(static_cast<UnionConstructor*>(v));
 	case ValueTag::StructConstructor:
 		return gc_visit(static_cast<StructConstructor*>(v));
 	}
@@ -363,6 +365,8 @@ void print(Value* v, int d) {
 		return print(static_cast<NativeFunction*>(v), d);
 	case ValueTag::Reference:
 		return print(static_cast<Reference*>(v), d);
+	case ValueTag::UnionConstructor:
+		return print(static_cast<UnionConstructor*>(v), d);
 	case ValueTag::StructConstructor:
 		return print(static_cast<StructConstructor*>(v), d);
 	}

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -119,6 +119,10 @@ Reference::Reference(Value* value)
     : Value {ValueTag::Reference}
     , m_value {value} {}
 
+UnionConstructor::UnionConstructor(InternedString constructor)
+    : Value {ValueTag::UnionConstructor}
+    , m_constructor {constructor} {}
+
 StructConstructor::StructConstructor(std::vector<InternedString> keys)
     : Value {ValueTag::StructConstructor}
     , m_keys {std::move(keys)} {}
@@ -142,6 +146,9 @@ void gc_visit(Error* v) {
 	v->m_visited = true;
 }
 void gc_visit(NativeFunction* v) {
+	v->m_visited = true;
+}
+void gc_visit(UnionConstructor* v) {
 	v->m_visited = true;
 }
 void gc_visit(StructConstructor* v) {

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -138,6 +138,12 @@ struct Reference : Value {
 	Reference(Value* value);
 };
 
+struct UnionConstructor : Value {
+	InternedString m_constructor;
+
+	UnionConstructor(InternedString constructor);
+};
+
 struct StructConstructor : Value {
 	std::vector<InternedString> m_keys;
 

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -110,6 +110,14 @@ struct Dictionary : Value {
 	void removeMember(StringType const& id);
 };
 
+struct Union : Value {
+	InternedString m_constructor;
+	Value* m_inner_value {nullptr}; // empty constructor
+
+	Union(InternedString constructor);
+	Union(InternedString constructor, Value* v);
+};
+
 struct Function : Value {
 	FunctionType m_def;
 	// TODO: store references instead of values

--- a/src/interpreter/value_tag.hpp
+++ b/src/interpreter/value_tag.hpp
@@ -19,6 +19,7 @@
                                                                                \
 	X(Reference)                                                               \
                                                                                \
+	X(UnionConstructor)                                                        \
 	X(StructConstructor)
 
 #define X(name) #name,

--- a/src/interpreter/value_tag.hpp
+++ b/src/interpreter/value_tag.hpp
@@ -12,6 +12,7 @@
 	X(Array)                                                                   \
 	X(Object)                                                                  \
 	X(Dictionary)                                                              \
+	X(Union)                                                                   \
                                                                                \
 	X(Function)                                                                \
 	X(NativeFunction)                                                          \

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -176,8 +176,8 @@ namespace TypeChecker {
 }
 
 [[nodiscard]] ErrorReport match_identifiers(
-    TypedAST::RecordAccessExpression* ast, Frontend::CompileTimeEnvironment& env) {
-	return match_identifiers(ast->m_record, env);
+    TypedAST::AccessExpression* ast, Frontend::CompileTimeEnvironment& env) {
+	return match_identifiers(ast->m_object, env);
 }
 
 [[nodiscard]] ErrorReport match_identifiers(
@@ -261,7 +261,7 @@ namespace TypeChecker {
 		DISPATCH(IndexExpression);
 		DISPATCH(CallExpression);
 		DISPATCH(TernaryExpression);
-		DISPATCH(RecordAccessExpression);
+		DISPATCH(AccessExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -213,6 +213,15 @@ namespace TypeChecker {
 }
 
 [[nodiscard]] ErrorReport match_identifiers(
+    TypedAST::UnionExpression* ast, Frontend::CompileTimeEnvironment& env) {
+
+	for (auto& type : ast->m_types)
+		CHECK_AND_RETURN(match_identifiers(type, env));
+
+	return {};
+}
+
+[[nodiscard]] ErrorReport match_identifiers(
     TypedAST::StructExpression* ast, Frontend::CompileTimeEnvironment& env) {
 
 	for (auto& type : ast->m_types)
@@ -264,6 +273,7 @@ namespace TypeChecker {
 		DISPATCH(Declaration);
 		DISPATCH(DeclarationList);
 
+		DISPATCH(UnionExpression);
 		DISPATCH(StructExpression);
 		DISPATCH(TypeTerm);
 	}

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -80,13 +80,13 @@ void metacheck(TypedAST::TernaryExpression* ast, TypeChecker& tc) {
 	tc.m_core.m_meta_core.unify(ast->m_else_expr->m_meta_type, tc.meta_value());
 }
 
-void metacheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
+void metacheck(TypedAST::AccessExpression* ast, TypeChecker& tc) {
 	ast->m_meta_type = tc.new_meta_var();
 
 	// TODO: we would like to support static records with
 	// typefunc members in the future
-	metacheck(ast->m_record, tc);
-	if (ast->m_record->m_meta_type == tc.meta_monotype())
+	metacheck(ast->m_object, tc);
+	if (ast->m_object->m_meta_type == tc.meta_monotype())
 		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_constructor());
 	else
 		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_value());
@@ -230,7 +230,7 @@ void metacheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		DISPATCH(CallExpression);
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
-		DISPATCH(RecordAccessExpression);
+		DISPATCH(AccessExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -86,7 +86,7 @@ void metacheck(TypedAST::AccessExpression* ast, TypeChecker& tc) {
 	// TODO: we would like to support static records with
 	// typefunc members in the future
 	metacheck(ast->m_object, tc);
-	MetaTypeId metatype = tc.m_meta_core.find(ast->m_object->m_meta_type);
+	MetaTypeId metatype = tc.m_core.m_meta_core.find(ast->m_object->m_meta_type);
 	// TODO: support vars
 	if (metatype == tc.meta_monotype())
 		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_constructor());

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -176,6 +176,15 @@ void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 					assert(0 && "value referenced in a type definition");
 }
 
+void metacheck(TypedAST::UnionExpression* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_typefunc();
+
+	for (auto& type : ast->m_types) {
+		metacheck(type, tc);
+		tc.m_core.m_meta_core.unify(type->m_meta_type, tc.meta_monotype());
+	}
+}
+
 void metacheck(TypedAST::StructExpression* ast, TypeChecker& tc) {
 	ast->m_meta_type = tc.meta_typefunc();
 
@@ -231,6 +240,7 @@ void metacheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		DISPATCH(Declaration);
 		DISPATCH(DeclarationList);
 
+		DISPATCH(UnionExpression);
 		DISPATCH(StructExpression);
 		DISPATCH(TypeTerm);
 	}

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -81,19 +81,21 @@ void metacheck(TypedAST::TernaryExpression* ast, TypeChecker& tc) {
 }
 
 void metacheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.new_meta_var();
+
 	// TODO: we would like to support static records with
 	// typefunc members in the future
-	ast->m_meta_type = tc.meta_value();
-
 	metacheck(ast->m_record, tc);
-	tc.m_core.m_meta_core.unify(ast->m_record->m_meta_type, tc.meta_value());
+	if (ast->m_record->m_meta_type == tc.meta_monotype())
+		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_constructor());
+	else
+		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_value());
 }
 
 void metacheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 	ast->m_meta_type = tc.meta_value();
 
 	metacheck(ast->m_constructor, tc);
-	tc.m_core.m_meta_core.unify(ast->m_constructor->m_meta_type, tc.meta_monotype());
 
 	for (auto& arg : ast->m_args) {
 		metacheck(arg, tc);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -86,7 +86,9 @@ void metacheck(TypedAST::AccessExpression* ast, TypeChecker& tc) {
 	// TODO: we would like to support static records with
 	// typefunc members in the future
 	metacheck(ast->m_object, tc);
-	if (ast->m_object->m_meta_type == tc.meta_monotype())
+	MetaTypeId metatype = tc.m_meta_core.find(ast->m_object->m_meta_type);
+	// TODO: support vars
+	if (metatype == tc.meta_monotype())
 		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_constructor());
 	else
 		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_value());

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -398,8 +398,8 @@ Writer<AST::AST*> Parser::parse_expression(int bp) {
 			if (handle_error(result, member))
 				return result;
 
-			auto e = m_ast_allocator->make<AST::RecordAccessExpression>();
-			e->m_record = lhs.m_result;
+			auto e = m_ast_allocator->make<AST::AccessExpression>();
+			e->m_object = lhs.m_result;
 			e->m_member = member.m_result;
 			lhs.m_result = e;
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -543,7 +543,8 @@ Writer<AST::AST*> Parser::parse_terminal() {
 		return array;
 	}
 
-	if (token->m_type == TokenTag::KEYWORD_STRUCT) {
+	if (token->m_type == TokenTag::KEYWORD_UNION ||
+	    token->m_type == TokenTag::KEYWORD_STRUCT) {
 		// TODO: do the other type functions
 		auto type = parse_type_function();
 		if (handle_error(result, type))

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -545,6 +545,21 @@ void interpreter_tests(Test::Tester& tests) {
 	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
 		    return ExitStatusTag::Ok;
 	    }}));
+
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	    R"(
+		either := union {
+			left : string(<>);
+			right : int(<>);
+		};
+
+		__invoke := fn() {
+			either;
+		};
+		)",
+	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
+		    return ExitStatusTag::Ok;
+	    }}));
 }
 
 void tarjan_algorithm_tests(Test::Tester& tester) {

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -558,10 +558,11 @@ void interpreter_tests(Test::Tester& tests) {
 			y : either(<>) = either(<>).left {"error"};
 
 			x = y;
+			return 0;
 		};
 		)",
 	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
-		    return ExitStatusTag::Ok;
+		    return Assert::equals(eval_expression("__invoke()", env), 0);
 	    }}));
 }
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -548,16 +548,22 @@ void interpreter_tests(Test::Tester& tests) {
 
 	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
 	    R"(
-		either := union {
-			left : string(<>);
-			right : int(<>);
+		tree := union {
+			leaf : int(<>);
+			node : tree_node(<>);
+		};
+
+		tree_node := struct {
+			left : tree(<>);
+			value : int(<>);
+			right : tree(<>);
 		};
 
 		__invoke := fn() {
-			x : either(<>) = either(<>).right {1};
-			y : either(<>) = either(<>).left {"error"};
-
-			x = y;
+			x : tree(<>) = tree(<>).leaf {1};
+			y : tree(<>) = tree(<>).node {
+				tree_node(<>) {x; 1; x}
+			};
 			return 0;
 		};
 		)",

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -554,7 +554,10 @@ void interpreter_tests(Test::Tester& tests) {
 		};
 
 		__invoke := fn() {
-			either;
+			x : either(<>) = either(<>).right {1};
+			y : either(<>) = either(<>).left {"error"};
+
+			x = y;
 		};
 		)",
 	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -213,9 +213,7 @@ void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 	auto constructor = static_cast<TypedAST::Constructor*>(ast->m_constructor);
 	assert(constructor->type() == TypedASTTag::Constructor);
 
-	auto handle = constructor->m_mono;
-
-	TypeFunctionId tf = tc.m_core.m_mono_core.find_function(handle->m_value);
+	TypeFunctionId tf = tc.m_core.m_mono_core.find_function(constructor->m_mono);
 	int tf_data_idx = tc.m_core.m_tf_core.find_function(tf);
 	TypeFunctionData& tf_data = tc.m_core.m_type_functions[tf_data_idx];
 
@@ -238,7 +236,7 @@ void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 		tc.m_core.m_mono_core.unify(constructor_type, ast->m_args[0]->m_value_type);
 	}
 
-	ast->m_value_type = handle->m_value;
+	ast->m_value_type = constructor->m_mono;
 }
 
 void print_information(TypedAST::Declaration* ast, TypeChecker& tc) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -189,8 +189,8 @@ void typecheck(TypedAST::TernaryExpression* ast, TypeChecker& tc) {
 	ast->m_value_type = ast->m_then_expr->m_value_type;
 }
 
-void typecheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
-	typecheck(ast->m_record, tc);
+void typecheck(TypedAST::AccessExpression* ast, TypeChecker& tc) {
+	typecheck(ast->m_object, tc);
 
 	// should this be a hidden type var?
 	MonoId member_type = tc.new_var();
@@ -204,7 +204,7 @@ void typecheck(TypedAST::RecordAccessExpression* ast, TypeChecker& tc) {
 	    true);
 	MonoId term_type = tc.m_core.new_term(dummy_tf, {}, "record instance");
 
-	tc.m_core.m_mono_core.unify(ast->m_record->m_value_type, term_type);
+	tc.m_core.m_mono_core.unify(ast->m_object->m_value_type, term_type);
 }
 
 void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
@@ -399,7 +399,7 @@ void typecheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		DISPATCH(CallExpression);
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
-		DISPATCH(RecordAccessExpression);
+		DISPATCH(AccessExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Declaration);

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -12,6 +12,7 @@ TypeChecker::TypeChecker(TypedAST::Allocator& allocator) : m_typed_ast_allocator
 	m_core.m_meta_core.new_term(-1); // 0 | value
 	m_core.m_meta_core.new_term(-1); // 1 | type func
 	m_core.m_meta_core.new_term(-1); // 2 | mono type
+	m_core.m_meta_core.new_term(-1); // 3 | constructor
 
 	m_core.new_builtin_type_function(-1); // 0  | function
 	m_core.new_builtin_type_function(0);  // 1  | int
@@ -224,6 +225,10 @@ MetaTypeId TypeChecker::meta_typefunc() {
 
 MetaTypeId TypeChecker::meta_monotype() {
 	return 2;
+}
+
+MetaTypeId TypeChecker::meta_constructor() {
+	return 3;
 }
 
 } // namespace TypeChecker

--- a/src/typechecker.hpp
+++ b/src/typechecker.hpp
@@ -40,6 +40,7 @@ struct TypeChecker {
 	MetaTypeId meta_value();
 	MetaTypeId meta_typefunc();
 	MetaTypeId meta_monotype();
+	MetaTypeId meta_constructor();
 };
 
 } // namespace TypeChecker

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -137,11 +137,11 @@ TypedAST* convert_ast(AST::TernaryExpression* ast, Allocator& alloc) {
 	return typed_ternary;
 }
 
-TypedAST* convert_ast(AST::RecordAccessExpression* ast, Allocator& alloc) {
-	auto typed_ast = alloc.make<RecordAccessExpression>();
+TypedAST* convert_ast(AST::AccessExpression* ast, Allocator& alloc) {
+	auto typed_ast = alloc.make<AccessExpression>();
 
 	typed_ast->m_member = ast->m_member;
-	typed_ast->m_record = convert_ast(ast->m_record, alloc);
+	typed_ast->m_object = convert_ast(ast->m_object, alloc);
 
 	return typed_ast;
 }
@@ -272,7 +272,7 @@ TypedAST* convert_ast(AST::AST* ast, Allocator& alloc) {
 		DISPATCH(CallExpression);
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
-		DISPATCH(RecordAccessExpression);
+		DISPATCH(AccessExpression);
 		DISPATCH(ConstructorExpression);
 		REJECT(BinaryExpression);
 

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -208,15 +208,30 @@ TypedAST* convert_ast(AST::WhileStatement* ast, Allocator& alloc) {
 	return typed_while;
 }
 
+TypedAST* convert_ast(AST::UnionExpression* ast, Allocator& alloc) {
+	auto typed_ast = alloc.make<UnionExpression>();
+
+	for (auto& constructor : ast->m_constructors) {
+		auto typed_field = static_cast<Identifier*>(convert_ast(&constructor, alloc));
+		typed_ast->m_constructors.push_back(std::move(*typed_field));
+	}
+
+	for (auto type : ast->m_types) {
+		typed_ast->m_types.push_back(convert_ast(type, alloc));
+	}
+
+	return typed_ast;
+};
+
 TypedAST* convert_ast(AST::StructExpression* ast, Allocator& alloc) {
 	auto typed_ast = alloc.make<StructExpression>();
 
-	for (auto& field : ast->m_fields){
+	for (auto& field : ast->m_fields) {
 		auto typed_field = static_cast<Identifier*>(convert_ast(&field, alloc));
 		typed_ast->m_fields.push_back(std::move(*typed_field));
 	}
 
-	for (auto type : ast->m_types){
+	for (auto type : ast->m_types) {
 		typed_ast->m_types.push_back(convert_ast(type, alloc));
 	}
 
@@ -270,9 +285,11 @@ TypedAST* convert_ast(AST::AST* ast, Allocator& alloc) {
 		DISPATCH(DeclarationList);
 		DISPATCH(Declaration);
 
+		DISPATCH(UnionExpression);
 		DISPATCH(StructExpression);
 		DISPATCH(TypeTerm);
 	}
+
 	std::cerr << "Error: AST type not handled in convert_ast: "
 	          << ast_string[(int)ast->type()] << std::endl;
 	assert(0);

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -209,12 +209,12 @@ struct IndexExpression : public TypedAST {
 	    : TypedAST {TypedASTTag::IndexExpression} {}
 };
 
-struct RecordAccessExpression : public TypedAST {
-	TypedAST* m_record;
+struct AccessExpression : public TypedAST {
+	TypedAST* m_object;
 	Token const* m_member;
 
-	RecordAccessExpression()
-	    : TypedAST {TypedASTTag::RecordAccessExpression} {}
+	AccessExpression()
+	    : TypedAST {TypedASTTag::AccessExpression} {}
 };
 
 struct TernaryExpression : public TypedAST {

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -318,7 +318,7 @@ struct MonoTypeHandle : public TypedAST {
 };
 
 struct Constructor : public TypedAST {
-	MonoTypeHandle* m_mono;
+	MonoId m_mono;
 	Token const* m_id;
 	// points to the ast node this one was made from
 	TypedAST* m_syntax;

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -317,4 +317,14 @@ struct MonoTypeHandle : public TypedAST {
 	    : TypedAST {TypedASTTag::MonoTypeHandle} {}
 };
 
+struct Constructor : public TypedAST {
+	MonoTypeHandle* m_mono;
+	Token const* m_id;
+	// points to the ast node this one was made from
+	TypedAST* m_syntax;
+
+	Constructor()
+	    : TypedAST {TypedASTTag::Constructor} {}
+};
+
 } // namespace TypedAST

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -275,6 +275,14 @@ struct WhileStatement : public TypedAST {
 	    : TypedAST {TypedASTTag::WhileStatement} {}
 };
 
+struct UnionExpression : public TypedAST {
+	std::vector<Identifier> m_constructors;
+	std::vector<TypedAST*> m_types;
+
+	UnionExpression()
+	    : TypedAST {TypedASTTag::UnionExpression} {}
+};
+
 struct StructExpression : public TypedAST {
 	std::vector<Identifier> m_fields;
 	std::vector<TypedAST*> m_types;

--- a/src/typed_ast_tag.hpp
+++ b/src/typed_ast_tag.hpp
@@ -31,7 +31,8 @@
 	X(StructExpression)                                                        \
 	X(TypeTerm)                                                                \
 	X(TypeFunctionHandle)                                                      \
-	X(MonoTypeHandle)
+	X(MonoTypeHandle)                                                          \
+	X(Constructor)
 
 #define X(name) #name,
 constexpr const char* typed_ast_string[] = {TYPED_AST_TAGS};

--- a/src/typed_ast_tag.hpp
+++ b/src/typed_ast_tag.hpp
@@ -14,7 +14,7 @@
 	X(Identifier)                                                              \
 	X(CallExpression)                                                          \
 	X(IndexExpression)                                                         \
-	X(RecordAccessExpression)                                                  \
+	X(AccessExpression)                                                        \
 	X(TernaryExpression)                                                       \
 	X(ConstructorExpression)                                                   \
 	/* All before this point are expressions */                                \

--- a/src/typed_ast_tag.hpp
+++ b/src/typed_ast_tag.hpp
@@ -27,6 +27,7 @@
 	X(DeclarationList)                                                         \
 	X(Declaration)                                                             \
                                                                                \
+	X(UnionExpression)                                                         \
 	X(StructExpression)                                                        \
 	X(TypeTerm)                                                                \
 	X(TypeFunctionHandle)                                                      \

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -77,8 +77,8 @@ TypeSystemCore::TypeSystemCore() {
 	};
 
 	m_meta_core.unify_function = [this](Unification::Core& core, int a, int b) {
-		a = m_mono_core.find_term(a);
-		b = m_mono_core.find_term(b);
+		a = core.find_term(a);
+		b = core.find_term(b);
 
 		if (a == b)
 			return;


### PR DESCRIPTION
This pr finishes the implementation of unions. It will also attempt to adapt the `RecordAccessExpression` as to allow this:
```rust
x := my_union.field { value };
```