### PR TITLE
Eval: store captures in a vector instead of a hash table

### DIFF
--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -128,7 +128,7 @@ String* GC::new_string_raw(std::string s) {
 	return result;
 }
 
-gc_ptr<Function> GC::new_function(FunctionType def, RecordType captures) {
+gc_ptr<Function> GC::new_function(FunctionType def, CapturesType captures) {
 	auto result = new Function(std::move(def), std::move(captures));
 	m_blocks.push_back(result);
 	return result;

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -38,7 +38,7 @@ struct GC {
 	auto new_float(float) -> gc_ptr<Float>;
 	auto new_boolean(bool) -> gc_ptr<Boolean>;
 	auto new_string(std::string) -> gc_ptr<String>;
-	auto new_function(FunctionType, RecordType) -> gc_ptr<Function>;
+	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 	auto new_reference(Value*) -> gc_ptr<Reference>;

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -129,7 +129,7 @@ gc_ptr<Dictionary> Interpreter::new_dictionary(DictionaryType declarations) {
 	return result;
 }
 
-gc_ptr<Function> Interpreter::new_function(FunctionType def, RecordType s) {
+gc_ptr<Function> Interpreter::new_function(FunctionType def, CapturesType s) {
 	auto result = m_gc->new_function(def, std::move(s));
 	run_gc_if_needed();
 	return result;

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -57,7 +57,7 @@ struct Interpreter {
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_record(RecordType) -> gc_ptr<Record>;
 	auto new_dictionary(DictionaryType) -> gc_ptr<Dictionary>;
-	auto new_function(FunctionType, RecordType) -> gc_ptr<Function>;
+	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 	auto new_reference(Value*) -> gc_ptr<Reference>;

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -106,7 +106,7 @@ Variant::Variant(InternedString constructor, Value* v)
     , m_constructor(constructor)
     , m_inner_value(v) {}
 
-Function::Function(FunctionType def, RecordType captures)
+Function::Function(FunctionType def, CapturesType captures)
     : Value(ValueTag::Function)
     , m_def(def)
     , m_captures(std::move(captures)) {}

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -24,6 +24,7 @@ using DictionaryType = std::unordered_map<StringType, Value*>;
 using ArrayType = std::vector<Value*>;
 using FunctionType = TypedAST::FunctionLiteral*;
 using NativeFunctionType = auto(Span<Value*>, Interpreter&) -> Value*;
+using CapturesType = std::vector<std::pair<Identifier, Value*>>;
 
 // Returns the value pointed to by a reference
 void print(Value* v, int d = 0);
@@ -121,9 +122,9 @@ struct Variant : Value {
 struct Function : Value {
 	FunctionType m_def;
 	// TODO: store references instead of values
-	RecordType m_captures;
+	CapturesType m_captures;
 
-	Function(FunctionType, RecordType);
+	Function(FunctionType, CapturesType);
 };
 
 struct NativeFunction : Value {


### PR DESCRIPTION
It's been bugging me how we use a hash table to store captures in the runtime, so that's now gone.

This is certainly faster for programs that use lots of closures.