### PR TITLE
Parser: don't add implicit poly parens in type terms

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1002,15 +1002,14 @@ Writer<AST::AST*> Parser::parse_type_term() {
 	auto callee = parse_identifier(true);
 	CHECK_AND_RETURN(result, callee);
 
-	auto e = m_ast_allocator->make<AST::TypeTerm>();
-	e->m_callee = callee.m_result;
-
 	if (!match(TokenTag::POLY_OPEN))
-		return make_writer<AST::AST*>(e);
+		return make_writer<AST::AST*>(callee.m_result);
 
 	auto args = parse_type_term_arguments();
 	CHECK_AND_RETURN(result, args);
 
+	auto e = m_ast_allocator->make<AST::TypeTerm>();
+	e->m_callee = callee.m_result;
 	e->m_args = std::move(args.m_result);
 	return make_writer<AST::AST*>(e);
 }

--- a/tests/typesystem.jp
+++ b/tests/typesystem.jp
@@ -1,3 +1,6 @@
+Int := int<::>;
+sum := fn(x : Int, y : Int) => x + y;
+
 a : int<::> = 1;
 b : string<::> = "hello";
 c : array<: int<::> :> = array { 1; 2; };


### PR DESCRIPTION
This is very overdue lol. The fix was extremely simple, the parser is now one line shorter.

(EDIT) The reason this is a problem is that it forbids things like

```rust
Int := int<::>;
f := fn(x : Int) => x;
```