### PR TITLE
Remove parenthesis from ternary

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -946,6 +946,13 @@ Writer<AST::AST*> Parser::parse_statement() {
 		CHECK_AND_RETURN(result, return_statement);
 		return return_statement;
 	} else if (p0->m_type == TokenTag::KEYWORD_IF) {
+		auto* p1 = peek(1);
+		if (p1->m_type != TokenTag::PAREN_OPEN) {
+			auto expression = parse_expression();
+			CHECK_AND_RETURN(result, expression);
+			REQUIRE(result, TokenTag::SEMICOLON);
+			return expression;
+		}
 		auto if_else_statement = parse_if_else_statement();
 		CHECK_AND_RETURN(result, if_else_statement);
 		return if_else_statement;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -488,12 +488,9 @@ Writer<AST::AST*> Parser::parse_terminal() {
 		return function;
 	}
 
-	if (token->m_type == TokenTag::PAREN_OPEN and
-	    peek(1)->m_type == TokenTag::KEYWORD_IF) {
-		m_lexer->advance();
+	if (token->m_type == TokenTag::KEYWORD_IF) {
 		auto ternary = parse_ternary_expression();
 		CHECK_AND_RETURN(result, ternary);
-		REQUIRE(result, TokenTag::PAREN_CLOSE);
 		return ternary;
 	}
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -926,8 +926,6 @@ Writer<AST::AST*> Parser::parse_statement() {
 	Writer<AST::AST*> result = {
 	    {"Parse Error: Failed to parse statement"}};
 
-	// TODO: paren_open, string tokens, integer and numer
-	// tokens, etc should also be recognized as expressions.
 	auto* p0 = peek(0);
 	if (p0->m_type == TokenTag::IDENTIFIER) {
 		auto* p1 = peek(1);
@@ -940,7 +938,6 @@ Writer<AST::AST*> Parser::parse_statement() {
 
 			return make_writer<AST::AST*>(declaration.m_result);
 		} else {
-			// TODO: wrap in an ExpressionStatement ?
 			auto expression = parse_expression();
 			CHECK_AND_RETURN(result, expression);
 			REQUIRE(result, TokenTag::SEMICOLON);
@@ -968,10 +965,10 @@ Writer<AST::AST*> Parser::parse_statement() {
 		CHECK_AND_RETURN(result, block_statement);
 		return block_statement;
 	} else {
-		auto err = make_expected_error("a statement", p0);
-
-		result.m_error.m_sub_errors.push_back(std::move(err));
-		return result;
+		auto expression = parse_expression();
+		CHECK_AND_RETURN(result, expression);
+		REQUIRE(result, TokenTag::SEMICOLON);
+		return expression;
 	}
 
 	return result;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -41,9 +41,9 @@ struct Parser {
 	Writer<AST::AST*> parse_sequence_expression();
 	Writer<AST::Identifier*> parse_identifier(bool types_allowed = false);
 	Writer<AST::Declaration*> parse_declaration();
-	Writer<AST::AST*> parse_expression(int bp = 0);
+	Writer<AST::AST*> parse_expression(int bp = 0, AST::AST* parsed_lhs = nullptr);
 	Writer<AST::AST*> parse_terminal();
-	Writer<AST::AST*> parse_ternary_expression();
+	Writer<AST::AST*> parse_ternary_expression(AST::AST* parsed_condition = nullptr);
 	Writer<AST::AST*> parse_function();
 	Writer<AST::AST*> parse_array_literal();
 	Writer<AST::AST*> parse_dictionary_literal();
@@ -51,7 +51,7 @@ struct Parser {
 	Writer<AST::AST*> parse_block();
 	Writer<AST::AST*> parse_statement();
 	Writer<AST::AST*> parse_return_statement();
-	Writer<AST::AST*> parse_if_else_statement();
+	Writer<AST::AST*> parse_if_else_statement(AST::AST* parsed_condition = nullptr);
 	Writer<AST::AST*> parse_for_statement();
 	Writer<AST::AST*> parse_while_statement();
 	Writer<AST::AST*> parse_match_expression();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -51,7 +51,7 @@ struct Parser {
 	Writer<AST::AST*> parse_block();
 	Writer<AST::AST*> parse_statement();
 	Writer<AST::AST*> parse_return_statement();
-	Writer<AST::AST*> parse_if_else_statement(AST::AST* parsed_condition = nullptr);
+	Writer<AST::AST*> parse_if_else_stmt_or_expr();
 	Writer<AST::AST*> parse_for_statement();
 	Writer<AST::AST*> parse_while_statement();
 	Writer<AST::AST*> parse_match_expression();

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -59,7 +59,8 @@ void interpreter_tests(Test::Tester& tests) {
 	        EQUALS("e", -1),
 	        EQUALS("f", -1.1),
 	        EQUALS("g", 1),
-	        EQUALS("h", 1.1)
+	        EQUALS("h", 1.1),
+	        EQUALS("ternary_disambiguations", 1)
 	    }));
 
 	tests.add_test(std::make_unique<TestCase>("tests/function.jp",

--- a/tests/basic_op.jp
+++ b/tests/basic_op.jp
@@ -57,6 +57,9 @@ ternary_disambiguations := seq {
 	(if (1 + 1 == 2) then "YES" else "NO");
 	 if (1 + 1 == 2) then "YES" else "NO";
 	
+	x := fn(a) => true;
+	if ((x)(1)) then 1 else 0;
+	
 	if (true)
 		if (true)
 		then 1

--- a/tests/basic_op.jp
+++ b/tests/basic_op.jp
@@ -24,7 +24,7 @@ if_else_if := fn() {
 ternary := fn() {
 	i := 0;
 	return (if i == 1 then     0 else 1) +
-	       (if i == 0 then i + 1 else 0);
+	        if i == 0 then i + 1 else 0;
 };
 
 array_access := fn() {
@@ -50,6 +50,7 @@ expressions_as_statements := seq {
 	true;
 	1.1;
 	(if 1 + 1 == 2 then "YES" else "NO");
+	 if 1 + 1 == 2 then "YES" else "NO";
 	(0);
 	return 0;
 };

--- a/tests/basic_op.jp
+++ b/tests/basic_op.jp
@@ -43,4 +43,15 @@ f := -1.1;
 g := +1;
 h := +1.1;
 
+expressions_as_statements := seq {
+	1 + 1;
+	"hello";
+	fn() => seq { return 0; };
+	true;
+	1.1;
+	(if 1 + 1 == 2 then "YES" else "NO");
+	(0);
+	return 0;
+};
+
 __invoke := fn() => 0;

--- a/tests/basic_op.jp
+++ b/tests/basic_op.jp
@@ -49,10 +49,23 @@ expressions_as_statements := seq {
 	fn() => seq { return 0; };
 	true;
 	1.1;
-	(if 1 + 1 == 2 then "YES" else "NO");
-	 if 1 + 1 == 2 then "YES" else "NO";
 	(0);
 	return 0;
+};
+
+ternary_disambiguations := seq {
+	(if 1 + 1 == 2 then "YES" else "NO");
+	 if 1 + 1 == 2 then "YES" else "NO";
+	
+	if (true)
+		if (true)
+		then 1
+		else 0;
+	
+	result := 0;
+	return if (if (false) then false else true)
+	       then 1
+	       else 0;
 };
 
 __invoke := fn() => 0;

--- a/tests/basic_op.jp
+++ b/tests/basic_op.jp
@@ -23,8 +23,8 @@ if_else_if := fn() {
 
 ternary := fn() {
 	i := 0;
-	return (if i == 1 then     0 else 1) +
-	        if i == 0 then i + 1 else 0;
+	return (if (i == 1) then     0 else 1) +
+	        if (i == 0) then i + 1 else 0;
 };
 
 array_access := fn() {
@@ -54,13 +54,19 @@ expressions_as_statements := seq {
 };
 
 ternary_disambiguations := seq {
-	(if 1 + 1 == 2 then "YES" else "NO");
-	 if 1 + 1 == 2 then "YES" else "NO";
+	(if (1 + 1 == 2) then "YES" else "NO");
+	 if (1 + 1 == 2) then "YES" else "NO";
 	
 	if (true)
 		if (true)
 		then 1
 		else 0;
+
+	bar := false;
+	if (bar) { print("10"); }
+
+	if (1 == 1)
+		1 + 1;
 	
 	result := 0;
 	return if (if (false) then false else true)

--- a/tests/recursion.jp
+++ b/tests/recursion.jp
@@ -14,9 +14,9 @@ odd := fn(x) {
 };
 
 inner := fn() {
-	fib:= fn(n) => (if n < 2
+	fib:= fn(n) => if (n < 2)
 		then n
-		else fib(n-1) + fib(n-2));
+		else fib(n-1) + fib(n-2);
 	return fib(3);
 };
 


### PR DESCRIPTION
Solves #238. Tangentially adds all expressions as statements in the most straight forward way.