### PR TITLE
Symbol table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ COMMON_TARGETS := \
 	match_identifiers \
 	metacheck \
 	parser \
+	symbol_table \
 	token \
 	typecheck \
 	typechecker \

--- a/src/compile_time_environment.hpp
+++ b/src/compile_time_environment.hpp
@@ -18,13 +18,12 @@ struct SequenceExpression;
 
 namespace Frontend {
 
-struct Scope {
-	bool m_nested {false};
-	std::unordered_map<InternedString, AST::Declaration*> m_vars;
-	std::unordered_set<MonoId> m_type_vars;
-};
-
 struct CompileTimeEnvironment {
+	struct Scope {
+		bool m_nested {false};
+		std::unordered_set<MonoId> m_type_vars;
+	};
+
 	Scope m_global_scope;
 	std::vector<Scope> m_scopes;
 	std::vector<AST::FunctionLiteral*> m_function_stack;
@@ -35,22 +34,6 @@ struct CompileTimeEnvironment {
 	std::vector<std::vector<AST::Declaration*>> declaration_components;
 
 	CompileTimeEnvironment();
-
-	void declare(AST::Declaration*);
-
-	AST::Declaration* access(InternedString const&);
-
-	AST::SequenceExpression* current_seq_expr();
-	void enter_seq_expr(AST::SequenceExpression*);
-	void exit_seq_expr();
-
-	AST::FunctionLiteral* current_function();
-	void enter_function(AST::FunctionLiteral*);
-	void exit_function();
-
-	AST::Declaration* current_top_level_declaration();
-	void enter_top_level_decl(AST::Declaration*);
-	void exit_top_level_decl();
 
 	Scope& current_scope();
 	void new_scope();

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -42,10 +42,12 @@ ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) 
 
 	AST::Allocator ast_allocator;
 	auto ast = AST::convert_ast(cst, ast_allocator);
+
+	// creates and stores a bunch of builtin declarations
 	TypeChecker::TypeChecker tc{ast_allocator};
 
 	{
-		auto err = TypeChecker::match_identifiers(ast, tc.m_env);
+		auto err = Frontend::match_identifiers(ast, tc.m_builtin_declarations);
 		if (!err.ok()) {
 			err.print();
 			return ExitStatusTag::StaticError;

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -2,16 +2,19 @@
 
 #include <iostream>
 #include <unordered_map>
+#include <vector>
 
 #include "./log/log.hpp"
+#include "./utils/chunked_array.hpp"
+#include "./utils/interned_string.hpp"
 #include "ast.hpp"
-#include "compile_time_environment.hpp"
 #include "error_report.hpp"
+#include "symbol_table.hpp"
 #include "token.hpp"
 
 #include <cassert>
 
-namespace TypeChecker {
+namespace Frontend {
 
 #define CHECK_AND_RETURN(expr)                                                 \
 	{                                                                          \
@@ -29,8 +32,9 @@ namespace TypeChecker {
 		}                                                                      \
 	}
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::Declaration* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::AST* ast, SymbolTable& env);
+
+[[nodiscard]] ErrorReport match_identifiers(AST::Declaration* ast, SymbolTable& env) {
 
 	ast->m_surrounding_function = env.current_function();
 	ast->m_surrounding_seq_expr = env.current_seq_expr();
@@ -48,8 +52,7 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::Identifier* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::Identifier* ast, SymbolTable& env) {
 
 	AST::Declaration* declaration = env.access(ast->text());
 
@@ -87,8 +90,7 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::Block* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::Block* ast, SymbolTable& env) {
 	env.new_nested_scope();
 	for (auto& child : ast->m_body)
 		CHECK_AND_RETURN(match_identifiers(child, env));
@@ -96,8 +98,7 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::IfElseStatement* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::IfElseStatement* ast, SymbolTable& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_condition, env));
 	CHECK_AND_RETURN(match_identifiers(ast->m_body, env));
 
@@ -106,16 +107,14 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::CallExpression* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::CallExpression* ast, SymbolTable& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_callee, env));
 	for (auto& arg : ast->m_args)
 		CHECK_AND_RETURN(match_identifiers(arg, env));
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::FunctionLiteral* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::FunctionLiteral* ast, SymbolTable& env) {
 
 	ast->m_surrounding_function = env.current_function();
 
@@ -137,16 +136,14 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::ArrayLiteral* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::ArrayLiteral* ast, SymbolTable& env) {
 	for (auto& element : ast->m_elements)
 		CHECK_AND_RETURN(match_identifiers(element, env));
 
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::WhileStatement* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::WhileStatement* ast, SymbolTable& env) {
 	env.new_nested_scope();
 
 	CHECK_AND_RETURN(match_identifiers(ast->m_condition, env));
@@ -156,34 +153,29 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::ReturnStatement* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::ReturnStatement* ast, SymbolTable& env) {
 	ast->m_surrounding_seq_expr = env.current_seq_expr();
 	return match_identifiers(ast->m_value, env);
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::IndexExpression* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::IndexExpression* ast, SymbolTable& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_callee, env));
 	CHECK_AND_RETURN(match_identifiers(ast->m_index, env));
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::TernaryExpression* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::TernaryExpression* ast, SymbolTable& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_condition, env));
 	CHECK_AND_RETURN(match_identifiers(ast->m_then_expr, env));
 	CHECK_AND_RETURN(match_identifiers(ast->m_else_expr, env));
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::AccessExpression* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::AccessExpression* ast, SymbolTable& env) {
 	return match_identifiers(ast->m_record, env);
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::MatchExpression* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::MatchExpression* ast, SymbolTable& env) {
 
 	CHECK_AND_RETURN(match_identifiers(&ast->m_matchee, env));
 
@@ -204,8 +196,7 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::ConstructorExpression* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::ConstructorExpression* ast, SymbolTable& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_constructor, env));
 
 	for (auto& arg : ast->m_args)
