### PR TITLE
Topologically ordered metacheck

### DIFF
--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -10,6 +10,7 @@
 namespace TypedAST {
 
 struct Declaration;
+struct DeclarationList;
 struct FunctionLiteral;
 
 } // namespace TypedAST
@@ -27,6 +28,9 @@ struct CompileTimeEnvironment {
 	std::vector<Scope> m_scopes;
 	std::vector<TypedAST::FunctionLiteral*> m_function_stack;
 	TypedAST::Declaration* m_current_decl {nullptr};
+
+	// TODO: is this a good place to put this?
+	std::vector<std::vector<TypedAST::Declaration*>> declaration_components;
 
 	CompileTimeEnvironment();
 
@@ -48,6 +52,9 @@ struct CompileTimeEnvironment {
 	void end_scope();
 
 	bool has_type_var(MonoId);
+
+	void compute_declaration_order(TypedAST::DeclarationList* ast);
 };
 
 } // namespace Frontend
+

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -253,12 +253,12 @@ TypedAST::Constructor* constructor_from_ast(
 		structure[access->m_member->m_text] = tc.new_var();
 		TypeFunctionId dummy_tf = tc.m_core.new_type_function(
 		    TypeFunctionTag::Sum, {}, std::move(structure), true);
+		MonoId dummy_monotype =
+		    tc.m_core.new_term(dummy_tf, {}, "Union Constructor Access");
 
-		// TODO: handle monotype being a var
 		MonoId monotype = mono_type_from_ast(access->m_object, tc);
-		TypeFunctionId tf = tc.m_core.m_mono_core.find_function(monotype);
 
-		tc.m_core.m_tf_core.unify(dummy_tf, tf);
+		tc.m_core.m_mono_core.unify(dummy_monotype, monotype);
 
 		constructor->m_mono = monotype;
 		constructor->m_id = access->m_member;
@@ -282,7 +282,6 @@ TypedAST::Declaration* ct_eval(
 
 TypedAST::DeclarationList* ct_eval(
     TypedAST::DeclarationList* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
-	// TODO: we might need to do the SCC decomposition here, too.
 
 	for (auto& decl : ast->m_declarations) {
 		int meta_type = tc.m_core.m_meta_core.find(decl.m_meta_type);

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -52,6 +52,7 @@ ExitStatusTag execute(std::string const& source, bool dump_ast, Runner* runner) 
 			return ExitStatusTag::StaticError;
 		}
 	}
+	tc.m_env.compute_declaration_order(static_cast<TypedAST::DeclarationList*>(top_level));
 
 	TypeChecker::metacheck(top_level, tc);
 	top_level = TypeChecker::ct_eval(top_level, tc, typed_ast_allocator);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -162,22 +162,28 @@ void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 	for (auto& decl : ast->m_declarations)
 		decl.m_meta_type = tc.new_meta_var();
 
-	for (auto& decl : ast->m_declarations) {
-		if (decl.m_type_hint) {
-			metacheck(decl.m_type_hint, tc);
-			tc.m_core.m_meta_core.unify(decl.m_type_hint->m_meta_type, tc.meta_monotype());
+	auto const& comps = tc.m_env.declaration_components;
+	for (auto const& comp : comps) {
+
+		for (auto decl : comp) {
+			if (decl->m_type_hint) {
+				metacheck(decl->m_type_hint, tc);
+				tc.m_core.m_meta_core.unify(
+				    decl->m_type_hint->m_meta_type, tc.meta_monotype());
+				// TODO? unify ( decl->metatype, value )
+			}
+			metacheck(decl->m_value, tc);
+			tc.m_core.m_meta_core.unify(
+			    decl->m_meta_type, decl->m_value->m_meta_type);
 		}
-		metacheck(decl.m_value, tc);
+
+		for (auto decl : comp)
+			if (tc.m_core.m_meta_core.find(decl->m_meta_type) == tc.meta_typefunc())
+				for (auto other : decl->m_references)
+					if (tc.m_core.m_meta_core.find(other->m_meta_type) ==
+					    tc.meta_value())
+						assert(0 && "value referenced in a type definition");
 	}
-
-	for (auto& decl : ast->m_declarations)
-		tc.m_core.m_meta_core.unify(decl.m_meta_type, decl.m_value->m_meta_type);
-
-	for (auto& decl : ast->m_declarations)
-		if (tc.m_core.m_meta_core.find(decl.m_meta_type) == tc.meta_typefunc())
-			for (auto other : decl.m_references)
-				if (tc.m_core.m_meta_core.find(other->m_meta_type) == tc.meta_value())
-					assert(0 && "value referenced in a type definition");
 }
 
 void metacheck(TypedAST::UnionExpression* ast, TypeChecker& tc) {
@@ -219,6 +225,10 @@ void metacheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 	case TypedASTTag::type:                                                    \
 		return void(metacheck_literal(ast, tc))
 
+#define REJECT(type)                                                          \
+	case TypedASTTag::type:                                                    \
+		assert(0);
+
 	switch (ast->type()) {
 		LITERAL(IntegerLiteral);
 		LITERAL(NumberLiteral);
@@ -247,6 +257,10 @@ void metacheck(TypedAST::TypedAST* ast, TypeChecker& tc) {
 		DISPATCH(UnionExpression);
 		DISPATCH(StructExpression);
 		DISPATCH(TypeTerm);
+
+		REJECT(TypeFunctionHandle);
+		REJECT(MonoTypeHandle);
+		REJECT(Constructor);
 	}
 
 	std::cerr << "Unhandled case in " << __PRETTY_FUNCTION__ << " : "

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -170,7 +170,7 @@ void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 				metacheck(decl->m_type_hint, tc);
 				tc.m_core.m_meta_core.unify(
 				    decl->m_type_hint->m_meta_type, tc.meta_monotype());
-				// TODO? unify ( decl->metatype, value )
+				tc.m_core.m_meta_core.unify(decl->m_meta_type, tc.meta_value());
 			}
 			metacheck(decl->m_value, tc);
 			tc.m_core.m_meta_core.unify(

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -570,6 +570,17 @@ void interpreter_tests(Test::Tester& tests) {
 	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
 		    return Assert::equals(eval_expression("__invoke()", env), 0);
 	    }}));
+
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	    R"(
+			a := c;
+			b := a.id { 10 };
+			c := union { id : int(<>); }(<>);
+			__invoke := fn() => 0;
+		)",
+	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
+		    return Assert::equals(eval_expression("__invoke()", env), 0);
+	    }}));
 }
 
 void tarjan_algorithm_tests(Test::Tester& tester) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -1,6 +1,5 @@
 #include "typecheck.hpp"
 
