### PR TITLE
Bugfix global seq exprs

### DIFF
--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -32,6 +32,7 @@ namespace TypeChecker {
     TypedAST::Declaration* ast, Frontend::CompileTimeEnvironment& env) {
 
 	ast->m_surrounding_function = env.current_function();
+	ast->m_surrounding_seq_expr = env.current_seq_expr();
 	env.declare(ast);
 
 	if (ast->m_type_hint)
@@ -168,6 +169,7 @@ namespace TypeChecker {
 
 [[nodiscard]] ErrorReport match_identifiers(
     TypedAST::ReturnStatement* ast, Frontend::CompileTimeEnvironment& env) {
+	ast->m_surrounding_seq_expr = env.current_seq_expr();
 	return match_identifiers(ast->m_value, env);
 }
 
@@ -225,7 +227,10 @@ namespace TypeChecker {
 
 [[nodiscard]] ErrorReport match_identifiers(
     TypedAST::SequenceExpression* ast, Frontend::CompileTimeEnvironment& env) {
-	return match_identifiers(ast->m_body, env);
+	env.enter_seq_expr(ast);
+	CHECK_AND_RETURN(match_identifiers(ast->m_body, env));
+	env.exit_seq_expr();
+	return {};
 }
 
 [[nodiscard]] ErrorReport match_identifiers(

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -64,7 +64,7 @@ namespace TypeChecker {
 
 	env.current_top_level_declaration()->m_references.insert(declaration);
 
-	if (!declaration->m_surrounding_function) {
+	if (declaration->is_global()) {
 		ast->m_origin = TypedAST::Identifier::Origin::Global;
 	} else if (declaration->m_surrounding_function != ast->m_surrounding_function) {
 		ast->m_origin = TypedAST::Identifier::Origin::Capture;
@@ -73,7 +73,7 @@ namespace TypeChecker {
 	}
 
 	// dont capture globals
-	if (declaration->m_surrounding_function) {
+	if (!declaration->is_global()) {
 		for (int i = env.m_function_stack.size(); i--;) {
 			auto* func = env.m_function_stack[i];
 			if (func == declaration->m_surrounding_function)

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -128,15 +128,15 @@ void interpreter_tests(Test::Tester& tests) {
 	        EQUALS("__invoke()", 42)
 	    }));
 
-	tests.add_test(std::make_unique<Test::InterpreterTestSet>("tests/seq_expressions.jp",
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	    "tests/seq_expressions.jp",
 	    Testers {
 	        EQUALS("return_const", 31415),
 	        EQUALS("return_call", 42),
-			EQUALS("issue232_1()", 6),
-			EQUALS("issue232_2()", 7),
+	        EQUALS("issue232_1()", 6),
+	        EQUALS("issue232_2()", 7),
 	        EQUALS("issue240_1", 10),
-	        EQUALS("issue240_2", 8)
-	    }));
+	        EQUALS("issue240_2", 8)}));
 }
 
 void tarjan_algorithm_tests(Test::Tester& tester) {

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -68,9 +68,6 @@ void interpreter_tests(Test::Tester& tests) {
 	        EQUALS("curry()", 42),
 		EQUALS("I(42)", 42),
 	        EQUALS("capture_order()", "ABCD"),
-	        EQUALS("sequence", 42),
-			EQUALS("issue232_1()", 6),
-			EQUALS("issue232_2()", 7)
 	    }));
 
 	tests.add_test(std::make_unique<TestCase>("tests/recursion.jp",
@@ -129,6 +126,16 @@ void interpreter_tests(Test::Tester& tests) {
 	tests.add_test(std::make_unique<Test::InterpreterTestSet>("tests/simple_language.jp",
 	    Testers {
 	        EQUALS("__invoke()", 42)
+	    }));
+
+	tests.add_test(std::make_unique<Test::InterpreterTestSet>("tests/seq_expressions.jp",
+	    Testers {
+	        EQUALS("return_const", 31415),
+	        EQUALS("return_call", 42),
+			EQUALS("issue232_1()", 6),
+			EQUALS("issue232_2()", 7),
+	        EQUALS("issue240_1", 10),
+	        EQUALS("issue240_2", 8)
 	    }));
 }
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -100,7 +100,6 @@ void typecheck(TypedAST::CallExpression* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
-	tc.m_env.enter_function(ast);
 	tc.m_env.new_nested_scope(); // NOTE: this is nested because of lexical scoping
 
 	{
@@ -128,7 +127,6 @@ void typecheck(TypedAST::FunctionLiteral* ast, TypeChecker& tc) {
 	tc.m_core.m_mono_core.unify(ast->m_return_type, ast->m_body->m_value_type);
 
 	tc.m_env.end_scope();
-	tc.m_env.exit_function();
 }
 
 void typecheck(TypedAST::ForStatement* ast, TypeChecker& tc) {
@@ -283,10 +281,8 @@ void typecheck(TypedAST::ConstructorExpression* ast, TypeChecker& tc) {
 }
 
 void typecheck(TypedAST::SequenceExpression* ast, TypeChecker& tc) {
-	tc.m_env.enter_seq_expr(ast);
 	ast->m_value_type = tc.new_var();
 	typecheck(ast->m_body, tc);
-	tc.m_env.exit_seq_expr();
 }
 
 void print_information(TypedAST::Declaration* ast, TypeChecker& tc) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -157,7 +157,7 @@ void typecheck(TypedAST::ReturnStatement* ast, TypeChecker& tc) {
 	typecheck(ast->m_value, tc);
 
 	auto mono = ast->m_value->m_value_type;
-	auto seq_expr = tc.m_env.current_seq_expr();
+	auto seq_expr = ast->m_surrounding_seq_expr;
 	tc.m_core.m_mono_core.unify(seq_expr->m_value_type, mono);
 }
 

--- a/src/typed_ast.hpp
+++ b/src/typed_ast.hpp
@@ -40,6 +40,7 @@ struct Allocator;
 TypedAST* convert_ast(AST::AST*, Allocator& alloc);
 
 struct FunctionLiteral;
+struct SequenceExpression;
 
 struct Declaration : public TypedAST {
 	InternedString m_identifier;
@@ -55,8 +56,12 @@ struct Declaration : public TypedAST {
 
 	int m_frame_offset {INT_MIN};
 
-	// nullptr means global
 	FunctionLiteral* m_surrounding_function {nullptr};
+	SequenceExpression* m_surrounding_seq_expr {nullptr};
+
+	bool is_global() const {
+		return !m_surrounding_function && !m_surrounding_seq_expr;
+	}
 
 	InternedString const& identifier_text() const;
 
@@ -258,6 +263,7 @@ struct Block : public TypedAST {
 
 struct ReturnStatement : public TypedAST {
 	TypedAST* m_value;
+	SequenceExpression* m_surrounding_seq_expr;
 
 	ReturnStatement()
 	    : TypedAST {TypedASTTag::ReturnStatement} {}

--- a/tests/function.jp
+++ b/tests/function.jp
@@ -22,27 +22,5 @@ cat := fn(a,c,d) => fn(b) => a + b + c + d;
 
 capture_order := fn() => cat("A","C","D")("B");
 
-sequence := seq {
-	return 21 * 2;
-};
-
 __invoke := fn() => 0;
 
-
-issue232_1 := fn() {
-	y := 5 + seq {
-		a := 2;
-		b := 1;
-		return b;
-	};
-	return y;
-};
-
-issue232_2 := fn() {
-	y := 5 + seq {
-		a := 2;
-		b := 1;
-		return a;
-	};
-	return y;
-};

--- a/tests/seq_expressions.jp
+++ b/tests/seq_expressions.jp
@@ -1,0 +1,41 @@
+
+return_const := seq {
+	return 31415;
+};
+
+return_call := seq {
+	return 21 * 2;
+};
+
+issue232_1 := fn() {
+	y := 5 + seq {
+		a := 2;
+		b := 1;
+		return b;
+	};
+	return y;
+};
+
+issue232_2 := fn() {
+	y := 5 + seq {
+		a := 2;
+		b := 1;
+		return a;
+	};
+	return y;
+};
+
+issue240_1 := seq {
+    b := seq { return 10; };
+    return b;
+};
+
+issue240_2 := seq {
+    var := 0;
+    b := seq {
+        var = 7;
+        return 1;
+    };
+    return b + var;
+};
+


### PR DESCRIPTION
closes #240

We were deciding that some variables were global, when in reality they were local to a seq-expr