@@ -214,16 +205,14 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::SequenceExpression* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::SequenceExpression* ast, SymbolTable& env) {
 	env.enter_seq_expr(ast);
 	CHECK_AND_RETURN(match_identifiers(ast->m_body, env));
 	env.exit_seq_expr();
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::DeclarationList* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::DeclarationList* ast, SymbolTable& env) {
 	for (auto& decl : ast->m_declarations) {
 		env.declare(&decl);
 		decl.m_surrounding_function = env.current_function();
@@ -247,8 +236,7 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::UnionExpression* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::UnionExpression* ast, SymbolTable& env) {
 
 	for (auto& type : ast->m_types)
 		CHECK_AND_RETURN(match_identifiers(type, env));
@@ -256,8 +244,7 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::StructExpression* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::StructExpression* ast, SymbolTable& env) {
 
 	for (auto& type : ast->m_types)
 		CHECK_AND_RETURN(match_identifiers(type, env));
@@ -265,16 +252,14 @@ namespace TypeChecker {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::TypeTerm* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::TypeTerm* ast, SymbolTable& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_callee, env));
 	for (auto& arg : ast->m_args)
 		CHECK_AND_RETURN(match_identifiers(arg, env));
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::AST* ast, Frontend::CompileTimeEnvironment& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::AST* ast, SymbolTable& env) {
 #define DISPATCH(type)                                                         \
 	case ASTTag::type:                                                    \
 		return match_identifiers(static_cast<AST::type*>(ast), env);
@@ -319,6 +304,14 @@ namespace TypeChecker {
 	Log::fatal() << "(internal) Unhandled case in match_identifiers '" << ast_string[int(ast->type())] << "'";
 }
 
+ErrorReport match_identifiers(AST::AST* ast, ChunkedArray<AST::Declaration>& builtins) {
+	SymbolTable st;
+	for (auto& bucket : builtins.m_buckets)
+		for (auto& decl : bucket)
+			st.declare(&decl);
+	return match_identifiers(ast, st);
+}
+
 #undef CHECK_AND_RETURN
 
-} // namespace TypeChecker
+} // namespace Frontend

