### PR TITLE
Better metacheck cycle support

### DIFF
--- a/src/algorithms/unification.cpp
+++ b/src/algorithms/unification.cpp
@@ -85,6 +85,10 @@ bool Core::is_term(int i) {
 	return node_header[i].tag == Tag::Term;
 }
 
+bool Core::is_var(int i) {
+	return node_header[i].tag == Tag::Var;
+}
+
 void Core::print_node(int header, int d) {
 	Core::NodeHeader& node = node_header[find(header)];
 

--- a/src/algorithms/unification.hpp
+++ b/src/algorithms/unification.hpp
@@ -35,6 +35,7 @@ struct Core {
 	int new_var(const char* debug = nullptr);
 	int new_term(int f, std::vector<int> args = {}, const char* debug = nullptr);
 
+	bool is_var(int i);
 	bool is_term(int i);
 
 	void print_node(int node_header, int d = 0);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -10,6 +10,14 @@ namespace TypeChecker {
 
 // literals
 
+void assign_meta_type(MetaTypeId& target, MetaTypeId value, TypeChecker& tc) {
+	if (target == -1) {
+		target = value;
+	} else {
+		tc.m_core.m_meta_core.unify(target, value);
+	}
+}
+
 void metacheck_literal(TypedAST::TypedAST* ast, TypeChecker& tc) {
 	ast->m_meta_type = tc.meta_value();
 }

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -87,11 +87,15 @@ void metacheck(TypedAST::AccessExpression* ast, TypeChecker& tc) {
 	// typefunc members in the future
 	metacheck(ast->m_record, tc);
 	MetaTypeId metatype = tc.m_core.m_meta_core.find(ast->m_record->m_meta_type);
-	// TODO: support vars
-	if (metatype == tc.meta_monotype())
-		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_constructor());
-	else
-		tc.m_core.m_meta_core.unify(ast->m_meta_type, tc.meta_value());
+
+	// TODO: support vars correctly
+	if (!tc.m_core.m_meta_core.is_var(metatype)) {
+		auto correct_metatype = metatype == tc.meta_monotype()
+		                            ? tc.meta_constructor()
+		                            : tc.meta_value();
+
+		tc.m_core.m_meta_core.unify(ast->m_meta_type, correct_metatype);
+	}
 }
 
 void metacheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -8,8 +8,6 @@
 
 namespace TypeChecker {
 
-// literals
-
 void unsafe_assign_meta_type(MetaTypeId& target, MetaTypeId value) {
 	target = value;
 }
@@ -21,6 +19,8 @@ void assign_meta_type(MetaTypeId& target, MetaTypeId value, TypeChecker& tc) {
 		tc.m_core.m_meta_core.unify(target, value);
 	}
 }
+
+// literals
 
 void metacheck_literal(TypedAST::TypedAST* ast, TypeChecker& tc) {
 	assign_meta_type(ast->m_meta_type, tc.meta_value(), tc);
@@ -205,13 +205,12 @@ void metacheck(TypedAST::DeclarationList* ast, TypeChecker& tc) {
 	auto const& comps = tc.m_env.declaration_components;
 	for (auto const& comp : comps) {
 
-		// Because we do branching in some of the metachecks,
-		// we end up with some extra ordering constrains.
-		// Since we don't do anything to deal with that, we
-		// do a few passes, and hope it converges.
-		for (int passes = 2; passes--;)
-			for (auto decl : comp)
-				process_declaration(decl, tc);
+		// We do a first pass to get some information off of the ASTs.
+		// After that, most things should be inferable during the second pass,
+		// but we will set a flag to activate a special behavior in case some
+		// things aren't.
+		for (auto decl : comp)
+			process_declaration(decl, tc);
 
 		tc.m_in_last_metacheck_pass = true;
 

--- a/src/typechecker.hpp
+++ b/src/typechecker.hpp
@@ -19,6 +19,7 @@ struct TypeChecker {
 	ChunkedArray<TypedAST::Declaration> m_builtin_declarations;
 
 	TypedAST::Allocator* m_typed_ast_allocator;
+	bool m_in_last_metacheck_pass {false};
 
 	TypeChecker(TypedAST::Allocator& allocator);
 


### PR DESCRIPTION
We've talked about this before. This should mitigate the incompleteness of metacheck's inference.

I don't think this breaks anything, but I'm not sure it fixes anything either, as I haven't been able to come up with a test case that breaks without this patch. If @lushoBarlett could help me out with that, that'd be awesome.

I didn't put any system to check whether we need to do more passes or not yet, which means metacheck is _always_ 3x slower now, which is pretty bad. Specially considering how a single pass is enough, most of the time.