### PR TITLE
Match expression

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -180,6 +180,23 @@ void print(TernaryExpression* ast, int d) {
 	std::cout << stab << "]\n";
 }
 
+void print(MatchExpression* ast, int d) {
+	std::string stab(d - 1, tabc);
+	std::string tab(d, tabc);
+	std::cout << stab << "[ MatchExpression\n" << tab << "Matchee:\n";
+	print(&ast->m_matchee, d + 1);
+	if (ast->m_type_hint) {
+		std::cout << tab << "Type:\n";
+		print(ast->m_type_hint, d + 1);
+	}
+	std::cout << tab << "Cases:\n";
+	for (int i = 0; i < ast->m_cases.size(); ++i) {
+		std::cout << tab << "Case " << ast->m_cases[0]->m_text.str() << ":\n";
+		print(ast->m_expressions[0], d + 1);
+	}
+	std::cout << stab << "]\n";
+}
+
 void print(ReturnStatement* ast, int d) {
 	std::string stab(d - 1, tabc);
 	std::cout << stab << "[ ReturnStatement\n";

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -183,6 +183,18 @@ struct TernaryExpression : public AST {
 	    : AST {ASTTag::TernaryExpression} {}
 };
 
+struct MatchExpression : public AST {
+	// NOTE: I'm avoiding using Declaration for this
+	// because it will generate confusion
+	Identifier m_matchee;
+	AST* m_type_hint {nullptr};
+	std::vector<Token const*> m_cases;
+	std::vector<AST*> m_expressions;
+
+	MatchExpression()
+	    : AST {ASTTag::MatchExpression} {}
+};
+
 struct ConstructorExpression : public AST {
 	AST* m_constructor;
 	std::vector<AST*> m_args;

--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -19,6 +19,7 @@
 	X(CallExpression) \
 	X(IndexExpression) \
 	X(AccessExpression) \
+	X(MatchExpression) \
 	X(ConstructorExpression) \
 	X(Block) \
 	X(ReturnStatement) \

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -121,6 +121,13 @@ void compute_offsets(TypedAST::AccessExpression* ast, int frame_offset) {
 	compute_offsets(ast->m_record, frame_offset);
 }
 
+void compute_offsets(TypedAST::MatchExpression* ast, int frame_offset) {
+	compute_offsets(&ast->m_matchee, frame_offset);
+
+	for (auto& expr : ast->m_expressions)
+		compute_offsets(expr.second, frame_offset);
+}
+
 void compute_offsets(TypedAST::ConstructorExpression* ast, int frame_offset) {
 	compute_offsets(ast->m_constructor, frame_offset);
 
@@ -169,6 +176,7 @@ void compute_offsets(TypedAST::TypedAST* ast, int frame_offset) {
 		DISPATCH(CallExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(AccessExpression);
+		DISPATCH(MatchExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -107,6 +107,19 @@ TypedAST::TypedAST* ct_eval(
 	return ast;
 }
 
+TypedAST::TypedAST* ct_eval(
+    TypedAST::MatchExpression* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
+	// NOTE: no need to ct_eval the identifier, because it is guaranteed
+	// to be of metatype value, thus nothing needs to be done
+	if (ast->m_type_hint)
+		ast->m_type_hint = ct_eval(ast->m_type_hint, tc, alloc);
+
+	for (auto& expr : ast->m_expressions)
+		expr.second = ct_eval(expr.second, tc, alloc);
+
+	return ast;
+}
+
 TypedAST::ConstructorExpression* ct_eval(
     TypedAST::ConstructorExpression* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
 	ast->m_constructor = constructor_from_ast(ast->m_constructor, tc, alloc);
@@ -357,6 +370,7 @@ TypedAST::TypedAST* ct_eval(
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(AccessExpression);
+		DISPATCH(MatchExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -188,6 +188,16 @@ AST* desugar(WhileStatement* ast, Allocator& alloc) {
 	return ast;
 }
 
+AST* desugar(MatchExpression* ast, Allocator& alloc) {
+	if (ast->m_type_hint)
+		ast->m_type_hint = desugar(ast->m_type_hint, alloc);
+
+	for (auto &expr : ast->m_expressions)
+		expr = desugar(expr, alloc);
+
+	return ast;
+}
+
 AST* desugar(AST* ast, Allocator& alloc) {
 #define DISPATCH(type)                                                         \
 	case ASTTag::type:                                                         \
@@ -229,6 +239,7 @@ AST* desugar(AST* ast, Allocator& alloc) {
 		DISPATCH(IfElseStatement);
 		DISPATCH(ForStatement);
 		DISPATCH(WhileStatement);
+		DISPATCH(MatchExpression);
 
 		RETURN(TypeTerm);
 		RETURN(TypeVar);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -81,6 +81,7 @@ std::pair<bool, TokenTag> Lexer::is_keyword(InternedString const& str) {
 		{{"then"}, TokenTag::KEYWORD_THEN},
 		{{"return"}, TokenTag::KEYWORD_RETURN},
 		{{"while"}, TokenTag::KEYWORD_WHILE},
+		{{"match"}, TokenTag::KEYWORD_MATCH},
 		{{"true"}, TokenTag::KEYWORD_TRUE},
 		{{"false"}, TokenTag::KEYWORD_FALSE},
 		{{"array"}, TokenTag::KEYWORD_ARRAY},

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -181,6 +181,19 @@ namespace TypeChecker {
 }
 
 [[nodiscard]] ErrorReport match_identifiers(
+    TypedAST::MatchExpression* ast, Frontend::CompileTimeEnvironment& env) {
+	CHECK_AND_RETURN(match_identifiers(&ast->m_matchee, env));
+
+	if (ast->m_type_hint)
+		CHECK_AND_RETURN(match_identifiers(ast->m_type_hint, env));
+
+	for (auto& expr : ast->m_expressions)
+		CHECK_AND_RETURN(match_identifiers(expr.second, env));
+
+	return {};
+}
+
+[[nodiscard]] ErrorReport match_identifiers(
     TypedAST::ConstructorExpression* ast, Frontend::CompileTimeEnvironment& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_constructor, env));
 
@@ -262,6 +275,7 @@ namespace TypeChecker {
 		DISPATCH(CallExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(AccessExpression);
+		DISPATCH(MatchExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -94,6 +94,22 @@ void metacheck(TypedAST::AccessExpression* ast, TypeChecker& tc) {
 		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_value());
 }
 
+void metacheck(TypedAST::MatchExpression* ast, TypeChecker& tc) {
+	ast->m_meta_type = tc.meta_value();
+
+	metacheck(&ast->m_matchee, tc);
+	tc.m_core.m_meta_core.unify(ast->m_matchee.m_meta_type, tc.meta_value());
+
+	if (ast->m_type_hint) {
+		metacheck(ast->m_type_hint, tc);
+		tc.m_core.m_meta_core.unify(
+		    ast->m_type_hint->m_meta_type, tc.meta_monotype());
+	}
+
+	for (auto& expr : ast->m_expressions)
+		metacheck(expr.second, tc);
+}
+
 void metacheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 	ast->m_meta_type = tc.meta_value();
 
@@ -233,6 +249,7 @@ void metacheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(AccessExpression);
+		DISPATCH(MatchExpression);
 		DISPATCH(ConstructorExpression);
 
 		DISPATCH(Block);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -836,48 +836,29 @@ Writer<AST::AST*> Parser::parse_match_expression() {
 	Writer<AST::AST*> result = {
 	    {"Parse Error: Failed to parse match expression"}};
 
-	if (handle_error(result, require(TokenTag::KEYWORD_MATCH)))
-		return result;
-
-	if (handle_error(result, require(TokenTag::PAREN_OPEN)))
-		return result;
+	REQUIRE(result, TokenTag::KEYWORD_MATCH);
+	REQUIRE(result, TokenTag::PAREN_OPEN);
 
 	auto matchee_and_hint = parse_name_and_type();
-	if (handle_error(result, matchee_and_hint))
-		return result;
-
-	if (handle_error(result, require(TokenTag::PAREN_CLOSE)))
-		return result;
-
-	if (handle_error(result, require(TokenTag::BRACE_OPEN)))
-		return result;
+	CHECK_AND_RETURN(result, matchee_and_hint);
+	REQUIRE(result, TokenTag::PAREN_CLOSE);
+	REQUIRE(result, TokenTag::BRACE_CLOSE);
 
 	std::vector<Token const*> cases;
 	std::vector<AST::AST*> expressions;
 	while(!consume(TokenTag::BRACE_CLOSE)) {
 		Writer<Token const*> case_name = require(TokenTag::IDENTIFIER);
-		if (handle_error(result, case_name))
-			return result;
-
-		if (handle_error(result, require(TokenTag::BRACE_OPEN)))
-			return result;
+		CHECK_AND_RETURN(result, case_name);
+		REQUIRE(result, TokenTag::BRACE_OPEN);
 
 		auto name_and_type = parse_name_and_type();
-		if (handle_error(result, name_and_type))
-			return result;
-
-		if (handle_error(result, require(TokenTag::BRACE_CLOSE)))
-			return result;
-
-		if (handle_error(result, require(TokenTag::ARROW)))
-			return result;
+		CHECK_AND_RETURN(result, name_and_type);
+		REQUIRE(result, TokenTag::BRACE_CLOSE);
+		REQUIRE(result, TokenTag::ARROW);
 
 		auto expression = parse_expression();
-		if (handle_error(result, expression))
-			return result;
-
-		if (handle_error(result, require(TokenTag::SEMICOLON)))
-			return result;
+		CHECK_AND_RETURN(result, expression);
+		REQUIRE(result, TokenTag::SEMICOLON);
 
 		AST::Declaration inner_value;
 		inner_value.m_identifier_token = name_and_type.m_result.first;
@@ -908,17 +889,14 @@ Writer<std::pair<Token const*, AST::AST*>> Parser::parse_name_and_type(bool requ
 	    {"Parse Error: Failed to parse name and type"}};
 
 	auto name = require(TokenTag::IDENTIFIER);
-	if (handle_error(result, name))
-		return result;
+	CHECK_AND_RETURN(result, name);
 
 	Writer<AST::AST*> type;
 	if (required_type or match(TokenTag::DECLARE)) {
-		if (handle_error(result, require(TokenTag::DECLARE)))
-			return result;
+		REQUIRE(result, TokenTag::DECLARE);
 
 		type = parse_type_term();
-		if (handle_error(result, type))
-			return result;
+		CHECK_AND_RETURN(result, type);
 	}
 
 	return make_writer<std::pair<Token const*, AST::AST*>>(

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -53,6 +53,9 @@ struct Parser {
 	Writer<AST::AST*> parse_if_else_statement();
 	Writer<AST::AST*> parse_for_statement();
 	Writer<AST::AST*> parse_while_statement();
+	Writer<AST::AST*> parse_match_expression();
+	Writer<std::pair<Token const*, AST::AST*>>
+	    parse_name_and_type(bool required_type = false);
 	Writer<AST::AST*> parse_type_term();
 	Writer<std::vector<AST::AST*>> parse_type_term_arguments();
 	Writer<std::pair<std::vector<AST::Identifier>,std::vector<AST::AST*>>>

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -562,19 +562,19 @@ void interpreter_tests(Test::Tester& tests) {
 		__invoke := fn() {
 			x : tree(<>) = tree(<>).leaf {1};
 			y : tree(<>) = tree(<>).node {
-				tree_node(<>) {x; 1; x}
+				tree_node(<>) {x; 2; x}
 			};
 
-			a := match(x : tree(<>)) {
+			node_value := fn(node) => match(node) {
 				leaf { i : int(<>) } => i;
 				node { n : tree_node(<>) } => n.value;
 			};
 
-			return a;
+			return node_value(x) + node_value(y);
 		};
 		)",
 	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
-		    return Assert::equals(eval_expression("__invoke()", env), 1);
+		    return Assert::equals(eval_expression("__invoke()", env), 3);
 	    }}));
 
 	tests.add_test(std::make_unique<Test::InterpreterTestSet>(

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -564,11 +564,17 @@ void interpreter_tests(Test::Tester& tests) {
 			y : tree(<>) = tree(<>).node {
 				tree_node(<>) {x; 1; x}
 			};
-			return 0;
+
+			a := match(x : tree(<>)) {
+				leaf { i : int(<>) } => i;
+				node { n : tree_node(<>) } => n.value;
+			};
+
+			return a;
 		};
 		)",
 	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
-		    return Assert::equals(eval_expression("__invoke()", env), 0);
+		    return Assert::equals(eval_expression("__invoke()", env), 1);
 	    }}));
 }
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -566,7 +566,7 @@ void interpreter_tests(Test::Tester& tests) {
 			};
 
 			node_value := fn(node) => match(node) {
-				leaf { i : int(<>) } => i;
+				leaf { i : string(<>) } => i;
 				node { n : tree_node(<>) } => n.value;
 			};
 

--- a/src/token_tag.hpp
+++ b/src/token_tag.hpp
@@ -77,6 +77,7 @@ constexpr const char* token_string[] = {
 	"KEYWORD_ELSE",
 	"KEYWORD_FOR",
 	"KEYWORD_WHILE",
+	"KEYWORD_MATCH",
 
 	"KEYWORD_UNION",
 	"KEYWORD_TUPLE",
@@ -162,6 +163,7 @@ enum class TokenTag {
 	KEYWORD_ELSE,
 	KEYWORD_FOR,
 	KEYWORD_WHILE,
+	KEYWORD_MATCH,
 
 	KEYWORD_UNION,
 	KEYWORD_TUPLE,

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -226,6 +226,17 @@ struct TernaryExpression : public TypedAST {
 	    : TypedAST {TypedASTTag::TernaryExpression} {}
 };
 
+struct MatchExpression : public TypedAST {
+	// NOTE: I'm avoiding using Declaration for this
+	// because it will generate confusion
+	Identifier m_matchee;
+	TypedAST* m_type_hint {nullptr};
+	std::unordered_map<InternedString, FunctionLiteral*> m_expressions;
+
+	MatchExpression()
+	    : TypedAST {TypedASTTag::MatchExpression} {}
+};
+
 struct ConstructorExpression : public TypedAST {
 	TypedAST* m_constructor;
 	std::vector<TypedAST*> m_args;

--- a/src/typed_ast_tag.hpp
+++ b/src/typed_ast_tag.hpp
@@ -15,6 +15,7 @@
 	X(CallExpression)                                                          \
 	X(IndexExpression)                                                         \
 	X(AccessExpression)                                                        \
+	X(MatchExpression)                                                         \
 	X(TernaryExpression)                                                       \
 	X(ConstructorExpression)                                                   \
 	/* All before this point are expressions */                                \


### PR DESCRIPTION
Implements the match expression it looks something like this:
```rust
match(my_variant [: variant_mono]) {
    constructor_name1 { declaration [: inner_type] } => expression;
    constructor_name2 { declaration [: inner_type] } => expression;
    ...
};
```