### PR TITLE
desugar for statements into while statements

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -259,16 +259,6 @@ struct IfElseStatement : public AST {
 	    : AST {ASTTag::IfElseStatement} {}
 };
 
-struct ForStatement : public AST {
-	Declaration m_declaration;
-	AST* m_condition;
-	AST* m_action;
-	AST* m_body;
-
-	ForStatement()
-	    : AST {ASTTag::ForStatement} {}
-};
-
 struct WhileStatement : public AST {
 	AST* m_condition;
 	AST* m_body;

--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -21,7 +21,6 @@
 	X(Block)                                                                   \
 	X(ReturnStatement)                                                         \
 	X(IfElseStatement)                                                         \
-	X(ForStatement)                                                            \
 	X(WhileStatement)                                                          \
                                                                                \
 	X(DeclarationList)                                                         \

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -81,15 +81,6 @@ void compute_offsets(AST::ArrayLiteral* ast, int frame_offset) {
 		compute_offsets(element, frame_offset);
 }
 
-void compute_offsets(AST::ForStatement* ast, int frame_offset) {
-	auto& decl = ast->m_declaration;
-	decl.m_frame_offset = frame_offset++;
-	compute_offsets(&ast->m_declaration, frame_offset);
-	compute_offsets(ast->m_condition, frame_offset+1);
-	compute_offsets(ast->m_action, frame_offset+1);
-	compute_offsets(ast->m_body, frame_offset+1);
-}
-
 void compute_offsets(AST::WhileStatement* ast, int frame_offset) {
 	compute_offsets(ast->m_condition, frame_offset);
 	compute_offsets(ast->m_body, frame_offset);
@@ -187,7 +178,6 @@ void compute_offsets(AST::AST* ast, int frame_offset) {
 		DISPATCH(SequenceExpression);
 
 		DISPATCH(Block);
-		DISPATCH(ForStatement);
 		DISPATCH(WhileStatement);
 		DISPATCH(IfElseStatement);
 		DISPATCH(ReturnStatement);

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -165,15 +165,6 @@ AST::IfElseStatement* ct_eval(
 	return ast;
 }
 
-AST::ForStatement* ct_eval(
-    AST::ForStatement* ast, TypeChecker& tc, AST::Allocator& alloc) {
-	ct_eval(&ast->m_declaration, tc, alloc);
-	ast->m_condition = ct_eval(ast->m_condition, tc, alloc);
-	ast->m_action = ct_eval(ast->m_action, tc, alloc);
-	ast->m_body = ct_eval(ast->m_body, tc, alloc);
-	return ast;
-}
-
 AST::WhileStatement* ct_eval(
     AST::WhileStatement* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	ast->m_condition = ct_eval(ast->m_condition, tc, alloc);
@@ -400,7 +391,6 @@ AST::AST* ct_eval(
 
 		DISPATCH(Block);
 		DISPATCH(IfElseStatement);
-		DISPATCH(ForStatement);
 		DISPATCH(WhileStatement);
 		DISPATCH(ReturnStatement);
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -307,31 +307,6 @@ void eval(AST::IfElseStatement* ast, Interpreter& e) {
 		eval_stmt(ast->m_else_body, e);
 };
 
-void eval(AST::ForStatement* ast, Interpreter& e) {
-	e.m_stack.start_stack_region();
-
-	eval(&ast->m_declaration, e);
-
-	while (1) {
-		eval(ast->m_condition, e);
-		auto condition_handle = e.m_stack.pop();
-		auto* condition = value_as<Boolean>(condition_handle.get());
-
-		if (!condition->m_value)
-			break;
-
-		eval_stmt(ast->m_body, e);
-
-		if (e.m_return_value)
-			break;
-
-		eval(ast->m_action, e);
-		e.m_stack.pop_unsafe();
-	}
-
-	e.m_stack.end_stack_region();
-};
-
 void eval(AST::WhileStatement* ast, Interpreter& e) {
 	while (1) {
 		eval(ast->m_condition, e);
@@ -411,7 +386,6 @@ void eval(AST::AST* ast, Interpreter& e) {
 		DISPATCH(Block);
 		DISPATCH(ReturnStatement);
 		DISPATCH(IfElseStatement);
-		DISPATCH(ForStatement);
 		DISPATCH(WhileStatement);
 
 		DISPATCH(TypeFunctionHandle);

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -146,19 +146,6 @@ namespace TypeChecker {
 }
 
 [[nodiscard]] ErrorReport match_identifiers(
-    AST::ForStatement* ast, Frontend::CompileTimeEnvironment& env) {
-	env.new_nested_scope();
-
-	CHECK_AND_RETURN(match_identifiers(&ast->m_declaration, env));
-	CHECK_AND_RETURN(match_identifiers(ast->m_condition, env));
-	CHECK_AND_RETURN(match_identifiers(ast->m_action, env));
-	CHECK_AND_RETURN(match_identifiers(ast->m_body, env));
-
-	env.end_scope();
-	return {};
-}
-
-[[nodiscard]] ErrorReport match_identifiers(
     AST::WhileStatement* ast, Frontend::CompileTimeEnvironment& env) {
 	env.new_nested_scope();
 
@@ -315,7 +302,6 @@ namespace TypeChecker {
 		DISPATCH(SequenceExpression);
 
 		DISPATCH(Block);
-		DISPATCH(ForStatement);
 		DISPATCH(WhileStatement);
 		DISPATCH(IfElseStatement);
 		DISPATCH(ReturnStatement);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -184,16 +184,6 @@ void metacheck(AST::IfElseStatement* ast, TypeChecker& tc) {
 		metacheck(ast->m_else_body, tc);
 }
 
-void metacheck(AST::ForStatement* ast, TypeChecker& tc) {
-	metacheck(&ast->m_declaration, tc);
-	metacheck(ast->m_condition, tc);
-	tc.m_core.m_meta_core.unify(
-	    ast->m_condition->m_meta_type, tc.meta_value());
-
-	metacheck(ast->m_action, tc);
-	metacheck(ast->m_body, tc);
-}
-
 void metacheck(AST::WhileStatement* ast, TypeChecker& tc) {
 	metacheck(ast->m_condition, tc);
 	tc.m_core.m_meta_core.unify(
@@ -324,7 +314,6 @@ void metacheck(AST::AST* ast, TypeChecker& tc) {
 
 		DISPATCH(Block);
 		DISPATCH(IfElseStatement);
-		DISPATCH(ForStatement);
 		DISPATCH(WhileStatement);
 		DISPATCH(ReturnStatement);
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -129,18 +129,6 @@ void typecheck(AST::FunctionLiteral* ast, TypeChecker& tc) {
 	tc.m_env.end_scope();
 }
 
-void typecheck(AST::ForStatement* ast, TypeChecker& tc) {
-	tc.m_env.new_nested_scope();
-	typecheck(&ast->m_declaration, tc);
-	typecheck(ast->m_condition, tc);
-	tc.m_core.m_mono_core.unify(
-	    ast->m_condition->m_value_type, tc.mono_boolean());
-
-	typecheck(ast->m_action, tc);
-	typecheck(ast->m_body, tc);
-	tc.m_env.end_scope();
-}
-
 void typecheck(AST::WhileStatement* ast, TypeChecker& tc) {
 	tc.m_env.new_nested_scope();
 	typecheck(ast->m_condition, tc);
@@ -404,7 +392,6 @@ void typecheck(AST::AST* ast, TypeChecker& tc) {
 		DISPATCH(DeclarationList);
 
 		DISPATCH(Block);
-		DISPATCH(ForStatement);
 		DISPATCH(WhileStatement);
 		DISPATCH(IfElseStatement);
 		DISPATCH(ReturnStatement);


### PR DESCRIPTION
We now have a bit more desugaring code, but we have one fewer node type to handle on every later stage.

For loops might be a tiny little bit slower now, due to more indirections, but that will go away once we compile to bytecode.