### PR TITLE
remove unneeded references in records and variants

### DIFF
--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -265,7 +265,7 @@ void eval(AST::ConstructorExpression* ast, Interpreter& e) {
 
 		for (int i = 0; i < ast->m_args.size(); ++i) {
 			record[record_constructor->m_keys[i]] =
-			    e.m_stack.m_stack[storage_point + i];
+			    value_of(e.m_stack.m_stack[storage_point + i]);
 		}
 		
 		auto result = e.m_gc->new_record(std::move(record));
@@ -281,7 +281,7 @@ void eval(AST::ConstructorExpression* ast, Interpreter& e) {
 
 		eval(ast->m_args[0], e);
 		auto result = e.m_gc->new_variant(
-		    variant_constructor->m_constructor, e.m_stack.access(0));
+		    variant_constructor->m_constructor, value_of(e.m_stack.access(0)));
 
 		// replace value with variant wrapper
 		e.m_stack.access(0) = result.get();


### PR DESCRIPTION
I was just writing some code, and found we missed some reference unwrappings in eval. It's probably not too hard to write some code that does something unexpected using this, but I don't think that's too interesting, or needed.