### PR TITLE
Eval: implement assignment to an array element

### DIFF
--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -100,8 +100,9 @@ void eval(TypedAST::ArrayLiteral* ast, Interpreter& e) {
 	result->m_value.reserve(ast->m_elements.size());
 	for (auto& element : ast->m_elements) {
 		eval(element, e);
-		auto value = e.m_env.pop();
-		result->m_value.push_back(unboxed(value.get()));
+		auto value_handle = e.m_env.pop();
+		auto* value = unboxed(value_handle.get());
+		result->append(e.new_reference(value).get());
 	}
 	e.m_env.push(result.get());
 }

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -32,7 +32,7 @@ Value* array_append(ArgsType v, Interpreter& e) {
 	assert(unboxed(v[0])->type() == ValueTag::Array);
 	Array* array = static_cast<Array*>(unboxed(v[0]));
 	for (unsigned int i = 1; i < v.size(); i++) {
-		array->m_value.push_back(unboxed(v[i]));
+		array->append(e.new_reference(unboxed(v[i])).get());
 	}
 	return array;
 }

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -39,7 +39,7 @@ Array::Array(ArrayType l)
     : Value(ValueTag::Array)
     , m_value(std::move(l)) {}
 
-void Array::append(Value* v) {
+void Array::append(Reference* v) {
 	m_value.push_back(v);
 }
 

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -17,11 +17,13 @@ namespace Interpreter {
 
 struct Interpreter;
 
+struct Reference;
+
 using Identifier = InternedString;
 using StringType = std::string;
 using RecordType = std::unordered_map<Identifier, Value*>;
 using DictionaryType = std::unordered_map<StringType, Value*>;
-using ArrayType = std::vector<Value*>;
+using ArrayType = std::vector<Reference*>;
 using FunctionType = TypedAST::FunctionLiteral*;
 using NativeFunctionType = auto(Span<Value*>, Interpreter&) -> Value*;
 using CapturesType = std::vector<std::pair<Identifier, Value*>>;
@@ -86,7 +88,7 @@ struct Array : Value {
 	Array();
 	Array(ArrayType l);
 
-	void append(Value* v);
+	void append(Reference* v);
 	Value* at(int position);
 };
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -694,7 +694,6 @@ void interpreter_tests(Test::Tester& tests) {
 		    return Assert::equals(eval_expression("__invoke()", env), 42);
 	    }}));
 
-
 	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
 	    R"(
 		__invoke := fn() => seq {
@@ -704,7 +703,19 @@ void interpreter_tests(Test::Tester& tests) {
 	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
 		    return Assert::equals(eval_expression("__invoke()", env), 42);
 	    }}));
-	
+
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	    R"(
+		__invoke := fn() {
+			arr := array { 0; 1; 2; 3; 4; };
+			arr[0] = 1;
+			arr[4] = 5;
+			return arr[0] + arr[1] + arr[2] + arr[3] + arr[4];
+		};
+		)",
+	    Testers {+[](Interpreter::Interpreter& env) -> ExitStatusTag {
+		    return Assert::equals(eval_expression("__invoke()", env), 12);
+	    }}));
 }
 
 void tarjan_algorithm_tests(Test::Tester& tester) {


### PR DESCRIPTION
We now put every array element in a reference. This is not the nicest
in terms of performance (because it adds an extra level of indirection),
but that's ok.

Also, I added a test.