### PR TITLE
Top level functions

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -170,7 +170,7 @@ AST* convert_ast(CST::DeclarationList* cst, Allocator& alloc) {
 	auto ast = alloc.make<DeclarationList>();
 
 	for (auto& declaration : cst->m_declarations) {
-		auto decl = static_cast<Declaration*>(convert_ast(&declaration, alloc));
+		auto decl = static_cast<Declaration*>(convert_ast(declaration, alloc));
 		ast->m_declarations.push_back(std::move(*decl));
 	}
 

--- a/src/cst.cpp
+++ b/src/cst.cpp
@@ -20,7 +20,7 @@ void print_impl(DeclarationList* cst, int d) {
 	std::cout << "(decl-list";
 	for (auto& decl : cst->m_declarations) {
 		std::cout << "\n";
-		print(&decl, d + indent_width);
+		print(decl, d + indent_width);
 	}
 	std::cout << ")";
 }

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -23,6 +23,8 @@ struct CST {
 	virtual ~CST() = default;
 };
 
+struct Block;
+
 struct Declaration : public CST {
 	Token const* m_identifier_token;
 	CST* m_type_hint {nullptr};  // can be nullptr
@@ -43,6 +45,15 @@ struct FunctionDeclaration : public CST {
 
 	FunctionDeclaration()
 	    : CST {CSTTag::FunctionDeclaration} {}
+};
+
+struct BlockFunctionDeclaration : public CST {
+	Token const* m_identifier_token;
+	std::vector<Declaration> m_args;
+	Block* m_body;
+
+	BlockFunctionDeclaration()
+	    : CST {CSTTag::BlockFunctionDeclaration} {}
 };
 
 struct DeclarationList : public CST {
@@ -112,8 +123,6 @@ struct ArrayLiteral : public CST {
 	ArrayLiteral()
 	    : CST {CSTTag::ArrayLiteral} {}
 };
-
-struct Block;
 
 struct BlockFunctionLiteral : public CST {
 	Block* m_body;

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -37,7 +37,7 @@ struct Declaration : public CST {
 };
 
 struct DeclarationList : public CST {
-	std::vector<Declaration> m_declarations;
+	std::vector<CST*> m_declarations;
 
 	DeclarationList()
 	    : CST {CSTTag::DeclarationList} {}
@@ -104,8 +104,10 @@ struct ArrayLiteral : public CST {
 	    : CST {CSTTag::ArrayLiteral} {}
 };
 
+struct Block;
+
 struct BlockFunctionLiteral : public CST {
-	CST* m_body;
+	Block* m_body;
 	std::vector<Declaration> m_args;
 
 	BlockFunctionLiteral()
@@ -197,8 +199,6 @@ struct ConstructorExpression : public CST {
 	ConstructorExpression()
 	    : CST {CSTTag::ConstructorExpression} {}
 };
-
-struct Block;
 
 struct SequenceExpression : public CST {
 	Block* m_body;

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -36,6 +36,15 @@ struct Declaration : public CST {
 	    : CST {CSTTag::Declaration} {}
 };
 
+struct FunctionDeclaration : public CST {
+	Token const* m_identifier_token;
+	std::vector<Declaration> m_args;
+	CST* m_body;
+
+	FunctionDeclaration()
+	    : CST {CSTTag::FunctionDeclaration} {}
+};
+
 struct DeclarationList : public CST {
 	std::vector<CST*> m_declarations;
 

--- a/src/cst_tag.hpp
+++ b/src/cst_tag.hpp
@@ -12,6 +12,7 @@
                                                                                \
 	X(DeclarationList)                                                         \
 	X(Declaration)                                                             \
+	X(FunctionDeclaration)                                                     \
 	X(Identifier)                                                              \
 	X(BinaryExpression)                                                        \
 	X(CallExpression)                                                          \

--- a/src/cst_tag.hpp
+++ b/src/cst_tag.hpp
@@ -13,6 +13,8 @@
 	X(DeclarationList)                                                         \
 	X(Declaration)                                                             \
 	X(FunctionDeclaration)                                                     \
+	X(BlockFunctionDeclaration)                                                \
+                                                                               \
 	X(Identifier)                                                              \
 	X(BinaryExpression)                                                        \
 	X(CallExpression)                                                          \

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -51,7 +51,7 @@ struct Parser {
 	Writer<CST::CST*> parse_function();
 	Writer<CST::CST*> parse_array_literal();
 	Writer<std::vector<CST::CST*>> parse_argument_list();
-	Writer<CST::CST*> parse_block();
+	Writer<CST::Block*> parse_block();
 	Writer<CST::CST*> parse_statement();
 	Writer<CST::CST*> parse_return_statement();
 	Writer<CST::CST*> parse_if_else_stmt_or_expr();
@@ -675,8 +675,11 @@ Writer<CST::CST*> Parser::parse_array_literal() {
 
 /*
  * functions look like this:
- * fn (x : int, y, z : string) {
- *   print(x);
+ * fn (x : int, y) => x
+ *
+ * and like this:
+ * fn (y, z : string) {
+ *   print(z);
  * }
  */
 Writer<CST::CST*> Parser::parse_function() {
@@ -750,8 +753,8 @@ Writer<CST::CST*> Parser::parse_function() {
 	}
 }
 
-Writer<CST::CST*> Parser::parse_block() {
-	Writer<CST::CST*> result = {
+Writer<CST::Block*> Parser::parse_block() {
+	Writer<CST::Block*> result = {
 	    {"Parse Error: Failed to parse block statement"}};
 
 	REQUIRE(result, TokenTag::BRACE_OPEN);
@@ -781,7 +784,7 @@ Writer<CST::CST*> Parser::parse_block() {
 	auto e = m_cst_allocator->make<CST::Block>();
 	e->m_body = std::move(statements);
 
-	return make_writer<CST::CST*>(e);
+	return make_writer<CST::Block*>(e);
 }
 
 Writer<CST::CST*> Parser::parse_return_statement() {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -777,10 +777,8 @@ Writer<CST::CST*> Parser::parse_function() {
 
 	REQUIRE(result, TokenTag::KEYWORD_FN);
 
-	auto args_ = parse_function_arguments();
-	CHECK_AND_RETURN(result, args_);
-
-	std::vector<CST::Declaration> args = std::move(args_.m_result);
+	auto args = parse_function_arguments();
+	CHECK_AND_RETURN(result, args);
 
 	if (consume(TokenTag::ARROW)) {
 		auto expression = parse_expression();
@@ -788,7 +786,7 @@ Writer<CST::CST*> Parser::parse_function() {
 
 		auto e = m_cst_allocator->make<CST::FunctionLiteral>();
 		e->m_body = expression.m_result;
-		e->m_args = std::move(args);
+		e->m_args = std::move(args.m_result);
 
 		return make_writer<CST::CST*>(e);
 	} else {
@@ -797,7 +795,7 @@ Writer<CST::CST*> Parser::parse_function() {
 
 		auto e = m_cst_allocator->make<CST::BlockFunctionLiteral>();
 		e->m_body = block.m_result;
-		e->m_args = std::move(args);
+		e->m_args = std::move(args.m_result);
 
 		return make_writer<CST::CST*>(e);
 	}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -132,45 +132,24 @@ Writer<CST::CST*> Parser::parse_top_level() {
 	Writer<CST::CST*> result = {
 	    {"Parse Error: Failed to parse top level program"}};
 
-	auto declarations = parse_declaration_list(TokenTag::END);
-	CHECK_AND_RETURN(result, declarations);
-
-	auto e = m_cst_allocator->make<CST::DeclarationList>();
-	e->m_declarations = std::move(declarations.m_result);
-
-	return make_writer<CST::CST*>(e);
-}
-
-Writer<std::vector<CST::Declaration>>
-Parser::parse_declaration_list(TokenTag terminator) {
-	Writer<std::vector<CST::Declaration>> result = {
-	    {"Parse Error: Failed to parse declaration list"}};
-
-	std::vector<CST::Declaration> declarations;
+	std::vector<CST::CST*> declarations;
 
 	while (1) {
 		auto p0 = peek();
 
-		if (p0->m_type == terminator)
+		if (p0->m_type == TokenTag::END)
 			break;
-
-		if (p0->m_type == TokenTag::END) {
-			result.m_error.m_sub_errors.push_back(
-			    make_expected_error("a declaration", p0));
-
-			result.m_error.m_sub_errors.push_back(
-			    make_expected_error(token_string[int(terminator)], p0));
-
-			return result;
-		}
 
 		auto declaration = parse_declaration();
 		CHECK_AND_RETURN(result, declaration);
 
-		declarations.push_back(std::move(*declaration.m_result));
+		declarations.push_back(std::move(declaration.m_result));
 	}
 
-	return make_writer(std::move(declarations));
+	auto e = m_cst_allocator->make<CST::DeclarationList>();
+	e->m_declarations = std::move(declarations);
+
+	return make_writer<CST::CST*>(e);
 }
 
 Writer<std::vector<CST::CST*>> Parser::parse_expression_list(

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -213,8 +213,8 @@ Writer<CST::CST*> Parser::parse_function_declaration() {
 	auto id = require(TokenTag::IDENTIFIER);
 	CHECK_AND_RETURN(result, id);
 
-	auto args_ = parse_function_arguments();
-	CHECK_AND_RETURN(result, args_);
+	auto args = parse_function_arguments();
+	CHECK_AND_RETURN(result, args);
 
 	if (consume(TokenTag::ARROW)) {
 		auto expression = parse_expression();
@@ -224,24 +224,22 @@ Writer<CST::CST*> Parser::parse_function_declaration() {
 
 		auto e = m_cst_allocator->make<CST::FunctionDeclaration>();
 		e->m_body = expression.m_result;
-		e->m_args = std::move(args_.m_result);
+		e->m_args = std::move(args.m_result);
 		e->m_identifier_token = id.m_result;
 
 		return make_writer<CST::CST*>(e);
 	} else {
-		return result;
-		/*
 		auto block = parse_block();
 		CHECK_AND_RETURN(result, block);
 
-		auto e = m_cst_allocator->make<CST::BlockFunctionLiteral>();
+		auto e = m_cst_allocator->make<CST::BlockFunctionDeclaration>();
 		e->m_body = block.m_result;
-		e->m_args = std::move(args);
+		e->m_args = std::move(args.m_result);
+		e->m_identifier_token = id.m_result;
 
 		REQUIRE(result, TokenTag::SEMICOLON);
 
 		return make_writer<CST::CST*>(e);
-		*/
 	}
 }
 

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <type_traits>
 
 #include "error_report.hpp"
 #include "token_array.hpp"
@@ -12,6 +13,29 @@ struct Allocator;
 
 template <typename T>
 struct Writer {
+	Writer() = default;
+	Writer(Writer const&) = default;
+	Writer(Writer&&) = default;
+
+	Writer(ErrorReport error)
+	    : m_error {std::move(error)} {}
+
+	Writer(ErrorReport error, T const& result)
+	    : m_error {std::move(error)}
+	    , m_result {result} {}
+
+	Writer(ErrorReport error, T&& result)
+	    : m_error {std::move(error)}
+	    , m_result {std::move(result)} {}
+
+	Writer& operator=(Writer const&) = default;
+	Writer& operator=(Writer&&) = default;
+
+	template <typename U>
+	Writer(Writer<U>&& o)
+	    : m_error {std::move(o.m_error)}
+	    , m_result {std::move(o.m_result)} {}
+
 	ErrorReport m_error {};
 	T m_result {};
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -63,12 +63,15 @@ void interpreter_tests(Test::Tester& tests) {
 	        EQUALS("ternary_disambiguations", 1)
 	    }));
 
-	tests.add_test(std::make_unique<TestCase>("tests/function.jp",
+	tests.add_test(std::make_unique<TestCase>(
+	    "tests/function.jp",
 	    Testers {
 	        EQUALS("normal()", 3),
 	        EQUALS("curry()", 42),
-		EQUALS("I(42)", 42),
+	        EQUALS("I(42)", 42),
 	        EQUALS("capture_order()", "ABCD"),
+	        EQUALS("second(1,2,3)", 2),
+	        EQUALS("third(1,2,3)", 3),
 	    }));
 
 	tests.add_test(std::make_unique<TestCase>("tests/recursion.jp",

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -13,4 +13,8 @@ struct Token {
 	int m_line0, m_col0;
 	/* end of token in source */
 	int m_line1, m_col1;
+
+	TokenTag type() const {
+		return m_type;
+	}
 };

--- a/tests/function.jp
+++ b/tests/function.jp
@@ -22,5 +22,11 @@ cat := fn(a,c,d) => fn(b) => a + b + c + d;
 
 capture_order := fn() => cat("A","C","D")("B");
 
+fn second(x, y, z) => y;
+
+fn third(x, y, z) {
+	return z;
+};
+
 __invoke := fn() => 0;
 


### PR DESCRIPTION
I added some syntactic sugar for function declarations.

We may now write

```rust
fn add(a, b) {
    return a + b;
};
```

And it will desugar to

```rust
add := fn (a, b) => seq {
    return a + b;
};
```

Likewise, regular functions work, too:

```rust
fn id(x) => x;
```

desugars to

```rust
id := fn(x) => x;
```