### PR TITLE
Bugfix capture match variable

### DIFF
--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -293,7 +293,9 @@ void eval(TypedAST::MatchExpression* ast, Interpreter& e) {
 
 	// We won't pop it, because it is already lined up for the later
 	// expressions. Instead, replace the variant with its inner value.
-	e.m_env.m_stack.back() = variant_inner;
+	// We also wrap it in a reference so it can be captured
+	auto ref = e.new_reference(unboxed(variant_inner));
+	e.m_env.m_stack.back() = ref.get();
 	
 	auto case_it = ast->m_cases.find(constructor);
 	// TODO: proper error handling

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -644,6 +644,23 @@ void interpreter_tests(Test::Tester& tests) {
 	    }}));
 
 
+	// Testing for a bug where we could not capture the inner variable that gets
+	// bound in a match expression
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	    R"jp(
+		A := union { X : int(<>); };
+		__invoke := fn() {
+			outter := A(<>).X{ 10 };
+			k := match(outter) {
+				X { inner } => fn() => inner;
+			};
+			return k();
+		}
+		)jp",
+	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
+		    return Assert::equals(eval_expression("__invoke()", env), 10);
+	    }}));
+
 	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
 	    R"(
 		// AST for a simple language


### PR DESCRIPTION
If we tried to capture the variable that gets bound in a match expression, eval would crash with an assertion stating that the captures were not references.

Now, we explicitly unbox and wrap the value in a fresh reference.

It might be better to not "re-box" it the value was already a reference, but that's a design decision that exceeds the scope of this pr