### PR TITLE
Function declarations

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -30,7 +30,7 @@ Token const* Identifier::token() const {
 }
 
 
-SequenceExpression* convert_and_wrap_block_in_seq_expr(CST::Block* cst, Allocator& alloc) {
+SequenceExpression* convert_and_wrap_in_seq(CST::Block* cst, Allocator& alloc) {
 	auto block = static_cast<Block*>(convert_ast(cst, alloc));
 	auto seq_expr = alloc.make<SequenceExpression>();
 	seq_expr->m_body = block;
@@ -119,7 +119,7 @@ AST* convert_ast(CST::BlockFunctionLiteral* cst, Allocator& alloc) {
 	auto ast = alloc.make<FunctionLiteral>();
 
 	ast->m_args = convert_args(cst->m_args, ast, alloc);
-	ast->m_body = convert_and_wrap_block_in_seq_expr(cst->m_body, alloc);
+	ast->m_body = convert_and_wrap_in_seq(cst->m_body, alloc);
 
 	return ast;
 }
@@ -185,7 +185,7 @@ AST* convert_ast(CST::FuncDeclaration* cst, Allocator& alloc) {
 AST* convert_ast(CST::BlockFuncDeclaration* cst, Allocator& alloc) {
 	auto func_ast = alloc.make<FunctionLiteral>();
 	func_ast->m_args = convert_args(cst->m_args, func_ast, alloc);
-	func_ast->m_body = convert_and_wrap_block_in_seq_expr(cst->m_body, alloc);
+	func_ast->m_body = convert_and_wrap_in_seq(cst->m_body, alloc);
 
 	auto ast = alloc.make<Declaration>();
 	ast->m_cst = cst;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -29,6 +29,19 @@ Token const* Identifier::token() const {
 	return static_cast<CST::Identifier*>(m_cst)->m_token;
 }
 
+
+SequenceExpression* wrap_block_in_seq_expr(Block* block, Allocator& alloc) {
+	auto seq_expr = alloc.make<SequenceExpression>();
+	seq_expr->m_body = block;
+	return seq_expr;
+}
+
+SequenceExpression* convert_and_wrap_block_in_seq_expr(CST::Block* cst, Allocator& alloc) {
+	auto block = static_cast<Block*>(convert_ast(cst, alloc));
+	return wrap_block_in_seq_expr(block, alloc);
+}
+
+
 AST* convert_ast(CST::IntegerLiteral* cst, Allocator& alloc) {
 	auto ast = alloc.make<IntegerLiteral>();
 	ast->m_value = std::stoi(cst->text());
@@ -110,10 +123,7 @@ AST* convert_ast(CST::BlockFunctionLiteral* cst, Allocator& alloc) {
 	auto ast = alloc.make<FunctionLiteral>();
 
 	ast->m_args = convert_args(cst->m_args, ast, alloc);
-
-	auto seq_expr = alloc.make<SequenceExpression>();
-	seq_expr->m_body = static_cast<Block*>(convert_ast(cst->m_body, alloc));
-	ast->m_body = seq_expr;
+	ast->m_body = convert_and_wrap_block_in_seq_expr(cst->m_body, alloc);
 
 	return ast;
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -15,9 +15,11 @@ InternedString const& Declaration::identifier_text() const {
 
 		auto cst = static_cast<CST::Declaration*>(m_cst);
 
-		Log::warning() << "No identifier on declaration, using token data as fallback: '" << cst->identifier() << "'";
+		auto found_identifier = cst->identifier_virtual();
 
-		return cst->identifier();
+		Log::warning() << "No identifier on declaration, using token data as fallback: '" << found_identifier << "'";
+
+		return found_identifier;
 	}
 
 	return m_identifier;
@@ -155,7 +157,7 @@ AST* convert_ast(CST::BinaryExpression* cst, Allocator& alloc) {
 	return ast;
 }
 
-AST* convert_ast(CST::Declaration* cst, Allocator& alloc) {
+AST* convert_ast(CST::PlainDeclaration* cst, Allocator& alloc) {
 	auto ast = alloc.make<Declaration>();
 	*ast = convert_declaration(cst, cst->m_data, alloc);
 	return ast;
@@ -165,7 +167,7 @@ AST* convert_ast(CST::DeclarationList* cst, Allocator& alloc) {
 	auto ast = alloc.make<DeclarationList>();
 
 	for (auto& declaration : cst->m_declarations) {
-		auto decl = static_cast<Declaration*>(convert_ast(&declaration, alloc));
+		auto decl = static_cast<Declaration*>(convert_ast(declaration, alloc));
 		ast->m_declarations.push_back(std::move(*decl));
 	}
 
@@ -420,7 +422,7 @@ AST* convert_ast(CST::CST* cst, Allocator& alloc) {
 		DISPATCH(WhileStatement);
 
 		DISPATCH(DeclarationList);
-		DISPATCH(Declaration);
+		DISPATCH(PlainDeclaration);
 
 		DISPATCH(UnionExpression);
 		DISPATCH(StructExpression);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -279,7 +279,10 @@ AST* convert_ast(CST::MatchExpression* cst, Allocator& alloc) {
 		    {case_name,
 		     MatchExpression::CaseData {std::move(declaration), expression}});
 
-		assert(insertion_result.second);
+		if (!insertion_result.second) {
+			// TODO: add location information
+			Log::fatal() << "Duplicate case in match expression";
+		}
 	}
 
 	ast->m_cases = std::move(cases);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -30,15 +30,11 @@ Token const* Identifier::token() const {
 }
 
 
-SequenceExpression* wrap_block_in_seq_expr(Block* block, Allocator& alloc) {
+SequenceExpression* convert_and_wrap_block_in_seq_expr(CST::Block* cst, Allocator& alloc) {
+	auto block = static_cast<Block*>(convert_ast(cst, alloc));
 	auto seq_expr = alloc.make<SequenceExpression>();
 	seq_expr->m_body = block;
 	return seq_expr;
-}
-
-SequenceExpression* convert_and_wrap_block_in_seq_expr(CST::Block* cst, Allocator& alloc) {
-	auto block = static_cast<Block*>(convert_ast(cst, alloc));
-	return wrap_block_in_seq_expr(block, alloc);
 }
 
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -15,7 +15,7 @@ InternedString const& Declaration::identifier_text() const {
 
 		auto cst = static_cast<CST::Declaration*>(m_cst);
 
-		auto found_identifier = cst->identifier_virtual();
+		auto const& found_identifier = cst->identifier_virtual();
 
 		Log::warning() << "No identifier on declaration, using token data as fallback: '" << found_identifier << "'";
 
@@ -160,6 +160,19 @@ AST* convert_ast(CST::BinaryExpression* cst, Allocator& alloc) {
 AST* convert_ast(CST::PlainDeclaration* cst, Allocator& alloc) {
 	auto ast = alloc.make<Declaration>();
 	*ast = convert_declaration(cst, cst->m_data, alloc);
+	return ast;
+}
+
+AST* convert_ast(CST::FuncDeclaration* cst, Allocator& alloc) {
+	auto func_ast = alloc.make<FunctionLiteral>();
+	func_ast->m_args = convert_args(cst->m_args, func_ast, alloc);
+	func_ast->m_body = convert_ast(cst->m_body, alloc);
+
+	auto ast = alloc.make<Declaration>();
+	ast->m_cst = cst;
+	ast->m_identifier = cst->identifier();
+	ast->m_value = func_ast;
+
 	return ast;
 }
 
@@ -423,6 +436,7 @@ AST* convert_ast(CST::CST* cst, Allocator& alloc) {
 
 		DISPATCH(DeclarationList);
 		DISPATCH(PlainDeclaration);
+		DISPATCH(FuncDeclaration);
 
 		DISPATCH(UnionExpression);
 		DISPATCH(StructExpression);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -186,6 +186,19 @@ AST* convert_ast(CST::FuncDeclaration* cst, Allocator& alloc) {
 	return ast;
 }
 
+AST* convert_ast(CST::BlockFuncDeclaration* cst, Allocator& alloc) {
+	auto func_ast = alloc.make<FunctionLiteral>();
+	func_ast->m_args = convert_args(cst->m_args, func_ast, alloc);
+	func_ast->m_body = convert_and_wrap_block_in_seq_expr(cst->m_body, alloc);
+
+	auto ast = alloc.make<Declaration>();
+	ast->m_cst = cst;
+	ast->m_identifier = cst->identifier();
+	ast->m_value = func_ast;
+
+	return ast;
+}
+
 AST* convert_ast(CST::DeclarationList* cst, Allocator& alloc) {
 	auto ast = alloc.make<DeclarationList>();
 
@@ -447,6 +460,7 @@ AST* convert_ast(CST::CST* cst, Allocator& alloc) {
 		DISPATCH(DeclarationList);
 		DISPATCH(PlainDeclaration);
 		DISPATCH(FuncDeclaration);
+		DISPATCH(BlockFuncDeclaration);
 
 		DISPATCH(UnionExpression);
 		DISPATCH(StructExpression);

--- a/src/cst.cpp
+++ b/src/cst.cpp
@@ -20,7 +20,7 @@ void print_impl(DeclarationList* cst, int d) {
 	std::cout << "(decl-list";
 	for (auto& decl : cst->m_declarations) {
 		std::cout << "\n";
-		print(&decl, d + indent_width);
+		print(decl, d + indent_width);
 	}
 	std::cout << ")";
 }
@@ -36,7 +36,7 @@ void print(DeclarationData& data, int d) {
 	std::cout << ")";
 }
 
-void print_impl(Declaration* cst, int d) {
+void print_impl(PlainDeclaration* cst, int d) {
 	print(cst->m_data, d);
 }
 
@@ -317,7 +317,7 @@ void print_impl(CST* cst, int d) {
 		DISPATCH(ConstructorExpression)
 
 		DISPATCH(DeclarationList)
-		DISPATCH(Declaration)
+		DISPATCH(PlainDeclaration)
 
 		DISPATCH(Block)
 		DISPATCH(ReturnStatement)

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -25,6 +25,8 @@ struct CST {
 	virtual ~CST() = default;
 };
 
+struct Block;
+
 struct DeclarationData {
 	Token const* m_identifier_token;
 	CST* m_type_hint {nullptr};  // can be nullptr
@@ -146,7 +148,7 @@ struct ArrayLiteral : public CST {
 };
 
 struct BlockFunctionLiteral : public CST {
-	CST* m_body;
+	Block* m_body;
 	FuncArguments m_args;
 
 	BlockFunctionLiteral()
@@ -239,7 +241,6 @@ struct ConstructorExpression : public CST {
 	    : CST {CSTTag::ConstructorExpression} {}
 };
 
-struct Block;
 
 struct SequenceExpression : public CST {
 	Block* m_body;

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -79,6 +79,23 @@ struct FuncDeclaration : public Declaration {
 	    : Declaration {CSTTag::FuncDeclaration} {}
 };
 
+struct BlockFuncDeclaration : public Declaration {
+	Token const* m_identifier;
+	FuncArguments m_args;
+	Block* m_body;
+
+	InternedString const& identifier() const {
+		return m_identifier->m_text;
+	}
+
+	InternedString const& identifier_virtual() const override {
+		return identifier();
+	}
+
+	BlockFuncDeclaration()
+	    : Declaration {CSTTag::BlockFuncDeclaration} {}
+};
+
 struct DeclarationList : public CST {
 	std::vector<Declaration*> m_declarations;
 

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -65,8 +65,12 @@ struct FuncDeclaration : public Declaration {
 	FuncArguments m_args;
 	CST* m_body;
 
-	InternedString const& identifier_virtual() const override {
+	InternedString const& identifier() const {
 		return m_identifier->m_text;
+	}
+
+	InternedString const& identifier_virtual() const override {
+		return identifier();
 	}
 
 	FuncDeclaration()

--- a/src/cst_tag.hpp
+++ b/src/cst_tag.hpp
@@ -11,7 +11,8 @@
 	X(FunctionLiteral)                                                         \
                                                                                \
 	X(DeclarationList)                                                         \
-	X(Declaration)                                                             \
+	X(PlainDeclaration)                                                        \
+	X(FuncDeclaration)                                                         \
 	X(Identifier)                                                              \
 	X(BinaryExpression)                                                        \
 	X(CallExpression)                                                          \

--- a/src/cst_tag.hpp
+++ b/src/cst_tag.hpp
@@ -13,6 +13,7 @@
 	X(DeclarationList)                                                         \
 	X(PlainDeclaration)                                                        \
 	X(FuncDeclaration)                                                         \
+	X(BlockFuncDeclaration)                                                    \
 	X(Identifier)                                                              \
 	X(BinaryExpression)                                                        \
 	X(CallExpression)                                                          \

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -76,7 +76,7 @@ struct Parser {
 	Writer<CST::Declaration*> parse_declaration();
 	Writer<CST::FuncDeclaration*> parse_func_declaration();
 	Writer<CST::PlainDeclaration*> parse_plain_declaration();
-	Writer<CST::DeclarationData> parse_declaration_data();
+	Writer<CST::DeclarationData> parse_plain_declaration_data();
 
 	Writer<CST::CST*> parse_expression(int bp = 0, CST::CST* parsed_lhs = nullptr);
 	Writer<CST::CST*> parse_terminal();
@@ -267,7 +267,7 @@ Writer<CST::FuncDeclaration*> Parser::parse_func_declaration() {
 Writer<CST::PlainDeclaration*> Parser::parse_plain_declaration() {
 	Writer<CST::PlainDeclaration*> result = {{"Failed to parse declaration"}};
 
-	auto decl_data = parse_declaration_data();
+	auto decl_data = parse_plain_declaration_data();
 	CHECK_AND_RETURN(result, decl_data);
 
 	auto p = m_cst_allocator.make<CST::PlainDeclaration>();
@@ -278,7 +278,7 @@ Writer<CST::PlainDeclaration*> Parser::parse_plain_declaration() {
 
 
 
-Writer<CST::DeclarationData> Parser::parse_declaration_data() {
+Writer<CST::DeclarationData> Parser::parse_plain_declaration_data() {
 	auto name = require(TokenTag::IDENTIFIER);
 	if (!name.ok())
 		return std::move(name).error();
@@ -890,7 +890,7 @@ Writer<CST::CST*> Parser::parse_for_statement() {
 	REQUIRE(result, TokenTag::PAREN_OPEN);
 
 	// NOTE: handles semicolon already
-	auto declaration = parse_declaration_data();
+	auto declaration = parse_plain_declaration_data();
 	CHECK_AND_RETURN(result, declaration);
 
 	auto condition = parse_expression();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -85,7 +85,7 @@ struct Parser {
 	Writer<CST::CST*> parse_function();
 	Writer<CST::CST*> parse_array_literal();
 	Writer<std::vector<CST::CST*>> parse_argument_list();
-	Writer<CST::CST*> parse_block();
+	Writer<CST::Block*> parse_block();
 	Writer<CST::CST*> parse_statement();
 	Writer<CST::CST*> parse_return_statement();
 	Writer<CST::CST*> parse_if_else_stmt_or_expr();
@@ -798,8 +798,8 @@ Writer<CST::CST*> Parser::parse_function() {
 	}
 }
 
-Writer<CST::CST*> Parser::parse_block() {
-	Writer<CST::CST*> result = {{"Failed to parse block statement"}};
+Writer<CST::Block*> Parser::parse_block() {
+	Writer<CST::Block*> result = {{"Failed to parse block statement"}};
 
 	REQUIRE(result, TokenTag::BRACE_OPEN);
 
@@ -827,7 +827,7 @@ Writer<CST::CST*> Parser::parse_block() {
 	auto e = m_cst_allocator.make<CST::Block>();
 	e->m_body = std::move(statements);
 
-	return make_writer<CST::CST*>(e);
+	return make_writer(e);
 }
 
 Writer<CST::CST*> Parser::parse_return_statement() {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -23,6 +23,11 @@ struct Writer {
 	Writer& operator=(Writer const&) = default;
 	Writer& operator=(Writer&&) = default;
 
+	template <typename U>
+	Writer(Writer<U>&& o)
+	    : m_error {std::move(o.m_error)}
+	    , m_result {std::move(o.m_result)} {}
+
 	Writer(ErrorReport error)
 	    : m_error {std::move(error)} {}
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -63,12 +63,18 @@ void interpreter_tests(Test::Tester& tests) {
 	        EQUALS("ternary_disambiguations", 1)
 	    }));
 
-	tests.add_test(std::make_unique<TestCase>("tests/function.jp",
+	tests.add_test(std::make_unique<TestCase>(
+	    "tests/function.jp",
 	    Testers {
 	        EQUALS("normal()", 3),
 	        EQUALS("curry()", 42),
-		EQUALS("I(42)", 42),
+	        EQUALS("I(42)", 42),
 	        EQUALS("capture_order()", "ABCD"),
+	        EQUALS("median_of_three(1,2,3)", 2),
+	        EQUALS("median_of_three(3,2,1)", 2),
+	        EQUALS("median_of_three(10,15,7)", 10),
+	        EQUALS("second(15,7)", 7),
+	        EQUALS("second(7,15)", 15),
 	    }));
 
 	tests.add_test(std::make_unique<TestCase>("tests/recursion.jp",

--- a/tests/function.jp
+++ b/tests/function.jp
@@ -22,5 +22,19 @@ cat := fn(a,c,d) => fn(b) => a + b + c + d;
 
 capture_order := fn() => cat("A","C","D")("B");
 
+fn second(x, y) => y;
+
+fn median_of_three(x, y, z) {
+	if (x < y) {
+		if (y < z) return y;
+		if (x < z) return z;
+		           return x;
+	} else {
+		if (x < z) return x;
+		if (y < z) return z;
+		           return y;
+	}
+};
+
 __invoke := fn() => 0;
 


### PR DESCRIPTION
This is the reboot of #257. It came out to a smaller diff, though. (but with a greater amount of added lines)

I added some syntactic sugar for function declarations.

We may now write

```rust
fn id(x) => x;

// desugars to
id := fn(x) => x;
```

Likewise, block functions work, too:

```rust
fn add(a, b) {
    return a + b;
};

// desugars to
add := fn (a, b) => seq {
    return a + b;
};
```