### PR TITLE
First steps towards allowing dynamic typing

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -330,8 +330,8 @@ AST* convert_ast(CST::UnionExpression* cst, Allocator& alloc) {
 	auto ast = alloc.make<UnionExpression>();
 
 	for (auto& constructor : cst->m_constructors) {
-		auto field = static_cast<Identifier*>(convert_ast(&constructor, alloc));
-		ast->m_constructors.push_back(std::move(*field));
+		auto field_name = static_cast<CST::Identifier&>(constructor).text();
+		ast->m_constructors.push_back(field_name);
 	}
 
 	for (auto type : cst->m_types) {
@@ -345,8 +345,8 @@ AST* convert_ast(CST::StructExpression* cst, Allocator& alloc) {
 	auto ast = alloc.make<StructExpression>();
 
 	for (auto& cst_field : cst->m_fields) {
-		auto field = static_cast<Identifier*>(convert_ast(&cst_field, alloc));
-		ast->m_fields.push_back(std::move(*field));
+		auto field_name = static_cast<CST::Identifier&>(cst_field).text();
+		ast->m_fields.push_back(field_name);
 	}
 
 	for (auto type : cst->m_types) {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -278,7 +278,7 @@ struct WhileStatement : public AST {
 };
 
 struct UnionExpression : public AST {
-	std::vector<Identifier> m_constructors;
+	std::vector<InternedString> m_constructors;
 	std::vector<AST*> m_types;
 
 	UnionExpression()
@@ -286,7 +286,7 @@ struct UnionExpression : public AST {
 };
 
 struct StructExpression : public AST {
-	std::vector<Identifier> m_fields;
+	std::vector<InternedString> m_fields;
 	std::vector<AST*> m_types;
 
 	StructExpression()

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -153,6 +153,11 @@ void compute_offsets(AST::StructExpression* ast, int frame_offset) {
 		compute_offsets(type, frame_offset);
 }
 
+void compute_offsets(AST::UnionExpression* ast, int frame_offset) {
+	for (auto& type : ast->m_types)
+		compute_offsets(type, frame_offset);
+}
+
 void compute_offsets(AST::TypeTerm* ast, int frame_offset) {
 	compute_offsets(ast->m_callee, frame_offset);
 	for (auto& arg : ast->m_args)
@@ -196,6 +201,7 @@ void compute_offsets(AST::AST* ast, int frame_offset) {
 		DISPATCH(DeclarationList);
 
 		DISPATCH(StructExpression);
+		DISPATCH(UnionExpression);
 		DISPATCH(TypeTerm);
 
 		DO_NOTHING(TypeFunctionHandle);

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -123,8 +123,8 @@ struct FunctionLiteral : public CST {
 struct Identifier : public CST {
 	Token const* m_token;
 
-	std::string const& text() {
-		return m_token->m_text.str();
+	InternedString const& text() {
+		return m_token->m_text;
 	}
 
 	Identifier()

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -207,7 +207,7 @@ TypeFunctionId type_func_from_ast(AST::AST* ast, TypeChecker& tc) {
 		int constructor_count = as_ue->m_constructors.size();
 		for (int i = 0; i < constructor_count; ++i){
 			MonoId mono = mono_type_from_ast(as_ue->m_types[i], tc);
-			InternedString name = as_ue->m_constructors[i].text();
+			InternedString name = as_ue->m_constructors[i];
 			assert(!structure.count(name));
 			structure[name] = mono;
 		}
@@ -224,7 +224,7 @@ TypeFunctionId type_func_from_ast(AST::AST* ast, TypeChecker& tc) {
 		int field_count = as_se->m_fields.size();
 		for (int i = 0; i < field_count; ++i){
 			MonoId mono = mono_type_from_ast(as_se->m_types[i], tc);
-			InternedString name = as_se->m_fields[i].text();
+			InternedString name = as_se->m_fields[i];
 			assert(!structure.count(name));
 			structure[name] = mono;
 			fields.push_back(name);

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -43,14 +43,17 @@ void eval(AST::Declaration* ast, Interpreter& e) {
 };
 
 void eval(AST::DeclarationList* ast, Interpreter& e) {
-	for (auto& decl : ast->m_declarations) {
-		auto ref = e.new_reference(e.null());
-		e.global_declare_direct(decl.identifier_text(), ref.get());
-		eval(decl.m_value, e);
-		auto value = e.m_stack.pop();
-		ref->m_value = value.get();
+	auto const& comps = *e.m_declaration_order;
+	for (auto const& comp : comps) {
+		for (auto decl : comp) {
+			auto ref = e.new_reference(e.null());
+			e.global_declare_direct(decl->identifier_text(), ref.get());
+			eval(decl->m_value, e);
+			auto value = e.m_stack.pop();
+			ref->m_value = value_of(value.get());
+		}
 	}
-};
+}
 
 void eval(AST::NumberLiteral* ast, Interpreter& e) {
 	e.push_float(ast->value());

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -53,9 +53,13 @@ ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) 
 	}
 	tc.m_env.compute_declaration_order(static_cast<AST::DeclarationList*>(ast));
 
-	TypeChecker::metacheck(ast, tc);
-	ast = TypeChecker::ct_eval(ast, tc, ast_allocator);
-	TypeChecker::typecheck(ast, tc);
+	// TODO: expose this flag
+	constexpr bool run_typechecking = true;
+	if (run_typechecking) {
+		TypeChecker::metacheck(ast, tc);
+		ast = TypeChecker::ct_eval(ast, tc, ast_allocator);
+		TypeChecker::typecheck(ast, tc);
+	}
 	TypeChecker::compute_offsets(ast, 0);
 
 	GC gc;

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -59,7 +59,7 @@ ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) 
 	TypeChecker::compute_offsets(ast, 0);
 
 	GC gc;
-	Interpreter env = {&tc, &gc};
+	Interpreter env = {&tc, &gc, &tc.m_env.declaration_components};
 	declare_native_functions(env);
 	eval(ast, env);
 

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -6,6 +6,10 @@
 
 #include <map>
 
+namespace AST {
+struct Declaration;
+}
+
 namespace TypeChecker {
 struct TypeChecker;
 }
@@ -26,13 +30,18 @@ struct Interpreter {
 	Stack m_stack;
 	TypeChecker::TypeChecker* m_tc;
 	GC* m_gc;
+	std::vector<std::vector<AST::Declaration*>> const* m_declaration_order;
 	int m_gc_size_on_last_pass {64};
 	Value* m_return_value {nullptr};
 	Scope m_global_scope;
 
-	Interpreter(TypeChecker::TypeChecker* tc, GC* gc)
+	Interpreter(
+	    TypeChecker::TypeChecker* tc,
+	    GC* gc,
+	    std::vector<std::vector<AST::Declaration*>> const* declaration_order)
 	    : m_tc {tc}
-	    , m_gc {gc} {}
+	    , m_gc {gc}
+	    , m_declaration_order {declaration_order} {}
 
 	void save_return_value(Value*);
 	Value* fetch_return_value();

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -294,6 +294,11 @@ void print(RecordConstructor* l, int d) {
 	std::cout << "RecordConstructor\n";
 }
 
+void print(VariantConstructor* l, int d) {
+	print_spaces(d);
+	std::cout << "VariantConstructor\n";
+}
+
 void print(Value* v, int d) {
 
 	switch (v->type()) {

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -13,7 +13,7 @@ enum class TypeFunctionTag { Builtin, Variant, Tuple, Record };
 // to tell how many arguments it takes. Else, for variant, tuple and record,
 // we store their structure as a hash from names to monotypes.
 //
-// Dummy type functions are for unifying purposes only, but do not count
+// Dummy type functions are for unification purposes only, but do not count
 // as 'deduced', because they were not created by the user/
 //
 // TODO: change for polymorphic approach


### PR DESCRIPTION
We now use a bit less TC information at runtime. I believe this can be brought down to 0, easily enough. As of now, all our tests run to completion without the need to run the typechecker.

I also did a few more changes to make this and some future changes easier.

- Store strings instead of identifiers in AST::UnionExpression and AST::StructExpression
- Run eval in dependency order
- Evaluate the runtime representation of record and variant types from the non `ct_eval`'d AST nodes

Not yet done, but should be relatively easy to do:

- Remove the fields vector from `TypeFunctionData`, replace with a pointer to `AST`?
- Rethink/rework the `AST::Constructor` abstraction. Though originally envisioned to represent a variant constructor, it is also used for records.