### PR TITLE
Cst touchup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ COMMON_TARGETS := \
 	match_identifiers \
 	metacheck \
 	parser \
+	source_location \
 	symbol_table \
 	token \
 	typecheck \

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -155,7 +155,7 @@ AST* convert_ast(CST::Declaration* cst, Allocator& alloc) {
 	auto ast = alloc.make<Declaration>();
 
 	ast->m_cst = cst;
-	ast->m_identifier = cst->m_identifier_token->m_text;
+	ast->m_identifier = cst->identifier_text();
 
 	if (cst->m_type_hint)
 		ast->m_type_hint = convert_ast(cst->m_type_hint, alloc);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -83,7 +83,7 @@ Declaration convert_declaration(CST::Declaration* cst, CST::DeclarationData& dat
 AST* convert_ast(CST::FunctionLiteral* cst, Allocator& alloc) {
 	auto ast = alloc.make<FunctionLiteral>();
 
-	for (auto& arg : cst->m_args) {
+	for (auto& arg : cst->m_args.m_args) {
 		Declaration decl = convert_declaration(nullptr, arg, alloc);
 		decl.m_surrounding_function = ast;
 
@@ -98,7 +98,7 @@ AST* convert_ast(CST::FunctionLiteral* cst, Allocator& alloc) {
 AST* convert_ast(CST::BlockFunctionLiteral* cst, Allocator& alloc) {
 	auto ast = alloc.make<FunctionLiteral>();
 
-	for (auto& arg : cst->m_args) {
+	for (auto& arg : cst->m_args.m_args) {
 		Declaration decl = convert_declaration(nullptr, arg, alloc);
 		decl.m_surrounding_function = ast;
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -321,7 +321,10 @@ AST* convert_ast(CST::ForStatement* cst, Allocator& alloc) {
 	while_ast->m_condition = convert_ast(cst->m_condition, alloc);;
 
 	auto outter_block_ast = alloc.make<Block>();
-	outter_block_ast->m_body.push_back(convert_ast(&cst->m_declaration, alloc));
+	auto decl = convert_declaration(nullptr, cst->m_declaration, alloc);
+	auto heap_decl = alloc.make<Declaration>();
+	*heap_decl = std::move(decl);
+	outter_block_ast->m_body.push_back(heap_decl);
 	outter_block_ast->m_body.push_back(while_ast);
 
 	return outter_block_ast;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -69,14 +69,14 @@ AST* convert_ast(CST::ArrayLiteral* cst, Allocator& alloc) {
 	return ast;
 }
 
-Declaration convert_declaration(CST::Declaration& cst, Allocator& alloc) {
+Declaration convert_declaration(CST::Declaration* cst, CST::DeclarationData& data, Allocator& alloc) {
 	Declaration decl;
-	decl.m_cst = &cst;
-	decl.m_identifier = cst.identifier();
-	if (cst.m_data.m_type_hint)
-		decl.m_type_hint = convert_ast(cst.m_data.m_type_hint, alloc);
-	if (cst.m_data.m_value)
-		decl.m_value = convert_ast(cst.m_data.m_value, alloc);
+	decl.m_cst = cst;
+	decl.m_identifier = data.identifier();
+	if (data.m_type_hint)
+		decl.m_type_hint = convert_ast(data.m_type_hint, alloc);
+	if (data.m_value)
+		decl.m_value = convert_ast(data.m_value, alloc);
 	return decl;
 }
 
@@ -84,7 +84,7 @@ AST* convert_ast(CST::FunctionLiteral* cst, Allocator& alloc) {
 	auto ast = alloc.make<FunctionLiteral>();
 
 	for (auto& arg : cst->m_args) {
-		Declaration decl = convert_declaration(arg, alloc);
+		Declaration decl = convert_declaration(&arg, arg.m_data, alloc);
 		decl.m_surrounding_function = ast;
 
 		ast->m_args.push_back(std::move(decl));
@@ -99,7 +99,7 @@ AST* convert_ast(CST::BlockFunctionLiteral* cst, Allocator& alloc) {
 	auto ast = alloc.make<FunctionLiteral>();
 
 	for (auto& arg : cst->m_args) {
-		Declaration decl = convert_declaration(arg, alloc);
+		Declaration decl = convert_declaration(nullptr, arg, alloc);
 		decl.m_surrounding_function = ast;
 
 		ast->m_args.push_back(std::move(decl));
@@ -153,7 +153,7 @@ AST* convert_ast(CST::BinaryExpression* cst, Allocator& alloc) {
 
 AST* convert_ast(CST::Declaration* cst, Allocator& alloc) {
 	auto ast = alloc.make<Declaration>();
-	*ast = convert_declaration(*cst, alloc);
+	*ast = convert_declaration(cst, cst->m_data, alloc);
 	return ast;
 }
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -84,7 +84,7 @@ AST* convert_ast(CST::FunctionLiteral* cst, Allocator& alloc) {
 	auto ast = alloc.make<FunctionLiteral>();
 
 	for (auto& arg : cst->m_args) {
-		Declaration decl = convert_declaration(&arg, arg.m_data, alloc);
+		Declaration decl = convert_declaration(nullptr, arg, alloc);
 		decl.m_surrounding_function = ast;
 
 		ast->m_args.push_back(std::move(decl));

--- a/src/cst.cpp
+++ b/src/cst.cpp
@@ -25,15 +25,19 @@ void print_impl(DeclarationList* cst, int d) {
 	std::cout << ")";
 }
 
-void print_impl(Declaration* cst, int d) {
+void print(DeclarationData& data, int d) {
 	print_indentation(d);
-	std::cout << "(decl \"" << cst->identifier() << "\"\n";
+	std::cout << "(decl \"" << data.identifier() << "\"\n";
 
-	print(cst->m_data.m_type_hint, d + 6);
+	print(data.m_type_hint, d + 6);
 	std::cout << "\n";
 
-	print(cst->m_data.m_value, d + 6);
+	print(data.m_value, d + 6);
 	std::cout << ")";
+}
+
+void print_impl(Declaration* cst, int d) {
+	print(cst->m_data, d);
 }
 
 void print_impl(NumberLiteral* cst, int d) {
@@ -91,9 +95,9 @@ void print_impl(Block* cst, int d) {
 void print_impl(BlockFunctionLiteral* cst, int d) {
 	print_indentation(d);
 	std::cout << "(function-literal (";
-	for (auto arg : cst->m_args) {
+	for (DeclarationData& arg : cst->m_args) {
 		std::cout << "\n";
-		print(&arg, d + indent_width);
+		print(arg, d + indent_width);
 	}
 	std::cout << ")\n";
 

--- a/src/cst.cpp
+++ b/src/cst.cpp
@@ -92,13 +92,17 @@ void print_impl(Block* cst, int d) {
 	std::cout << ")";
 }
 
-void print_impl(BlockFunctionLiteral* cst, int d) {
-	print_indentation(d);
-	std::cout << "(function-literal (";
-	for (DeclarationData& arg : cst->m_args) {
+void print_impl(FuncArguments& args, int d) {
+	for (DeclarationData& arg : args) {
 		std::cout << "\n";
 		print(arg, d + indent_width);
 	}
+}
+
+void print_impl(BlockFunctionLiteral* cst, int d) {
+	print_indentation(d);
+	std::cout << "(function-literal (";
+	print_impl(cst->m_args, d);
 	std::cout << ")\n";
 
 	print(cst->m_body, d + indent_width);
@@ -109,10 +113,7 @@ void print_impl(BlockFunctionLiteral* cst, int d) {
 void print_impl(FunctionLiteral* cst, int d) {
 	print_indentation(d);
 	std::cout << "(short-function-literal (";
-	for (auto arg : cst->m_args) {
-		std::cout << "\n";
-		print(arg, d + indent_width);
-	}
+	print_impl(cst->m_args, d);
 	std::cout << ")\n";
 
 	print(cst->m_body, d + indent_width);

--- a/src/cst.cpp
+++ b/src/cst.cpp
@@ -111,7 +111,7 @@ void print_impl(FunctionLiteral* cst, int d) {
 	std::cout << "(short-function-literal (";
 	for (auto arg : cst->m_args) {
 		std::cout << "\n";
-		print(&arg, d + indent_width);
+		print(arg, d + indent_width);
 	}
 	std::cout << ")\n";
 

--- a/src/cst.cpp
+++ b/src/cst.cpp
@@ -223,7 +223,7 @@ void print_impl(IfElseStatement* cst, int d) {
 void print_impl(ForStatement* cst, int d) {
 	print_indentation(d);
 	std::cout << "(for-stmt\n";
-	print(&cst->m_declaration, d + indent_width);
+	print(cst->m_declaration, d + indent_width);
 	std::cout << "\n";
 	print(cst->m_condition, d + indent_width);
 	std::cout << "\n";

--- a/src/cst.cpp
+++ b/src/cst.cpp
@@ -27,12 +27,12 @@ void print_impl(DeclarationList* cst, int d) {
 
 void print_impl(Declaration* cst, int d) {
 	print_indentation(d);
-	std::cout << "(decl \"" << cst->identifier_text() << "\"\n";
+	std::cout << "(decl \"" << cst->identifier() << "\"\n";
 
-	print(cst->m_type_hint, d + 6);
+	print(cst->m_data.m_type_hint, d + 6);
 	std::cout << "\n";
 
-	print(cst->m_value, d + 6);
+	print(cst->m_data.m_value, d + 6);
 	std::cout << ")";
 }
 

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -24,13 +24,21 @@ struct CST {
 	virtual ~CST() = default;
 };
 
-struct Declaration : public CST {
+struct DeclarationData {
 	Token const* m_identifier_token;
 	CST* m_type_hint {nullptr};  // can be nullptr
 	CST* m_value {nullptr}; // can be nullptr
 
-	InternedString const& identifier_text() const {
+	InternedString const& identifier() const {
 		return m_identifier_token->m_text;
+	}
+};
+
+struct Declaration : public CST {
+	DeclarationData m_data;
+
+	InternedString const& identifier() const {
+		return m_data.identifier();
 	}
 
 	Declaration()

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "./utils/interned_string.hpp"
 #include "cst_tag.hpp"
 #include "token.hpp"
 
@@ -28,8 +29,8 @@ struct Declaration : public CST {
 	CST* m_type_hint {nullptr};  // can be nullptr
 	CST* m_value {nullptr}; // can be nullptr
 
-	std::string const& identifier_text() const {
-		return m_identifier_token->m_text.str();
+	InternedString const& identifier_text() const {
+		return m_identifier_token->m_text;
 	}
 
 	Declaration()

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -113,9 +113,13 @@ struct ArrayLiteral : public CST {
 	    : CST {CSTTag::ArrayLiteral} {}
 };
 
+struct FuncArguments {
+	std::vector<DeclarationData> m_args;
+};
+
 struct BlockFunctionLiteral : public CST {
 	CST* m_body;
-	std::vector<DeclarationData> m_args;
+	FuncArguments m_args;
 
 	BlockFunctionLiteral()
 	    : CST {CSTTag::BlockFunctionLiteral} {}
@@ -123,7 +127,7 @@ struct BlockFunctionLiteral : public CST {
 
 struct FunctionLiteral : public CST {
 	CST* m_body;
-	std::vector<DeclarationData> m_args;
+	FuncArguments m_args;
 
 	FunctionLiteral()
 	    : CST {CSTTag::FunctionLiteral} {}

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -123,7 +123,7 @@ struct BlockFunctionLiteral : public CST {
 
 struct FunctionLiteral : public CST {
 	CST* m_body;
-	std::vector<Declaration> m_args;
+	std::vector<DeclarationData> m_args;
 
 	FunctionLiteral()
 	    : CST {CSTTag::FunctionLiteral} {}

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -113,9 +113,7 @@ struct ArrayLiteral : public CST {
 	    : CST {CSTTag::ArrayLiteral} {}
 };
 
-struct FuncArguments {
-	std::vector<DeclarationData> m_args;
-};
+using FuncArguments = std::vector<DeclarationData>;
 
 struct BlockFunctionLiteral : public CST {
 	CST* m_body;

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -240,7 +240,7 @@ struct IfElseStatement : public CST {
 };
 
 struct ForStatement : public CST {
-	Declaration m_declaration;
+	DeclarationData m_declaration;
 	CST* m_condition;
 	CST* m_action;
 	CST* m_body;

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -115,7 +115,7 @@ struct ArrayLiteral : public CST {
 
 struct BlockFunctionLiteral : public CST {
 	CST* m_body;
-	std::vector<Declaration> m_args;
+	std::vector<DeclarationData> m_args;
 
 	BlockFunctionLiteral()
 	    : CST {CSTTag::BlockFunctionLiteral} {}

--- a/src/error_report.cpp
+++ b/src/error_report.cpp
@@ -1,6 +1,7 @@
 #include "error_report.hpp"
 
 #include <iostream>
+#include <sstream>
 
 bool ErrorReport::ok() {
 	return m_sub_errors.empty() && m_text.empty();
@@ -14,4 +15,10 @@ void ErrorReport::print(int d) {
 
 	for (auto& sub : m_sub_errors)
 		sub.print(d + 1);
+}
+
+ErrorReport make_located_error(string_view text, SourceLocation location) {
+	std::stringstream ss;
+	ss << "At " << location.to_string() << " : " << text;
+	return ErrorReport {ss.str()};
 }

--- a/src/error_report.hpp
+++ b/src/error_report.hpp
@@ -3,6 +3,9 @@
 #include <string>
 #include <vector>
 
+#include "source_location.hpp"
+#include "utils/string_view.hpp"
+
 struct ErrorReport {
 	std::string m_text;
 	std::vector<ErrorReport> m_sub_errors;
@@ -10,3 +13,5 @@ struct ErrorReport {
 	bool ok();
 	void print(int d = 1);
 };
+
+ErrorReport make_located_error(string_view text, SourceLocation location);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -56,6 +56,7 @@ struct Lexer {
 TokenArray tokenize(std::string const& source) {
 	TokenArray ta;
 	std::vector<char> v;
+	v.reserve(source.size());
 	for (char c : source)
 		v.push_back(c);
 	Lexer lexer = {std::move(v), ta};

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -59,9 +59,9 @@ namespace Frontend {
 	if (!declaration) {
 		// TODO: clean up how we build error reports
 		auto token = ast->token();
-		return {
-		    "at line " + std::to_string(token->m_line0 + 1) +
-		    " : accessed undeclared identifier '" + ast->text().str() + "'"};
+		return make_located_error(
+		    "accessed undeclared identifier '" + ast->text().str() + "'",
+		    token->m_source_location.start);
 	}
 
 	ast->m_declaration = declaration;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -688,26 +688,26 @@ Writer<CST::CST*> Parser::parse_function() {
 	REQUIRE(result, TokenTag::KEYWORD_FN);
 	REQUIRE(result, TokenTag::PAREN_OPEN);
 
-	std::vector<CST::Declaration> args;
+	std::vector<CST::DeclarationData> args_data;
 	while (1) {
 		if (consume(TokenTag::PAREN_CLOSE)) {
 			break;
 		} else if (match(TokenTag::IDENTIFIER)) {
 			// consume argument name
 
-			CST::Declaration arg;
+			CST::DeclarationData arg_data;
 
-			arg.m_data.m_identifier_token = peek();
+			arg_data.m_identifier_token = peek();
 			advance_token_cursor();
 
 			if (consume(TokenTag::DECLARE)) {
 				// optionally consume a type hint
 				auto type = parse_type_term();
 				CHECK_AND_RETURN(result, type);
-				arg.m_data.m_type_hint = type.m_result;
+				arg_data.m_type_hint = type.m_result;
 			}
 
-			args.push_back(std::move(arg));
+			args_data.push_back(std::move(arg_data));
 
 			if (consume(TokenTag::COMMA)) {
 				// If we find a comma, we have to parse
@@ -737,7 +737,7 @@ Writer<CST::CST*> Parser::parse_function() {
 
 		auto e = m_cst_allocator->make<CST::FunctionLiteral>();
 		e->m_body = expression.m_result;
-		e->m_args = std::move(args);
+		e->m_args = std::move(args_data);
 
 		return make_writer<CST::CST*>(e);
 	} else {
@@ -746,11 +746,6 @@ Writer<CST::CST*> Parser::parse_function() {
 
 		auto e = m_cst_allocator->make<CST::BlockFunctionLiteral>();
 		e->m_body = block.m_result;
-
-		std::vector<CST::DeclarationData> args_data;
-		for(auto& arg : args)
-			args_data.push_back(arg.m_data);
-
 		e->m_args = std::move(args_data);
 
 		return make_writer<CST::CST*>(e);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -17,6 +17,27 @@ Writer<T> make_writer(T x) {
 	return {{}, std::move(x)};
 }
 
+// WHY DO I HAVE TO TYPE THIS TWICE!?
+template <typename T, typename U>
+bool handle_error(Writer<T>& lhs, Writer<U>& rhs) {
+	if (not rhs.ok()) {
+		// NOTE: it's kinda bad that we move out of a non r-value, but
+		// due to the way we use it, it's safe.
+		lhs.add_sub_error(std::move(rhs).error());
+		return true;
+	}
+	return false;
+}
+
+template <typename T, typename U>
+bool handle_error(Writer<T>& lhs, Writer<U>&& rhs) {
+	if (not rhs.ok()) {
+		lhs.add_sub_error(std::move(rhs).error());
+		return true;
+	}
+	return false;
+}
+
 ErrorReport make_located_error(string_view text, Token const* token) {
 	std::stringstream ss;
 	ss << "Parse error at " << token->m_line0 + 1 << ":" << token->m_col0 + 1
@@ -111,27 +132,6 @@ struct Parser {
 		return false;
 	}
 };
-
-// WHY DO I HAVE TO TYPE THIS TWICE!?
-template <typename T, typename U>
-bool handle_error(Writer<T>& lhs, Writer<U>& rhs) {
-	if (not rhs.ok()) {
-		// NOTE: it's kinda bad that we move out of a non r-value, but
-		// due to the way we use it, it's safe.
-		lhs.add_sub_error(std::move(rhs).error());
-		return true;
-	}
-	return false;
-}
-
-template <typename T, typename U>
-bool handle_error(Writer<T>& lhs, Writer<U>&& rhs) {
-	if (not rhs.ok()) {
-		lhs.add_sub_error(std::move(rhs).error());
-		return true;
-	}
-	return false;
-}
 
 #define CHECK_AND_RETURN(result, writer)                                       \
 	if (handle_error(result, writer))                                          \

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -746,7 +746,12 @@ Writer<CST::CST*> Parser::parse_function() {
 
 		auto e = m_cst_allocator->make<CST::BlockFunctionLiteral>();
 		e->m_body = block.m_result;
-		e->m_args = std::move(args);
+
+		std::vector<CST::DeclarationData> args_data;
+		for(auto& arg : args)
+			args_data.push_back(arg.m_data);
+
+		e->m_args = std::move(args_data);
 
 		return make_writer<CST::CST*>(e);
 	}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -39,11 +39,7 @@ bool handle_error(Writer<T>& lhs, Writer<U>&& rhs) {
 }
 
 ErrorReport make_located_error(string_view text, Token const* token) {
-	std::stringstream ss;
-	ss << "Parse error at " << token->m_line0 + 1 << ":" << token->m_col0 + 1
-	   << " : " << text;
-
-	return ErrorReport {ss.str()};
+	return make_located_error(text, token->m_source_location.start);
 }
 
 ErrorReport make_expected_error(string_view expected, Token const* found_token) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -253,9 +253,11 @@ Writer<CST::Declaration*> Parser::parse_declaration() {
 	REQUIRE(result, TokenTag::SEMICOLON);
 
 	auto p = m_cst_allocator->make<CST::Declaration>();
-	p->m_identifier_token = name.m_result;
-	p->m_type_hint = type.m_result;
-	p->m_value = value.m_result;
+	p->m_data = {
+		name.m_result,
+		type.m_result,
+		value.m_result,
+	};
 
 	return make_writer<CST::Declaration*>(p);
 }
@@ -695,14 +697,14 @@ Writer<CST::CST*> Parser::parse_function() {
 
 			CST::Declaration arg;
 
-			arg.m_identifier_token = peek();
+			arg.m_data.m_identifier_token = peek();
 			advance_token_cursor();
 
 			if (consume(TokenTag::DECLARE)) {
 				// optionally consume a type hint
 				auto type = parse_type_term();
 				CHECK_AND_RETURN(result, type);
-				arg.m_type_hint = type.m_result;
+				arg.m_data.m_type_hint = type.m_result;
 			}
 
 			args.push_back(std::move(arg));

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -15,6 +15,31 @@ struct Writer {
 	ErrorReport m_error {};
 	T m_result {};
 
+	Writer() = default;
+
+	Writer(Writer const&) = default;
+	Writer(Writer&&) = default;
+
+	Writer& operator=(Writer const&) = default;
+	Writer& operator=(Writer&&) = default;
+
+	Writer(ErrorReport error)
+	    : m_error {std::move(error)} {}
+
+	Writer(ErrorReport error, T result)
+	    : m_error {std::move(error)}
+	    , m_result {std::move(result)} {}
+
+	ErrorReport& error() & {
+		return m_error;
+	}
+	ErrorReport const& error() const& {
+		return m_error;
+	}
+	ErrorReport&& error() && {
+		return std::move(m_error);
+	}
+
 	bool ok() {
 		return m_error.ok();
 	}

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -30,6 +30,10 @@ struct Writer {
 	    : m_error {std::move(error)}
 	    , m_result {std::move(result)} {}
 
+	void add_sub_error(ErrorReport err) {
+		m_error.m_sub_errors.push_back(std::move(err));
+	}
+
 	ErrorReport& error() & {
 		return m_error;
 	}

--- a/src/source_location.cpp
+++ b/src/source_location.cpp
@@ -1,0 +1,1 @@
+#include "source_location.hpp"

--- a/src/source_location.hpp
+++ b/src/source_location.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+struct SourceLocation {
+	int line, col;
+
+	std::string to_string() const {
+		return std::to_string(line + 1) + ":" + std::to_string(col + 1);
+	}
+};
+
+struct SourceRange {
+	SourceLocation start;
+	SourceLocation end;
+};

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "source_location.hpp"
 #include "token_tag.hpp"
 #include "utils/interned_string.hpp"
 
@@ -9,8 +10,5 @@ struct Token {
 	/* source code representation of token */
 	InternedString m_text;
 
-	/* beggining of token in source */
-	int m_line0, m_col0;
-	/* end of token in source */
-	int m_line1, m_col1;
+	SourceRange m_source_location;
 };


### PR DESCRIPTION
## Data Layout

I changed up some of how the Cst is organized: I put the data that goes in declarations into its own helper struct called `DeclarationData`.
This struct is smaller than CST::Declaration by probably 16 bytes (due to it not having a tag and a virtual pointer), so it is lighter-weight when stored by value in other nodes. (e.g. FunctionLiteral, ForStatement)

There is now a type alias for function arguments. It's just more convenient than typing out `std::vector<DeclarationData>` every single time.

Also, tokens no longer store 4 integers with their source location information, but a brand new `SourceRange` struct. Hopefully this will come in handy in many different places

## Error reporting

I refactored a good deal of how we generate errors in the parser et al, while introducing some visual improvements. It's not night-and-day, but I think it's significant.

Here is an example of how some errors are generated in the parser:

```diff
There is a newer and nicer API to add sub-errors to Writer<T>
-	result.m_error.m_sub_errors.push_back(
-	    make_expected_error("a declaration", p0));
+	result.add_sub_error(make_expected_error("a declaration", p0));

We can pass TokenTag to make_expected_error now
-	return {make_expected_error(
-	    token_string[int(expected_type)], current_token)};
+	return {make_expected_error(expected_type, current_token)};

This error now gives a source location
-	result.m_error.m_sub_errors.push_back(
-	    {{"Found a terminator after a delimiter in an "
-	      "expression list "}});
+	result.add_sub_error(make_located_error(
+	    "Found trailing delimiter in expression list", p0));
```

The way `match_identifiers` generates its errors has been unified with how the parser does it.

```diff
-	return {
-	    "at line " + std::to_string(token->m_line0 + 1) +
-	    " : accessed undeclared identifier '" + ast->text().str() + "'"};
+	return make_located_error(
+	    "accessed undeclared identifier '" + ast->text().str() + "'",
+	    token->m_source_location.start);
```

Whether this snippet of code is better is debatable, but I think it's definitely clearer, as it directly states its intent. This change also makes the error look more similar to the parser's

```diff
	- While scanning top level declaration '__invoke'
-	-- at line 7 : accessed undeclared identifier 'a'
+	-- At 7:3 : accessed undeclared identifier 'a'
```