-#include "algorithms/tarjan_solver.hpp"
 #include "compile_time_environment.hpp"
 #include "typechecker.hpp"
 #include "typechecker_types.hpp"
@@ -284,50 +283,12 @@ void typecheck(TypedAST::Declaration* ast, TypeChecker& tc) {
 
 void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 
-	// two way mapping
-	std::unordered_map<TypedAST::Declaration*, int> decl_to_index;
-	std::vector<TypedAST::Declaration*> index_to_decl;
-
-	// assign a unique int to every top level declaration
-	int i = 0;
-	for (auto& decl : ast->m_declarations) {
-		index_to_decl.push_back(&decl);
-		decl_to_index.insert({&decl, i});
-		++i;
-	}
-
-	// build up the explicit declaration graph
-	TarjanSolver solver(index_to_decl.size());
-	for (auto kv : decl_to_index) {
-		auto decl = kv.first;
-#if DEBUG
-		std::cerr << "@@ " << decl->identifier_text() << " -- (" << kv.second
-		          << ")\n";
-#endif
-		auto u = kv.second;
-		for (auto other : decl->m_references) {
-			auto it = decl_to_index.find(other);
-			if (it != decl_to_index.end()) {
-				int v = it->second;
-#if DEBUG
-				std::cerr << "@@   " << other->identifier_text()
-				          << " -- add_edge(" << u << ", " << v << ")\n";
-#endif
-				solver.add_edge(u, v);
-			}
-		}
-	}
-
-	// compute strongly connected components
-	solver.solve();
-
-	auto const& comps = solver.vertices_of_components();
-	for (auto const& verts : comps) {
+	auto const& comps = tc.m_env.declaration_components;
+	for (auto const& decls : comps) {
 
 		bool type_in_component = false;
 		bool non_type_in_component = false;
-		for (int u : verts) {
-			auto decl = index_to_decl[u];
+		for (auto decl : decls) {
 
 			auto meta_type = tc.m_core.m_meta_core.find(decl->m_meta_type);
 			if (meta_type == tc.meta_typefunc() || meta_type == tc.meta_monotype())
@@ -343,31 +304,18 @@ void typecheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 		if (type_in_component)
 			continue;
 
-#if DEBUG
-		std::cerr << "@@@@ TYPECHECKING COMPONENT @@@@\n";
-		std::cerr << "@@@@ MEMBER LIST START @@@@\n";
-		for (int u : verts) {
-			auto decl = index_to_decl[u];
-			std::cerr << "  MEMBER: " << decl->identifier_text() << '\n';
-		}
-		std::cerr << "@@@@ MEMBER LIST END @@@@\n";
-#endif
-
 		// set up some dummy types on every decl
-		for (int u : verts) {
-			auto decl = index_to_decl[u];
+		for (auto decl : decls) {
 			decl->m_value_type = tc.new_hidden_var();
 		}
 
-		for (int u : verts) {
-			auto decl = index_to_decl[u];
+		for (auto decl : decls) {
 			process_contents(decl, tc);
 		}
 
 		// generalize all the decl types, so that they are
 		// identified as polymorphic in the next rec-block
-		for (int u : verts) {
-			auto decl = index_to_decl[u];
+		for (auto decl : decls) {
 			generalize(decl, tc);
 			print_information(decl, tc);
 		}


### PR DESCRIPTION
As I mentioned somewhere, 

```rust
a := c;
b := a.id { 10 };
c := union { id : int(<>); }(<>);
```

didn't work. This was due to not knowing the metatype of `a` when checking `a.id` in `c`, which made its metatype default to `value`, which is wrong (it should be `constructor`).

While I did not improve on that behavior, I made it harder to reach a declaration without knowing the metatypes of parts of that expression by metachecking declarations in topological order (aka in dependency order)