--- a/src/match_identifiers.hpp
+++ b/src/match_identifiers.hpp
@@ -4,18 +4,19 @@
 
 namespace AST {
 struct AST;
+struct Declaration;
 }
+
+template<typename T>
+struct ChunkedArray;
 
 namespace Frontend {
-struct CompileTimeEnvironment;
-}
-
-namespace TypeChecker {
 
 /*
  * Matches every identifier in the given ast with a declaration.
  * This also includes captures in a closure.
  */
 [[nodiscard]] ErrorReport match_identifiers(
-    AST::AST* ast, Frontend::CompileTimeEnvironment&);
-} // namespace TypeChecker
+    AST::AST* ast, ChunkedArray<AST::Declaration>&);
+
+} // namespace Frontend

--- a/src/symbol_table.cpp
+++ b/src/symbol_table.cpp
@@ -17,8 +17,7 @@ SymbolTable::SymbolMap& SymbolTable::latest_shadowed_scope() {
 
 void SymbolTable::declare(AST::Declaration* decl) {
 	auto old_decl = [&]() -> AST::Declaration* {
-		auto insert_result =
-		    m_available_vars.insert({decl->identifier_text(), decl});
+		auto insert_result = m_bindings.insert({decl->identifier_text(), decl});
 		if (insert_result.second) // introduced a previously undeclared name
 			return nullptr;
 		return std::exchange(insert_result.first->second, decl);
@@ -31,8 +30,8 @@ void SymbolTable::declare(AST::Declaration* decl) {
 }
 
 AST::Declaration* SymbolTable::access(InternedString const& name) {
-	auto it = m_available_vars.find(name);
-	if (it == m_available_vars.end())
+	auto it = m_bindings.find(name);
+	if (it == m_bindings.end())
 		return nullptr;
 	return it->second;
 }
@@ -46,9 +45,9 @@ void SymbolTable::end_scope() {
 
 	for (auto& kv : prev_scope) {
 		if (kv.second)
-			m_available_vars[kv.first] = kv.second;
+			m_bindings[kv.first] = kv.second;
 		else
-			m_available_vars.erase(kv.first);
+			m_bindings.erase(kv.first);
 	}
 
 	m_shadowed_scopes.pop_back();

--- a/src/symbol_table.cpp
+++ b/src/symbol_table.cpp
@@ -25,7 +25,7 @@ void SymbolTable::declare(AST::Declaration* decl) {
 
 	auto insert_result =
 	    latest_shadowed_scope().insert({decl->identifier_text(), old_decl});
-	if (!insert_result.second) // clobbers a name in the same scope
+	if (!insert_result.second)
 		Log::fatal() << "Redeclaration of '" << decl->identifier_text() << "'";
 }
 

--- a/src/symbol_table.cpp
+++ b/src/symbol_table.cpp
@@ -1,0 +1,91 @@
+#include "symbol_table.hpp"
+
+#include "ast.hpp"
+#include "./log/log.hpp"
+
+#include <cassert>
+
+namespace Frontend {
+
+SymbolTable::Scope& SymbolTable::current_scope() {
+	return m_scopes.empty() ? m_global_scope : m_scopes.back();
+}
+
+void SymbolTable::declare(AST::Declaration* decl) {
+	auto insert_result = current_scope().m_vars.insert({decl->identifier_text(), decl});
+	if (!insert_result.second)
+		Log::fatal() << "Redeclaration of '" << decl->identifier_text() << "'";
+}
+
+AST::Declaration* SymbolTable::access(InternedString const& name) {
+	auto scan_scope = [](Scope& scope, InternedString const& name) -> AST::Declaration* {
+		auto it = scope.m_vars.find(name);
+		if (it != scope.m_vars.end())
+			return it->second;
+		return nullptr;
+	};
+
+	// scan nested scopes from the inside out
+	for (int i = m_scopes.size(); i--;) {
+		auto ptr = scan_scope(m_scopes[i], name);
+		if (ptr)
+			return ptr;
+		if (!m_scopes[i].m_nested)
+			break;
+	}
+
+	// fall back to global scope lookup
+	return scan_scope(m_global_scope, name);
+}
+
+void SymbolTable::new_scope() {
+	m_scopes.push_back({false});
+}
+
+void SymbolTable::new_nested_scope() {
+	m_scopes.push_back({true});
+}
+
+void SymbolTable::end_scope() {
+	m_scopes.pop_back();
+}
+
+AST::SequenceExpression* SymbolTable::current_seq_expr() {
+	return m_seq_expr_stack.empty() ? nullptr : m_seq_expr_stack.back();
+}
+
+void SymbolTable::enter_seq_expr(AST::SequenceExpression* seq_expr) {
+	m_seq_expr_stack.push_back(seq_expr);
+}
+
+void SymbolTable::exit_seq_expr() {
+	m_seq_expr_stack.pop_back();
+}
+
+AST::FunctionLiteral* SymbolTable::current_function() {
+	return m_function_stack.empty() ? nullptr : m_function_stack.back();
+}
+
+void SymbolTable::enter_function(AST::FunctionLiteral* func) {
+	m_function_stack.push_back(func);
+}
+
+void SymbolTable::exit_function() {
+	m_function_stack.pop_back();
+}
+
+AST::Declaration* SymbolTable::current_top_level_declaration() {
+	return m_current_decl;
+}
+
+void SymbolTable::enter_top_level_decl(AST::Declaration* decl) {
+	assert(!m_current_decl);
+	m_current_decl = decl;
+}
+
+void SymbolTable::exit_top_level_decl() {
+	assert(m_current_decl);
+	m_current_decl = nullptr;
+}
+
+} // namespace Frontend

--- a/src/symbol_table.cpp
+++ b/src/symbol_table.cpp
@@ -23,9 +23,9 @@ void SymbolTable::declare(AST::Declaration* decl) {
 		return std::exchange(insert_result.first->second, decl);
 	}();
 
-	auto scope_insert_result =
+	auto insert_result =
 	    latest_shadowed_scope().insert({decl->identifier_text(), old_decl});
-	if (!scope_insert_result.second) // clobbers a name in the same scope
+	if (!insert_result.second) // clobbers a name in the same scope
 		Log::fatal() << "Redeclaration of '" << decl->identifier_text() << "'";
 }
 

--- a/src/symbol_table.hpp
+++ b/src/symbol_table.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "./utils/interned_string.hpp"
+
+namespace AST {
+struct SequenceExpression;
+struct Declaration;
+struct FunctionLiteral;
+}
+
+namespace Frontend {
+
+struct SymbolTable {
+	struct Scope {
+		bool m_nested {false};
+		std::unordered_map<InternedString, AST::Declaration*> m_vars;
+	};
+
+	Scope m_global_scope;
+	std::vector<Scope> m_scopes;
+	std::vector<AST::FunctionLiteral*> m_function_stack;
+	std::vector<AST::SequenceExpression*> m_seq_expr_stack;
+	AST::Declaration* m_current_decl {nullptr};
+
+	void declare(AST::Declaration*);
+	AST::Declaration* access(InternedString const&);
+
+	AST::SequenceExpression* current_seq_expr();
+	void enter_seq_expr(AST::SequenceExpression*);
+	void exit_seq_expr();
+
+	AST::FunctionLiteral* current_function();
+	void enter_function(AST::FunctionLiteral*);
+	void exit_function();
+
+	AST::Declaration* current_top_level_declaration();
+	void enter_top_level_decl(AST::Declaration*);
+	void exit_top_level_decl();
+
+	Scope& current_scope();
+	void new_scope();
+	void new_nested_scope();
+	void end_scope();
+};
+
+} // namespace Frontend

--- a/src/symbol_table.hpp
+++ b/src/symbol_table.hpp
@@ -36,7 +36,7 @@ struct SymbolTable {
 	void new_nested_scope();
 	void end_scope();
 
-	SymbolMap m_available_vars;
+	SymbolMap m_bindings;
 	std::vector<SymbolMap> m_shadowed_scopes;
 
 	std::vector<AST::FunctionLiteral*> m_function_stack;

--- a/src/symbol_table.hpp
+++ b/src/symbol_table.hpp
@@ -14,16 +14,9 @@ struct FunctionLiteral;
 namespace Frontend {
 
 struct SymbolTable {
-	struct Scope {
-		bool m_nested {false};
-		std::unordered_map<InternedString, AST::Declaration*> m_vars;
-	};
+	using SymbolMap = std::unordered_map<InternedString, AST::Declaration*>;
 
-	Scope m_global_scope;
-	std::vector<Scope> m_scopes;
-	std::vector<AST::FunctionLiteral*> m_function_stack;
-	std::vector<AST::SequenceExpression*> m_seq_expr_stack;
-	AST::Declaration* m_current_decl {nullptr};
+	SymbolTable();
 
 	void declare(AST::Declaration*);
 	AST::Declaration* access(InternedString const&);
@@ -40,10 +33,19 @@ struct SymbolTable {
 	void enter_top_level_decl(AST::Declaration*);
 	void exit_top_level_decl();
 
-	Scope& current_scope();
-	void new_scope();
 	void new_nested_scope();
 	void end_scope();
+
+	SymbolMap m_available_vars;
+	std::vector<SymbolMap> m_shadowed_scopes;
+
+	std::vector<AST::FunctionLiteral*> m_function_stack;
+	std::vector<AST::SequenceExpression*> m_seq_expr_stack;
+	AST::Declaration* m_current_decl {nullptr};
+
+private:
+	SymbolMap& latest_shadowed_scope();
+
 };
 
 } // namespace Frontend

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -103,7 +103,7 @@ void typecheck(AST::FunctionLiteral* ast, TypeChecker& tc) {
 	tc.m_env.new_nested_scope(); // NOTE: this is nested because of lexical scoping
 
 	{
-		// TODO: do return type hint
+		// TODO: consume return-type type-hints
 		ast->m_return_type = tc.new_var();
 
 		std::vector<MonoId> arg_types;

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -130,6 +130,7 @@ void typecheck(AST::FunctionLiteral* ast, TypeChecker& tc) {
 }
 
 void typecheck(AST::WhileStatement* ast, TypeChecker& tc) {
+	// TODO: Why do while statements create a new nested scope?
 	tc.m_env.new_nested_scope();
 	typecheck(ast->m_condition, tc);
 	tc.m_core.m_mono_core.unify(

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -149,7 +149,6 @@ void typecheck(AST::ReturnStatement* ast, TypeChecker& tc) {
 }
 
 void typecheck(AST::IndexExpression* ast, TypeChecker& tc) {
-	// TODO: put the monotype in the ast
 	typecheck(ast->m_callee, tc);
 	typecheck(ast->m_index, tc);
 

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -203,7 +203,6 @@ AST::Declaration* TypeChecker::new_builtin_declaration(InternedString const& nam
 	m_builtin_declarations.push_back({});
 	auto result = &m_builtin_declarations.back();
 	result->m_identifier = name;
-	m_env.declare(result);
 	return result;
 }
 

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -123,7 +123,7 @@ MonoId TypeSystemCore::new_term(
 	tf = m_tf_core.find(tf);
 
 	{
-		// TODO: add a TypeFunctionTag::Unkown tag, to express
+		// TODO: add a TypeFunctionTag::Unknown tag, to express
 		// that it's a dummy of unknown characteristics
 
 		// TODO: add some APIs to make this less jarring


### PR DESCRIPTION
`CompileTimeEnvironment` was handling too many things, so I saw an opportunity for separation: it wasn't that hard to tell that most of its methods were only used on `match_identifiers`.

Once It was separated, I changed the data structure, to make it faster. One of the insights is that only nested scopes were ever used, so it could be optimized around that fact.

name lookups are now a single hash table lookup, and not some messy, branchy, loop over a vector of hash tables.