### PR TITLE
Naming cleanup

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -159,7 +159,7 @@ void print(AccessExpression* ast, int d) {
 
 	print_indentation(d);
 	std::cout << "Object:\n";
-	print(ast->m_object, d + 1);
+	print(ast->m_record, d + 1);
 
 	print_indentation(d);
 	std::cout << "Member: " << ast->m_member->m_text << "\n";

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -167,7 +167,7 @@ struct IndexExpression : public AST {
 };
 
 struct AccessExpression : public AST {
-	AST* m_object;
+	AST* m_record;
 	Token const* m_member;
 
 	AccessExpression()

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -118,7 +118,7 @@ void compute_offsets(TypedAST::TernaryExpression* ast, int frame_offset) {
 }
 
 void compute_offsets(TypedAST::AccessExpression* ast, int frame_offset) {
-	compute_offsets(ast->m_object, frame_offset);
+	compute_offsets(ast->m_record, frame_offset);
 }
 
 void compute_offsets(TypedAST::ConstructorExpression* ast, int frame_offset) {

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -183,7 +183,7 @@ TypeFunctionId type_func_from_ast(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		}
 
 		TypeFunctionId result = tc.m_core.new_type_function(
-		    TypeFunctionTag::Sum, {}, std::move(structure));
+		    TypeFunctionTag::Variant, {}, std::move(structure));
 
 		return result;
 	} else if (ast->type() == TypedASTTag::StructExpression) {
@@ -252,7 +252,7 @@ TypedAST::Constructor* constructor_from_ast(
 		std::unordered_map<InternedString, MonoId> structure;
 		structure[access->m_member->m_text] = tc.new_var();
 		TypeFunctionId dummy_tf = tc.m_core.new_type_function(
-		    TypeFunctionTag::Sum, {}, std::move(structure), true);
+		    TypeFunctionTag::Variant, {}, std::move(structure), true);
 
 		MonoId monotype = mono_type_from_ast(access->m_object, tc);
 		TypeFunctionId tf = tc.m_core.m_mono_core.find_function(monotype);

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -103,7 +103,7 @@ TypedAST::TypedAST* ct_eval(
 	if (metatype == tc.meta_constructor())
 		return constructor_from_ast(ast, tc, alloc);
 
-	ast->m_object = ct_eval(ast->m_object, tc, alloc);
+	ast->m_record = ct_eval(ast->m_record, tc, alloc);
 	return ast;
 }
 
@@ -254,7 +254,7 @@ TypedAST::Constructor* constructor_from_ast(
 		TypeFunctionId dummy_tf = tc.m_core.new_type_function(
 		    TypeFunctionTag::Variant, {}, std::move(structure), true);
 
-		MonoId monotype = mono_type_from_ast(access->m_object, tc);
+		MonoId monotype = mono_type_from_ast(access->m_record, tc);
 		TypeFunctionId tf = tc.m_core.m_mono_core.find_function(monotype);
 
 		tc.m_core.m_tf_core.unify(dummy_tf, tf);

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -90,7 +90,7 @@ AST* desugarPizza(BinaryExpression* ast, Allocator& alloc) {
 }
 
 AST* desugar(AccessExpression* ast, Allocator& alloc) {
-	ast->m_object = desugar(ast->m_object, alloc);
+	ast->m_record = desugar(ast->m_record, alloc);
 	return ast;
 }
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -302,13 +302,13 @@ void eval(TypedAST::ConstructorExpression* ast, Interpreter& e) {
 			e.m_env.pop();
 
 		e.m_env.push(result.get());
-	} else if (constructor_value->type() == ValueTag::UnionConstructor) {
-		auto constructor_actually = static_cast<UnionConstructor*>(constructor_value);
+	} else if (constructor_value->type() == ValueTag::VariantConstructor) {
+		auto constructor_actually = static_cast<VariantConstructor*>(constructor_value);
 
 		assert(ast->m_args.size() == 1);
 
 		eval(ast->m_args[0], e);
-		auto result = e.m_gc->new_union(
+		auto result = e.m_gc->new_variant(
 		    constructor_actually->m_constructor, e.m_env.m_stack.back());
 		e.m_env.pop();
 
@@ -387,7 +387,7 @@ void eval(TypedAST::WhileStatement* ast, Interpreter& e) {
 	}
 };
 
-// TODO: include union implementations? if so, remove duplication
+// TODO: include variant implementations? if so, remove duplication
 void eval(TypedAST::TypeFunctionHandle* ast, Interpreter& e) {
 	int type_function = e.m_tc->m_core.m_tf_core.find_function(ast->m_value);
 	auto& type_function_data = e.m_tc->m_core.m_type_functions[type_function];
@@ -410,7 +410,7 @@ void eval(TypedAST::Constructor* ast, Interpreter& e) {
 	if (tf_data.tag == TypeFunctionTag::Record) {
 		e.push_struct_constructor(tf_data.fields);
 	} else if (tf_data.tag == TypeFunctionTag::Variant) {
-		e.push_union_constructor(ast->m_id->m_text);
+		e.push_variant_constructor(ast->m_id->m_text);
 	} else {
 		assert(0 && "not implemented this type function for construction");
 	}

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -409,7 +409,7 @@ void eval(TypedAST::Constructor* ast, Interpreter& e) {
 
 	if (tf_data.tag == TypeFunctionTag::Record) {
 		e.push_struct_constructor(tf_data.fields);
-	} else if (tf_data.tag == TypeFunctionTag::Sum) {
+	} else if (tf_data.tag == TypeFunctionTag::Variant) {
 		e.push_union_constructor(ast->m_id->m_text);
 	} else {
 		assert(0 && "not implemented this type function for construction");

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -67,8 +67,8 @@ gc_ptr<Variant> GC::new_variant(InternedString constructor, Value* v) {
 	return result;
 }
 
-gc_ptr<Object> GC::new_object(ObjectType declarations) {
-	auto result = new Object;
+gc_ptr<Record> GC::new_record(RecordType declarations) {
+	auto result = new Record;
 	result->m_value = std::move(declarations);
 	m_blocks.push_back(result);
 	return result;
@@ -128,7 +128,7 @@ String* GC::new_string_raw(std::string s) {
 	return result;
 }
 
-gc_ptr<Function> GC::new_function(FunctionType def, ObjectType captures) {
+gc_ptr<Function> GC::new_function(FunctionType def, RecordType captures) {
 	auto result = new Function(std::move(def), std::move(captures));
 	m_blocks.push_back(result);
 	return result;
@@ -158,8 +158,8 @@ VariantConstructor* GC::new_variant_constructor_raw(InternedString constructor) 
 	return result;
 }
 
-StructConstructor* GC::new_struct_constructor_raw(std::vector<InternedString> keys) {
-	auto result = new StructConstructor(std::move(keys));
+RecordConstructor* GC::new_record_constructor_raw(std::vector<InternedString> keys) {
+	auto result = new RecordConstructor(std::move(keys));
 	m_blocks.push_back(result);
 	return result;
 }

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -61,8 +61,8 @@ Null* GC::null() {
 	return m_null;
 }
 
-gc_ptr<Union> GC::new_union(InternedString constructor, Value* v) {
-	auto result = new Union(constructor, v);
+gc_ptr<Variant> GC::new_variant(InternedString constructor, Value* v) {
+	auto result = new Variant(constructor, v);
 	m_blocks.push_back(result);
 	return result;
 }
@@ -152,8 +152,8 @@ gc_ptr<Reference> GC::new_reference(Value* v) {
 	return result;
 }
 
-UnionConstructor* GC::new_union_constructor_raw(InternedString constructor) {
-	auto result = new UnionConstructor(constructor);
+VariantConstructor* GC::new_variant_constructor_raw(InternedString constructor) {
+	auto result = new VariantConstructor(constructor);
 	m_blocks.push_back(result);
 	return result;
 }

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -30,7 +30,7 @@ struct GC {
 
 	auto null() -> Null*;
 
-	auto new_union(InternedString constructor, Value* v) -> gc_ptr<Union>;
+	auto new_variant(InternedString constructor, Value* v) -> gc_ptr<Variant>;
 	auto new_object(ObjectType) -> gc_ptr<Object>;
 	auto new_dictionary(DictionaryType) -> gc_ptr<Dictionary>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;
@@ -47,7 +47,7 @@ struct GC {
 	auto new_float_raw(float) -> Float*;
 	auto new_boolean_raw(bool) -> Boolean*;
 	auto new_string_raw(std::string) -> String*;
-	auto new_union_constructor_raw(InternedString) -> UnionConstructor*;
+	auto new_variant_constructor_raw(InternedString) -> VariantConstructor*;
 	auto new_struct_constructor_raw(std::vector<InternedString>) -> StructConstructor*;
 };
 

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -31,14 +31,14 @@ struct GC {
 	auto null() -> Null*;
 
 	auto new_variant(InternedString constructor, Value* v) -> gc_ptr<Variant>;
-	auto new_object(ObjectType) -> gc_ptr<Object>;
+	auto new_record(RecordType) -> gc_ptr<Record>;
 	auto new_dictionary(DictionaryType) -> gc_ptr<Dictionary>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_integer(int) -> gc_ptr<Integer>;
 	auto new_float(float) -> gc_ptr<Float>;
 	auto new_boolean(bool) -> gc_ptr<Boolean>;
 	auto new_string(std::string) -> gc_ptr<String>;
-	auto new_function(FunctionType, ObjectType) -> gc_ptr<Function>;
+	auto new_function(FunctionType, RecordType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 	auto new_reference(Value*) -> gc_ptr<Reference>;
@@ -48,7 +48,7 @@ struct GC {
 	auto new_boolean_raw(bool) -> Boolean*;
 	auto new_string_raw(std::string) -> String*;
 	auto new_variant_constructor_raw(InternedString) -> VariantConstructor*;
-	auto new_struct_constructor_raw(std::vector<InternedString>) -> StructConstructor*;
+	auto new_record_constructor_raw(std::vector<InternedString>) -> RecordConstructor*;
 };
 
 } // namespace Interpreter

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -106,8 +106,8 @@ void Interpreter::push_variant_constructor(InternedString constructor) {
 	run_gc_if_needed();
 }
 
-void Interpreter::push_struct_constructor(std::vector<InternedString> keys) {
-	m_env.push(m_gc->new_struct_constructor_raw(std::move(keys)));
+void Interpreter::push_record_constructor(std::vector<InternedString> keys) {
+	m_env.push(m_gc->new_record_constructor_raw(std::move(keys)));
 	run_gc_if_needed();
 }
 
@@ -117,8 +117,8 @@ gc_ptr<Array> Interpreter::new_list(ArrayType elements) {
 	return result;
 }
 
-gc_ptr<Object> Interpreter::new_object(ObjectType declarations) {
-	auto result = m_gc->new_object(std::move(declarations));
+gc_ptr<Record> Interpreter::new_record(RecordType declarations) {
+	auto result = m_gc->new_record(std::move(declarations));
 	run_gc_if_needed();
 	return result;
 }
@@ -129,7 +129,7 @@ gc_ptr<Dictionary> Interpreter::new_dictionary(DictionaryType declarations) {
 	return result;
 }
 
-gc_ptr<Function> Interpreter::new_function(FunctionType def, ObjectType s) {
+gc_ptr<Function> Interpreter::new_function(FunctionType def, RecordType s) {
 	auto result = m_gc->new_function(def, std::move(s));
 	run_gc_if_needed();
 	return result;

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -101,8 +101,8 @@ void Interpreter::push_string(std::string s) {
 	run_gc_if_needed();
 }
 
-void Interpreter::push_union_constructor(InternedString constructor) {
-	m_env.push(m_gc->new_union_constructor_raw(constructor));
+void Interpreter::push_variant_constructor(InternedString constructor) {
+	m_env.push(m_gc->new_variant_constructor_raw(constructor));
 	run_gc_if_needed();
 }
 

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -53,11 +53,11 @@ struct Interpreter {
 	void push_boolean(bool);
 	void push_string(std::string);
 	void push_variant_constructor(InternedString constructor);
-	void push_struct_constructor(std::vector<InternedString>);
+	void push_record_constructor(std::vector<InternedString>);
 	auto new_list(ArrayType) -> gc_ptr<Array>;
-	auto new_object(ObjectType) -> gc_ptr<Object>;
+	auto new_record(RecordType) -> gc_ptr<Record>;
 	auto new_dictionary(DictionaryType) -> gc_ptr<Dictionary>;
-	auto new_function(FunctionType, ObjectType) -> gc_ptr<Function>;
+	auto new_function(FunctionType, RecordType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 	auto new_reference(Value*) -> gc_ptr<Reference>;

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -52,7 +52,7 @@ struct Interpreter {
 	void push_float(float);
 	void push_boolean(bool);
 	void push_string(std::string);
-	void push_union_constructor(InternedString constructor);
+	void push_variant_constructor(InternedString constructor);
 	void push_struct_constructor(std::vector<InternedString>);
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_object(ObjectType) -> gc_ptr<Object>;

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -52,17 +52,17 @@ Value* Array::at(int position) {
 	}
 }
 
-Object::Object()
-    : Value(ValueTag::Object) {}
-Object::Object(ObjectType o)
-    : Value(ValueTag::Object)
+Record::Record()
+    : Value(ValueTag::Record) {}
+Record::Record(RecordType o)
+    : Value(ValueTag::Record)
     , m_value(std::move(o)) {}
 
-void Object::addMember(Identifier const& id, Value* v) {
+void Record::addMember(Identifier const& id, Value* v) {
 	m_value[id] = v;
 }
 
-Value* Object::getMember(Identifier const& id) {
+Value* Record::getMember(Identifier const& id) {
 	auto it = m_value.find(id);
 	if (it == m_value.end()) {
 		// TODO: return RangeError
@@ -106,7 +106,7 @@ Variant::Variant(InternedString constructor, Value* v)
     , m_constructor(constructor)
     , m_inner_value(v) {}
 
-Function::Function(FunctionType def, ObjectType captures)
+Function::Function(FunctionType def, RecordType captures)
     : Value(ValueTag::Function)
     , m_def(def)
     , m_captures(std::move(captures)) {}
@@ -123,8 +123,8 @@ VariantConstructor::VariantConstructor(InternedString constructor)
     : Value {ValueTag::VariantConstructor}
     , m_constructor {constructor} {}
 
-StructConstructor::StructConstructor(std::vector<InternedString> keys)
-    : Value {ValueTag::StructConstructor}
+RecordConstructor::RecordConstructor(std::vector<InternedString> keys)
+    : Value {ValueTag::RecordConstructor}
     , m_keys {std::move(keys)} {}
 
 void gc_visit(Null* v) {
@@ -151,7 +151,7 @@ void gc_visit(NativeFunction* v) {
 void gc_visit(VariantConstructor* v) {
 	v->m_visited = true;
 }
-void gc_visit(StructConstructor* v) {
+void gc_visit(RecordConstructor* v) {
 	v->m_visited = true;
 }
 
@@ -165,7 +165,7 @@ void gc_visit(Array* l) {
 	}
 }
 
-void gc_visit(Object* o) {
+void gc_visit(Record* o) {
 	if (o->m_visited)
 		return;
 
@@ -225,8 +225,8 @@ void gc_visit(Value* v) {
 		return gc_visit(static_cast<Error*>(v));
 	case ValueTag::Array:
 		return gc_visit(static_cast<Array*>(v));
-	case ValueTag::Object:
-		return gc_visit(static_cast<Object*>(v));
+	case ValueTag::Record:
+		return gc_visit(static_cast<Record*>(v));
 	case ValueTag::Dictionary:
 		return gc_visit(static_cast<Dictionary*>(v));
 	case ValueTag::Variant:
@@ -239,8 +239,8 @@ void gc_visit(Value* v) {
 		return gc_visit(static_cast<Reference*>(v));
 	case ValueTag::VariantConstructor:
 		return gc_visit(static_cast<VariantConstructor*>(v));
-	case ValueTag::StructConstructor:
-		return gc_visit(static_cast<StructConstructor*>(v));
+	case ValueTag::RecordConstructor:
+		return gc_visit(static_cast<RecordConstructor*>(v));
 	}
 }
 
@@ -283,7 +283,7 @@ void print(Error* v, int d) {
 	std::cout << value_string[int(v->type())] << '\n';
 }
 
-void print(Object* o, int d) {
+void print(Record* o, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(o->type())] << '\n';
 	for (auto& kv : o->m_value){
@@ -331,9 +331,9 @@ void print(Reference* l, int d) {
 	print(l->m_value, d + 1);
 }
 
-void print(StructConstructor* l, int d) {
+void print(RecordConstructor* l, int d) {
 	print_spaces(d);
-	std::cout << "StructConstructor\n";
+	std::cout << "RecordConstructor\n";
 }
 
 void print(Value* v, int d) {
@@ -353,8 +353,8 @@ void print(Value* v, int d) {
 		return print(static_cast<Error*>(v), d);
 	case ValueTag::Array:
 		return print(static_cast<Array*>(v), d);
-	case ValueTag::Object:
-		return print(static_cast<Object*>(v), d);
+	case ValueTag::Record:
+		return print(static_cast<Record*>(v), d);
 	case ValueTag::Dictionary:
 		return print(static_cast<Dictionary*>(v), d);
 	case ValueTag::Variant:
@@ -367,8 +367,8 @@ void print(Value* v, int d) {
 		return print(static_cast<Reference*>(v), d);
 	case ValueTag::VariantConstructor:
 		return print(static_cast<VariantConstructor*>(v), d);
-	case ValueTag::StructConstructor:
-		return print(static_cast<StructConstructor*>(v), d);
+	case ValueTag::RecordConstructor:
+		return print(static_cast<RecordConstructor*>(v), d);
 	}
 }
 

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -97,12 +97,12 @@ void Dictionary::removeMember(StringType const& id) {
 	m_value.erase(id);
 }
 
-Union::Union(InternedString constructor)
-    : Value(ValueTag::Union)
+Variant::Variant(InternedString constructor)
+    : Value(ValueTag::Variant)
     , m_constructor(constructor) {}
 
-Union::Union(InternedString constructor, Value* v)
-    : Value(ValueTag::Union)
+Variant::Variant(InternedString constructor, Value* v)
+    : Value(ValueTag::Variant)
     , m_constructor(constructor)
     , m_inner_value(v) {}
 
@@ -119,8 +119,8 @@ Reference::Reference(Value* value)
     : Value {ValueTag::Reference}
     , m_value {value} {}
 
-UnionConstructor::UnionConstructor(InternedString constructor)
-    : Value {ValueTag::UnionConstructor}
+VariantConstructor::VariantConstructor(InternedString constructor)
+    : Value {ValueTag::VariantConstructor}
     , m_constructor {constructor} {}
 
 StructConstructor::StructConstructor(std::vector<InternedString> keys)
@@ -148,7 +148,7 @@ void gc_visit(Error* v) {
 void gc_visit(NativeFunction* v) {
 	v->m_visited = true;
 }
-void gc_visit(UnionConstructor* v) {
+void gc_visit(VariantConstructor* v) {
 	v->m_visited = true;
 }
 void gc_visit(StructConstructor* v) {
@@ -183,7 +183,7 @@ void gc_visit(Dictionary* d) {
 		gc_visit(child.second);
 }
 
-void gc_visit(Union* u) {
+void gc_visit(Variant* u) {
 	if (u->m_visited)
 		return;
 
@@ -229,16 +229,16 @@ void gc_visit(Value* v) {
 		return gc_visit(static_cast<Object*>(v));
 	case ValueTag::Dictionary:
 		return gc_visit(static_cast<Dictionary*>(v));
-	case ValueTag::Union:
-		return gc_visit(static_cast<Union*>(v));
+	case ValueTag::Variant:
+		return gc_visit(static_cast<Variant*>(v));
 	case ValueTag::Function:
 		return gc_visit(static_cast<Function*>(v));
 	case ValueTag::NativeFunction:
 		return gc_visit(static_cast<NativeFunction*>(v));
 	case ValueTag::Reference:
 		return gc_visit(static_cast<Reference*>(v));
-	case ValueTag::UnionConstructor:
-		return gc_visit(static_cast<UnionConstructor*>(v));
+	case ValueTag::VariantConstructor:
+		return gc_visit(static_cast<VariantConstructor*>(v));
 	case ValueTag::StructConstructor:
 		return gc_visit(static_cast<StructConstructor*>(v));
 	}
@@ -299,7 +299,7 @@ void print(Dictionary* m, int d) {
 	std::cout << value_string[int(m->type())] << '\n';
 }
 
-void print(Union* m, int d) {
+void print(Variant* m, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(m->type())] << " " << m->m_constructor << '\n';
 	print(m->m_inner_value, d);
@@ -357,16 +357,16 @@ void print(Value* v, int d) {
 		return print(static_cast<Object*>(v), d);
 	case ValueTag::Dictionary:
 		return print(static_cast<Dictionary*>(v), d);
-	case ValueTag::Union:
-		return print(static_cast<Union*>(v), d);
+	case ValueTag::Variant:
+		return print(static_cast<Variant*>(v), d);
 	case ValueTag::Function:
 		return print(static_cast<Function*>(v), d);
 	case ValueTag::NativeFunction:
 		return print(static_cast<NativeFunction*>(v), d);
 	case ValueTag::Reference:
 		return print(static_cast<Reference*>(v), d);
-	case ValueTag::UnionConstructor:
-		return print(static_cast<UnionConstructor*>(v), d);
+	case ValueTag::VariantConstructor:
+		return print(static_cast<VariantConstructor*>(v), d);
 	case ValueTag::StructConstructor:
 		return print(static_cast<StructConstructor*>(v), d);
 	}

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -19,7 +19,7 @@ struct Interpreter;
 
 using Identifier = InternedString;
 using StringType = std::string;
-using ObjectType = std::unordered_map<Identifier, Value*>;
+using RecordType = std::unordered_map<Identifier, Value*>;
 using DictionaryType = std::unordered_map<StringType, Value*>;
 using ArrayType = std::vector<Value*>;
 using FunctionType = TypedAST::FunctionLiteral*;
@@ -89,11 +89,11 @@ struct Array : Value {
 	Value* at(int position);
 };
 
-struct Object : Value {
-	ObjectType m_value;
+struct Record : Value {
+	RecordType m_value;
 
-	Object();
-	Object(ObjectType);
+	Record();
+	Record(RecordType);
 
 	void addMember(Identifier const& id, Value* v);
 	Value* getMember(Identifier const& id);
@@ -121,9 +121,9 @@ struct Variant : Value {
 struct Function : Value {
 	FunctionType m_def;
 	// TODO: store references instead of values
-	ObjectType m_captures;
+	RecordType m_captures;
 
-	Function(FunctionType, ObjectType);
+	Function(FunctionType, RecordType);
 };
 
 struct NativeFunction : Value {
@@ -144,10 +144,10 @@ struct VariantConstructor : Value {
 	VariantConstructor(InternedString constructor);
 };
 
-struct StructConstructor : Value {
+struct RecordConstructor : Value {
 	std::vector<InternedString> m_keys;
 
-	StructConstructor(std::vector<InternedString> keys);
+	RecordConstructor(std::vector<InternedString> keys);
 };
 
 } // namespace Interpreter

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -110,12 +110,12 @@ struct Dictionary : Value {
 	void removeMember(StringType const& id);
 };
 
-struct Union : Value {
+struct Variant : Value {
 	InternedString m_constructor;
 	Value* m_inner_value {nullptr}; // empty constructor
 
-	Union(InternedString constructor);
-	Union(InternedString constructor, Value* v);
+	Variant(InternedString constructor);
+	Variant(InternedString constructor, Value* v);
 };
 
 struct Function : Value {
@@ -138,10 +138,10 @@ struct Reference : Value {
 	Reference(Value* value);
 };
 
-struct UnionConstructor : Value {
+struct VariantConstructor : Value {
 	InternedString m_constructor;
 
-	UnionConstructor(InternedString constructor);
+	VariantConstructor(InternedString constructor);
 };
 
 struct StructConstructor : Value {

--- a/src/interpreter/value_tag.hpp
+++ b/src/interpreter/value_tag.hpp
@@ -10,7 +10,7 @@
 	X(Error)                                                                   \
                                                                                \
 	X(Array)                                                                   \
-	X(Object)                                                                  \
+	X(Record)                                                                  \
 	X(Dictionary)                                                              \
 	X(Variant)                                                                 \
                                                                                \
@@ -20,7 +20,7 @@
 	X(Reference)                                                               \
                                                                                \
 	X(VariantConstructor)                                                      \
-	X(StructConstructor)
+	X(RecordConstructor)
 
 #define X(name) #name,
 constexpr const char* value_string[] = {

--- a/src/interpreter/value_tag.hpp
+++ b/src/interpreter/value_tag.hpp
@@ -12,14 +12,14 @@
 	X(Array)                                                                   \
 	X(Object)                                                                  \
 	X(Dictionary)                                                              \
-	X(Union)                                                                   \
+	X(Variant)                                                                 \
                                                                                \
 	X(Function)                                                                \
 	X(NativeFunction)                                                          \
                                                                                \
 	X(Reference)                                                               \
                                                                                \
-	X(UnionConstructor)                                                        \
+	X(VariantConstructor)                                                      \
 	X(StructConstructor)
 
 #define X(name) #name,

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -177,7 +177,7 @@ namespace TypeChecker {
 
 [[nodiscard]] ErrorReport match_identifiers(
     TypedAST::AccessExpression* ast, Frontend::CompileTimeEnvironment& env) {
-	return match_identifiers(ast->m_object, env);
+	return match_identifiers(ast->m_record, env);
 }
 
 [[nodiscard]] ErrorReport match_identifiers(

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -85,8 +85,8 @@ void metacheck(TypedAST::AccessExpression* ast, TypeChecker& tc) {
 
 	// TODO: we would like to support static records with
 	// typefunc members in the future
-	metacheck(ast->m_object, tc);
-	MetaTypeId metatype = tc.m_core.m_meta_core.find(ast->m_object->m_meta_type);
+	metacheck(ast->m_record, tc);
+	MetaTypeId metatype = tc.m_core.m_meta_core.find(ast->m_record->m_meta_type);
 	// TODO: support vars
 	if (metatype == tc.meta_monotype())
 		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_constructor());

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -399,7 +399,7 @@ Writer<AST::AST*> Parser::parse_expression(int bp) {
 				return result;
 
 			auto e = m_ast_allocator->make<AST::AccessExpression>();
-			e->m_object = lhs.m_result;
+			e->m_record = lhs.m_result;
 			e->m_member = member.m_result;
 			lhs.m_result = e;
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -190,7 +190,7 @@ void typecheck(TypedAST::TernaryExpression* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::AccessExpression* ast, TypeChecker& tc) {
-	typecheck(ast->m_object, tc);
+	typecheck(ast->m_record, tc);
 
 	// should this be a hidden type var?
 	MonoId member_type = tc.new_var();
@@ -204,7 +204,7 @@ void typecheck(TypedAST::AccessExpression* ast, TypeChecker& tc) {
 	    true);
 	MonoId term_type = tc.m_core.new_term(dummy_tf, {}, "record instance");
 
-	tc.m_core.m_mono_core.unify(ast->m_object->m_value_type, term_type);
+	tc.m_core.m_mono_core.unify(ast->m_record->m_value_type, term_type);
 }
 
 void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -226,7 +226,7 @@ void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 			tc.m_core.m_mono_core.unify(field_type, ast->m_args[i]->m_value_type);
 		}
 	// match the argument type with the constructor used
-	} else if (tf_data.tag == TypeFunctionTag::Sum) {
+	} else if (tf_data.tag == TypeFunctionTag::Variant) {
 		assert(ast->m_args.size() == 1);
 
 		typecheck(ast->m_args[0], tc);

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -141,7 +141,7 @@ TypedAST* convert_ast(AST::AccessExpression* ast, Allocator& alloc) {
 	auto typed_ast = alloc.make<AccessExpression>();
 
 	typed_ast->m_member = ast->m_member;
-	typed_ast->m_object = convert_ast(ast->m_object, alloc);
+	typed_ast->m_record = convert_ast(ast->m_record, alloc);
 
 	return typed_ast;
 }

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -210,7 +210,7 @@ struct IndexExpression : public TypedAST {
 };
 
 struct AccessExpression : public TypedAST {
-	TypedAST* m_object;
+	TypedAST* m_record;
 	Token const* m_member;
 
 	AccessExpression()

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -8,9 +8,9 @@
 #include "utils/interned_string.hpp"
 #include "typechecker_types.hpp"
 
-enum class TypeFunctionTag { Builtin, Sum, Product, Record };
+enum class TypeFunctionTag { Builtin, Variant, Tuple, Record };
 // Concrete type function. If it's a built-in, we use argument_count
-// to tell how many arguments it takes. Else, for sum, product and record,
+// to tell how many arguments it takes. Else, for variant, tuple and record,
 // we store their structure as a hash from names to monotypes.
 //
 // Dummy type functions are for unifying purposes only, but do not count


### PR DESCRIPTION
We were using some inconsistent naming. That's gone now.

We always say 'record' to mean something with fields that can be accessed

We always say 'variant' to mean something that can be one of a set of types

We always say 'tuple' when talking about tuples (which aren't implemented)