### PR TITLE
Argument type hints

### DIFF
--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -23,8 +23,9 @@ TypedAST::ArrayLiteral* ct_eval(
 
 TypedAST::FunctionLiteral* ct_eval(
     TypedAST::FunctionLiteral* ast, TypeChecker& tc, TypedAST::Allocator& alloc) {
-
-	// TODO: type hints
+	for (auto& arg : ast->m_args)
+		if (arg.m_type_hint)
+			arg.m_type_hint = ct_eval(arg.m_type_hint, tc, alloc);
 
 	assert(ast->m_body->type() == TypedASTTag::Block);
 	auto body = static_cast<TypedAST::Block*>(ast->m_body);

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -106,10 +106,11 @@ namespace TypeChecker {
 	env.enter_function(ast);
 	env.new_nested_scope(); // NOTE: this is nested because of lexical scoping
 
-	int arg_count = ast->m_args.size();
-
-	for (int i = 0; i < arg_count; ++i)
-		env.declare(ast->m_args[i].identifier_text(), &ast->m_args[i]);
+	for (auto& arg : ast->m_args) {
+		if (arg.m_type_hint)
+			CHECK_AND_RETURN(match_identifiers(arg.m_type_hint, env));
+		env.declare(arg.identifier_text(), &arg);
+	}
 
 	// scan body
 	assert(ast->m_body->type() == TypedASTTag::Block);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -48,8 +48,10 @@ void metacheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
 	assign_meta_type(ast->m_meta_type, tc.meta_value(), tc);
 
 	for (auto& arg : ast->m_args) {
-		if (arg.m_type_hint)
+		if (arg.m_type_hint) {
 			metacheck(arg.m_type_hint, tc);
+			assign_meta_type(arg.m_type_hint, tc.meta_monotype(), tc);
+		}
 		assign_meta_type(arg.m_meta_type, tc.meta_value(), tc);
 	}
 

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -50,7 +50,7 @@ void metacheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
 	for (auto& arg : ast->m_args) {
 		if (arg.m_type_hint) {
 			metacheck(arg.m_type_hint, tc);
-			assign_meta_type(arg.m_type_hint, tc.meta_monotype(), tc);
+			assign_meta_type(arg.m_type_hint->m_meta_type, tc.meta_monotype(), tc);
 		}
 		assign_meta_type(arg.m_meta_type, tc.meta_value(), tc);
 	}

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -47,10 +47,11 @@ void metacheck(TypedAST::Identifier* ast, TypeChecker& tc) {
 void metacheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
 	assign_meta_type(ast->m_meta_type, tc.meta_value(), tc);
 
-	int arg_count = ast->m_args.size();
-	for (int i = 0; i < arg_count; ++i)
-		// TODO: metacheck type hints
-		assign_meta_type(ast->m_args[i].m_meta_type, tc.meta_value(), tc);
+	for (auto& arg : ast->m_args) {
+		if (arg.m_type_hint)
+			metacheck(arg.m_type_hint, tc);
+		assign_meta_type(arg.m_meta_type, tc.meta_value(), tc);
+	}
 
 	assert(ast->m_body->type() == TypedASTTag::Block);
 	auto body = static_cast<TypedAST::Block*>(ast->m_body);

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -618,6 +618,30 @@ void interpreter_tests(Test::Tester& tests) {
 		    return Assert::equals(eval_expression("__invoke()", env), 3);
 	    }}));
 
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	    R"(
+		f := fn (error_number : int(<>)) =>
+			fn(x : either(<>)) => match(x) {
+				left { i } => i;
+				right { s } => error_number;
+			};
+
+		either := union {
+			left : int(<>);
+			right : string(<>);
+		};
+
+		__invoke := fn() {
+			x := either(<>).left{ 1 };
+			y := either(<>).right{ "error" };
+
+			def := f(10);
+			return def(x) + def(y);
+		};
+		)",
+	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
+		    return Assert::equals(eval_expression("__invoke()", env), 11);
+	    }}));
 }
 
 void tarjan_algorithm_tests(Test::Tester& tester) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -107,13 +107,12 @@ void typecheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
 		// TODO: do something better, use the type hints
 		ast->m_return_type = tc.new_var();
 
-		int arg_count = ast->m_args.size();
 		std::vector<MonoId> arg_types;
 
-		for (int i = 0; i < arg_count; ++i) {
-			int mono = tc.new_var();
-			arg_types.push_back(mono);
-			ast->m_args[i].m_value_type = mono;
+		for (auto& arg : ast->m_args) {
+			arg.m_value_type = tc.new_var();
+			process_declaration_type_hint(&arg, tc);
+			arg_types.push_back(arg.m_value_type);
 		}
 
 		// return type

--- a/src/typed_ast.cpp
+++ b/src/typed_ast.cpp
@@ -65,6 +65,8 @@ TypedAST* convert_ast(AST::FunctionLiteral* ast, Allocator& alloc) {
 		Declaration typed_decl;
 
 		typed_decl.m_identifier_token = arg.m_identifier_token;
+		if (arg.m_type_hint)
+			typed_decl.m_type_hint = convert_ast(arg.m_type_hint, alloc);
 		typed_decl.m_surrounding_function = typed_function;
 
 		typed_function->m_args.push_back(std::move(typed_decl));


### PR DESCRIPTION
Takes function arguments' type hints into account for type inference. As a sidenote, I consider that we may benefit on a way to test for program failures as well.