### PR TITLE
Better parser api

### DIFF
--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -21,8 +21,7 @@ namespace Interpreter {
 
 ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) {
 
-	TokenArray ta;
-	tokenize(source, ta);
+	TokenArray ta = tokenize(source);
 
 	CST::Allocator cst_allocator;
 	auto parse_result = parse_program(ta, cst_allocator);
@@ -83,8 +82,7 @@ ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) 
 // into account the rest of the program that's already been processed, before
 // this is run
 Value* eval_expression(const std::string& expr, Interpreter& env) {
-	TokenArray ta;
-	tokenize(expr, ta);
+	TokenArray ta = tokenize(expr);
 
 	CST::Allocator cst_allocator;
 	auto parse_result = parse_expression(ta, cst_allocator);

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -22,8 +22,10 @@ namespace Interpreter {
 ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) {
 
 	TokenArray ta;
+	tokenize(source, ta);
+
 	CST::Allocator cst_allocator;
-	auto parse_result = parse_program(source, ta, cst_allocator);
+	auto parse_result = parse_program(ta, cst_allocator);
 
 	if (not parse_result.ok()) {
 		parse_result.m_error.print();
@@ -82,12 +84,14 @@ ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) 
 // this is run
 Value* eval_expression(const std::string& expr, Interpreter& env) {
 	TokenArray ta;
-	CST::Allocator cst_allocator;
-	AST::Allocator ast_allocator;
+	tokenize(expr, ta);
 
-	auto parse_result = parse_expression(expr, ta, cst_allocator);
+	CST::Allocator cst_allocator;
+	auto parse_result = parse_expression(ta, cst_allocator);
 	// TODO: handle parse error
 	auto cst = parse_result.m_result;
+
+	AST::Allocator ast_allocator;
 	auto ast = AST::convert_ast(cst, ast_allocator);
 
 	// TODO?: return a gc_ptr

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -22,7 +22,7 @@ namespace Interpreter {
 
 ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) {
 
-	TokenArray ta = tokenize(source);
+	TokenArray const ta = tokenize(source);
 
 	CST::Allocator cst_allocator;
 	auto parse_result = parse_program(ta, cst_allocator);
@@ -83,7 +83,7 @@ ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) 
 // into account the rest of the program that's already been processed, before
 // this is run
 Value* eval_expression(const std::string& expr, Interpreter& env) {
-	TokenArray ta = tokenize(expr);
+	TokenArray const ta = tokenize(expr);
 
 	CST::Allocator cst_allocator;
 	auto parse_result = parse_expression(ta, cst_allocator);

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -5,6 +5,7 @@
 #include "../compute_offsets.hpp"
 #include "../cst_allocator.hpp"
 #include "../ct_eval.hpp"
+#include "../lexer.hpp"
 #include "../match_identifiers.hpp"
 #include "../metacheck.hpp"
 #include "../parser.hpp"

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
 		    // TODO: We need to clean this up
 
 		    {
-			    TokenArray ta = tokenize("__invoke()");
+			    TokenArray const ta = tokenize("__invoke()");
 
 			    CST::Allocator cst_allocator;
 			    auto top_level_call_ast = parse_expression(ta, cst_allocator);

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -44,12 +44,12 @@ int main(int argc, char** argv) {
 		    // TODO: We need to clean this up
 
 		    {
-			    TokenArray ta;
-			    CST::Allocator cst_allocator;
-			    AST::Allocator ast_allocator;
+			    TokenArray ta = tokenize("__invoke()");
 
-				tokenize("__invoke()", ta);
+			    CST::Allocator cst_allocator;
 			    auto top_level_call_ast = parse_expression(ta, cst_allocator);
+
+			    AST::Allocator ast_allocator;
 			    auto top_level_call = AST::convert_ast(top_level_call_ast.m_result, ast_allocator);
 
 				eval(top_level_call, env);

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -5,6 +5,7 @@
 
 #include "../cst_allocator.hpp"
 #include "../parser.hpp"
+#include "../lexer.hpp"
 #include "../token_array.hpp"
 #include "../ast.hpp"
 #include "../ast_allocator.hpp"

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -48,7 +48,8 @@ int main(int argc, char** argv) {
 			    CST::Allocator cst_allocator;
 			    AST::Allocator ast_allocator;
 
-			    auto top_level_call_ast = parse_expression("__invoke()", ta, cst_allocator);
+				tokenize("__invoke()", ta);
+			    auto top_level_call_ast = parse_expression(ta, cst_allocator);
 			    auto top_level_call = AST::convert_ast(top_level_call_ast.m_result, ast_allocator);
 
 				eval(top_level_call, env);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -8,7 +8,7 @@
 
 #include "token_array.hpp"
 
-Token const& eof() {
+static Token const& eof() {
 	static Token t = {TokenTag::END, "(EOF)", -1, -1, -1, -1};
 	return t;
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -6,7 +6,63 @@
 #include <cctype>
 #include <cstdlib>
 
+#include "./algorithms/trie.hpp"
+#include "token.hpp"
 #include "token_array.hpp"
+#include "token_tag.hpp"
+
+struct Lexer {
+	Lexer(std::vector<char>, TokenArray&);
+
+	char char_at(int index);
+	char current_char() {
+		return char_at(m_source_index);
+	}
+	char next_char() {
+		return char_at(m_source_index + 1);
+	}
+	char peek_char(int di = 0) {
+		return char_at(m_source_index + di);
+	}
+
+	bool done() {
+		return m_done;
+	}
+
+	bool consume_symbol();
+	bool consume_string();
+	bool consume_comment();
+	bool consume_identifier_or_keyword();
+	bool consume_number();
+	void consume_token();
+	void push_token(TokenTag, int);
+
+	std::pair<bool, TokenTag> is_keyword(InternedString const&);
+
+	std::vector<char> m_source;
+	TokenArray& m_tokens;
+
+	Trie m_symbols_trie;
+
+	bool m_done {false};
+
+	int m_source_index {0};
+	int m_token_index {0};
+
+	int m_current_line {0};
+	int m_current_column {0};
+};
+
+TokenArray tokenize(std::string const& source) {
+	TokenArray ta;
+	std::vector<char> v;
+	for (char c : source)
+		v.push_back(c);
+	Lexer lexer = {std::move(v), ta};
+	while (not lexer.done())
+		lexer.consume_token();
+	return ta;
+}
 
 static Token const& eof() {
 	static Token t = {TokenTag::END, "(EOF)", -1, -1, -1, -1};

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -309,29 +309,3 @@ bool Lexer::consume_comment() {
 
 	return true;
 }
-
-void Lexer::advance() {
-	m_token_index += 1;
-	while (m_token_index >= int(m_tokens.size())) {
-		if (done())
-			break;
-		consume_token();
-	}
-}
-
-void Lexer::regress() {
-	assert(m_token_index > 0);
-	m_token_index -= 1;
-}
-
-Token const& Lexer::token_at(int index) {
-	while (!done() && index >= int(m_tokens.size())) {
-		consume_token();
-	}
-
-	if (done() && index >= int(m_tokens.size())) {
-		return eof();
-	}
-
-	return m_tokens.at(index);
-}

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -35,20 +35,6 @@ struct Lexer {
 
 	std::pair<bool, TokenTag> is_keyword(InternedString const&);
 
-	void advance();
-	void regress();
-
-	Token const& token_at(int index);
-	Token const& current_token() {
-		return token_at(m_token_index);
-	}
-	Token const& next_token() {
-		return token_at(m_token_index + 1);
-	}
-	Token const& peek_token(int dt = 0) {
-		return token_at(m_token_index + dt);
-	}
-
 	std::vector<char> m_source;
 	TokenArray& m_tokens;
 

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -1,50 +1,6 @@
 #pragma once
 
-#include <vector>
-
-#include "./algorithms/trie.hpp"
-#include "token.hpp"
+#include <string>
 #include "token_array.hpp"
-#include "token_tag.hpp"
 
-struct Lexer {
-	Lexer(std::vector<char>, TokenArray&);
-
-	char char_at(int index);
-	char current_char() {
-		return char_at(m_source_index);
-	}
-	char next_char() {
-		return char_at(m_source_index + 1);
-	}
-	char peek_char(int di = 0) {
-		return char_at(m_source_index + di);
-	}
-
-	bool done() {
-		return m_done;
-	}
-
-	bool consume_symbol();
-	bool consume_string();
-	bool consume_comment();
-	bool consume_identifier_or_keyword();
-	bool consume_number();
-	void consume_token();
-	void push_token(TokenTag, int);
-
-	std::pair<bool, TokenTag> is_keyword(InternedString const&);
-
-	std::vector<char> m_source;
-	TokenArray& m_tokens;
-
-	Trie m_symbols_trie;
-
-	bool m_done {false};
-
-	int m_source_index {0};
-	int m_token_index {0};
-
-	int m_current_line {0};
-	int m_current_column {0};
-};
+TokenArray tokenize(std::string const& source);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1165,11 +1165,15 @@ static void tokenize(std::string const& source, TokenArray& ta) {
 		lexer.consume_token();
 }
 
-static Parser init_parser(std::string const& source, TokenArray& ta, CST::Allocator& allocator) {
-	tokenize(source, ta);
+static Parser make_parser(TokenArray& ta, CST::Allocator& allocator) {
 	Parser p {ta};
 	p.m_ast_allocator = &allocator;
 	return p;
+}
+
+static Parser init_parser(std::string const& source, TokenArray& ta, CST::Allocator& allocator) {
+	tokenize(source, ta);
+	return make_parser(ta, allocator);
 }
 
 Writer<CST::CST*> parse_program(std::string const& source, TokenArray& ta, CST::Allocator& allocator) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1156,13 +1156,17 @@ Writer<CST::CST*> Parser::parse_type_function() {
 #undef CHECK_AND_RETURN
 #undef REQUIRE
 
-static Parser init_parser(std::string const& source, TokenArray& ta, CST::Allocator& allocator) {
+static void tokenize(std::string const& source, TokenArray& ta) {
 	std::vector<char> v;
 	for (char c : source)
 		v.push_back(c);
 	Lexer lexer = {std::move(v), ta};
 	while (not lexer.done())
 		lexer.consume_token();
+}
+
+static Parser init_parser(std::string const& source, TokenArray& ta, CST::Allocator& allocator) {
+	tokenize(source, ta);
 	Parser p {ta};
 	p.m_ast_allocator = &allocator;
 	return p;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -38,8 +38,9 @@ struct Parser {
 	CST::Allocator* m_ast_allocator;
 	int m_token_cursor { 0 };
 
-	Parser(TokenArray& tokens)
-	    : m_tokens {tokens} {}
+	Parser(TokenArray& tokens, CST::Allocator* cst_allocator)
+	    : m_tokens {tokens}
+	    , m_ast_allocator {cst_allocator} {}
 
 	Writer<std::vector<CST::Declaration>> parse_declaration_list(TokenTag);
 	Writer<std::vector<CST::CST*>> parse_expression_list(TokenTag, TokenTag, bool);
@@ -1153,18 +1154,12 @@ Writer<CST::CST*> Parser::parse_type_function() {
 #undef CHECK_AND_RETURN
 #undef REQUIRE
 
-static Parser make_parser(TokenArray& ta, CST::Allocator& allocator) {
-	Parser p {ta};
-	p.m_ast_allocator = &allocator;
-	return p;
-}
-
 Writer<CST::CST*> parse_program(TokenArray& ta, CST::Allocator& allocator) {
-	Parser p = make_parser(ta, allocator);
+	Parser p {ta, &allocator};
 	return p.parse_top_level();
 }
 
 Writer<CST::CST*> parse_expression(TokenArray& ta, CST::Allocator& allocator) {
-	Parser p = make_parser(ta, allocator);
+	Parser p {ta, &allocator};
 	return p.parse_expression();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -4,10 +4,7 @@
 #include "cst.hpp"
 #include "cst_allocator.hpp"
 #include "error_report.hpp"
-#include "lexer.hpp"
 #include "token_array.hpp"
-
-#include <iostream>
 
 #include <sstream>
 #include <utility>
@@ -1155,17 +1152,6 @@ Writer<CST::CST*> Parser::parse_type_function() {
 
 #undef CHECK_AND_RETURN
 #undef REQUIRE
-
-TokenArray tokenize(std::string const& source) {
-	TokenArray ta;
-	std::vector<char> v;
-	for (char c : source)
-		v.push_back(c);
-	Lexer lexer = {std::move(v), ta};
-	while (not lexer.done())
-		lexer.consume_token();
-	return ta;
-}
 
 static Parser make_parser(TokenArray& ta, CST::Allocator& allocator) {
 	Parser p {ta};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -34,11 +34,11 @@ ErrorReport make_expected_error(string_view expected, Token const* found_token) 
 
 struct Parser {
 	/* token handler */
-	TokenArray& m_tokens;
+	TokenArray const& m_tokens;
 	CST::Allocator* m_cst_allocator;
 	int m_token_cursor { 0 };
 
-	Parser(TokenArray& tokens, CST::Allocator* cst_allocator)
+	Parser(TokenArray const& tokens, CST::Allocator* cst_allocator)
 	    : m_tokens {tokens}
 	    , m_cst_allocator {cst_allocator} {}
 
@@ -1154,12 +1154,12 @@ Writer<CST::CST*> Parser::parse_type_function() {
 #undef CHECK_AND_RETURN
 #undef REQUIRE
 
-Writer<CST::CST*> parse_program(TokenArray& ta, CST::Allocator& allocator) {
+Writer<CST::CST*> parse_program(TokenArray const& ta, CST::Allocator& allocator) {
 	Parser p {ta, &allocator};
 	return p.parse_top_level();
 }
 
-Writer<CST::CST*> parse_expression(TokenArray& ta, CST::Allocator& allocator) {
+Writer<CST::CST*> parse_expression(TokenArray const& ta, CST::Allocator& allocator) {
 	Parser p {ta, &allocator};
 	return p.parse_expression();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1156,13 +1156,15 @@ Writer<CST::CST*> Parser::parse_type_function() {
 #undef CHECK_AND_RETURN
 #undef REQUIRE
 
-void tokenize(std::string const& source, TokenArray& ta) {
+TokenArray tokenize(std::string const& source) {
+	TokenArray ta;
 	std::vector<char> v;
 	for (char c : source)
 		v.push_back(c);
 	Lexer lexer = {std::move(v), ta};
 	while (not lexer.done())
 		lexer.consume_token();
+	return ta;
 }
 
 static Parser make_parser(TokenArray& ta, CST::Allocator& allocator) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1156,7 +1156,7 @@ Writer<CST::CST*> Parser::parse_type_function() {
 #undef CHECK_AND_RETURN
 #undef REQUIRE
 
-static void tokenize(std::string const& source, TokenArray& ta) {
+void tokenize(std::string const& source, TokenArray& ta) {
 	std::vector<char> v;
 	for (char c : source)
 		v.push_back(c);
@@ -1171,17 +1171,12 @@ static Parser make_parser(TokenArray& ta, CST::Allocator& allocator) {
 	return p;
 }
 
-static Parser init_parser(std::string const& source, TokenArray& ta, CST::Allocator& allocator) {
-	tokenize(source, ta);
-	return make_parser(ta, allocator);
-}
-
-Writer<CST::CST*> parse_program(std::string const& source, TokenArray& ta, CST::Allocator& allocator) {
-	Parser p = init_parser(source, ta, allocator);
+Writer<CST::CST*> parse_program(TokenArray& ta, CST::Allocator& allocator) {
+	Parser p = make_parser(ta, allocator);
 	return p.parse_top_level();
 }
 
-Writer<CST::CST*> parse_expression(std::string const& source, TokenArray& ta, CST::Allocator& allocator) {
-	Parser p = init_parser(source, ta, allocator);
+Writer<CST::CST*> parse_expression(TokenArray& ta, CST::Allocator& allocator) {
+	Parser p = make_parser(ta, allocator);
 	return p.parse_expression();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -12,11 +12,6 @@
 
 #include <cassert>
 
-static Token const& eof() {
-	static Token t = {TokenTag::END, "(EOF)", -1, -1, -1, -1};
-	return t;
-}
-
 template <typename T>
 Writer<T> make_writer(T x) {
 	return {{}, std::move(x)};
@@ -76,8 +71,6 @@ struct Parser {
 
 	Token const* peek(int dt = 0) {
 		int index = m_token_cursor + dt;
-		if (index >= m_tokens.size())
-			return &eof();
 		return &m_tokens.at(index);
 	}
 

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -20,5 +20,5 @@ struct Writer {
 	}
 };
 
-Writer<CST::CST*> parse_program(TokenArray&, CST::Allocator&);
-Writer<CST::CST*> parse_expression(TokenArray&, CST::Allocator&);
+Writer<CST::CST*> parse_program(TokenArray const&, CST::Allocator&);
+Writer<CST::CST*> parse_expression(TokenArray const&, CST::Allocator&);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -20,5 +20,6 @@ struct Writer {
 	}
 };
 
-Writer<CST::CST*> parse_program(std::string const&, TokenArray&, CST::Allocator&);
-Writer<CST::CST*> parse_expression(std::string const&, TokenArray&, CST::Allocator&);
+void tokenize(std::string const& source, TokenArray&);
+Writer<CST::CST*> parse_program(TokenArray&, CST::Allocator&);
+Writer<CST::CST*> parse_expression(TokenArray&, CST::Allocator&);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -20,6 +20,6 @@ struct Writer {
 	}
 };
 
-void tokenize(std::string const& source, TokenArray&);
+TokenArray tokenize(std::string const& source);
 Writer<CST::CST*> parse_program(TokenArray&, CST::Allocator&);
 Writer<CST::CST*> parse_expression(TokenArray&, CST::Allocator&);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -20,6 +20,5 @@ struct Writer {
 	}
 };
 
-TokenArray tokenize(std::string const& source);
 Writer<CST::CST*> parse_program(TokenArray&, CST::Allocator&);
 Writer<CST::CST*> parse_expression(TokenArray&, CST::Allocator&);

--- a/src/playground/main.cpp
+++ b/src/playground/main.cpp
@@ -3,11 +3,12 @@
 #include <sstream>
 #include <string>
 
-#include "../cst_allocator.hpp"
-#include "../parser.hpp"
-#include "../token_array.hpp"
 #include "../ast.hpp"
 #include "../ast_allocator.hpp"
+#include "../cst_allocator.hpp"
+#include "../lexer.hpp"
+#include "../parser.hpp"
+#include "../token_array.hpp"
 
 int main(int argc, char** argv) {
 

--- a/src/playground/main.cpp
+++ b/src/playground/main.cpp
@@ -32,8 +32,7 @@ int main(int argc, char** argv) {
 	std::string source = file_content.str();
 
 	{
-		TokenArray ta;
-		tokenize(source, ta);
+		TokenArray ta = tokenize(source);
 
 		CST::Allocator cst_allocator;
 		auto parse_result = parse_program(ta, cst_allocator);

--- a/src/playground/main.cpp
+++ b/src/playground/main.cpp
@@ -33,8 +33,10 @@ int main(int argc, char** argv) {
 
 	{
 		TokenArray ta;
+		tokenize(source, ta);
+
 		CST::Allocator cst_allocator;
-		auto parse_result = parse_program(source, ta, cst_allocator);
+		auto parse_result = parse_program(ta, cst_allocator);
 
 		if (not parse_result.ok()) {
 			parse_result.m_error.print();

--- a/src/playground/main.cpp
+++ b/src/playground/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
 	std::string source = file_content.str();
 
 	{
-		TokenArray ta = tokenize(source);
+		TokenArray const ta = tokenize(source);
 
 		CST::Allocator cst_allocator;
 		auto parse_result = parse_program(ta, cst_allocator);

--- a/src/utils/chunked_array.hpp
+++ b/src/utils/chunked_array.hpp
@@ -26,7 +26,11 @@ struct ChunkedArray {
 		return m_buckets[i / bucket_size][i % bucket_size];
 	}
 
-	int size() {
+	T const& at(int i) const {
+		return m_buckets[i / bucket_size][i % bucket_size];
+	}
+
+	int size() const {
 		return m_buckets.empty() ? 0
 		                         : (int(m_buckets.size()) - 1) * bucket_size +
 		                               int(m_buckets.back().size());


### PR DESCRIPTION
So, I went and improved both the parser's and lexer's api, fully baking in the assumption that we first fully tokenize a file, and then parse it.

It is now a lot more value-oriented, and const-friendly, which aligns more with modern C++ values, and reads more nicely. (also, purely coincidentally, it is more SOLID compliant)

old style:
```c++
TokenArray ta;
CST::Allocator ca;
auto cst_handle = parse_program(source, ta, ca);
```

new style
```c++
TokenArray const ta = tokenize(source);
CST::Allocator ca;
auto cst_handle = parse_program(ta, ca);
```

Furthermore, the implementation of `parse_program` et al itself became a lot nicer (though that's mostly because it has a single responsibility now)

Other than that, I also moved the `Lexer` type definition into the module implementation file, which I feel is a lot tidier.

### Notes for reviewer

I recommend to read this PR commit by commit, as each one is a small refactoring (in the proper sense of the word). 