### PR TITLE
Value restriction

### DIFF
--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -11,18 +11,6 @@
 
 namespace TypeChecker {
 
-// this function implements 'the value restriction', a technique
-// that enables type inference on mutable datatypes
-static bool is_value_expression(AST::AST* ast) {
-	switch (ast->type()) {
-	case ASTTag::FunctionLiteral:
-	case ASTTag::Identifier:
-		return true;
-	default:
-		return false;
-	}
-}
-
 static void process_type_hint(AST::Declaration* ast, TypeChecker& tc);
 
 // Literals
@@ -289,6 +277,18 @@ void print_information(AST::Declaration* ast, TypeChecker& tc) {
 	Log::info("The type is:");
 	tc.m_core.m_mono_core.print_node(poly_data.base);
 #endif
+}
+
+// this function implements 'the value restriction', a technique
+// that enables type inference on mutable datatypes
+static bool is_value_expression(AST::AST* ast) {
+	switch (ast->type()) {
+	case ASTTag::FunctionLiteral:
+	case ASTTag::Identifier:
+		return true;
+	default:
+		return false;
+	}
 }
 
 void generalize(AST::Declaration* ast, TypeChecker& tc) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -295,13 +295,17 @@ void generalize(AST::Declaration* ast, TypeChecker& tc) {
 	assert(!ast->m_is_polymorphic);
 
 	assert(ast->m_value);
-	if (!is_value_expression(ast->m_value))
-		return;
 
-	ast->m_is_polymorphic = true;
-	ast->m_decl_type = tc.generalize(ast->m_value_type);
+	if (is_value_expression(ast->m_value)) {
+		ast->m_is_polymorphic = true;
+		ast->m_decl_type = tc.generalize(ast->m_value_type);
 
-	print_information(ast, tc);
+		print_information(ast, tc);
+	} else {
+		// if it's not a value expression, its free vars get bound
+		// to the environment instead of being generalized
+		tc.bind_free_vars(ast->m_value_type);
+	}
 }
 
 static void process_type_hint(AST::Declaration* ast, TypeChecker& tc) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -11,10 +11,17 @@
 
 namespace TypeChecker {
 
-// NOTE(SMestre): This file duplicates a bit of what
-// match_identifiers does. However, I think that's the right
-// thing to do. At least, the alternatives I came up with
-// are quite a bit worse.
+// this function implements 'the value restriction', a technique
+// that enables type inference on mutable datatypes
+static bool is_value_expression(AST::AST* ast) {
+	switch (ast->type()) {
+	case ASTTag::FunctionLiteral:
+	case ASTTag::Identifier:
+		return true;
+	default:
+		return false;
+	}
+}
 
 static void process_declaration_type_hint(AST::Declaration* ast, TypeChecker& tc);
 
@@ -286,6 +293,10 @@ void print_information(AST::Declaration* ast, TypeChecker& tc) {
 
 void generalize(AST::Declaration* ast, TypeChecker& tc) {
 	assert(!ast->m_is_polymorphic);
+
+	assert(ast->m_value);
+	if (!is_value_expression(ast->m_value))
+		return;
 
 	ast->m_is_polymorphic = true;
 	ast->m_decl_type = tc.generalize(ast->m_value_type);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -23,7 +23,7 @@ static bool is_value_expression(AST::AST* ast) {
 	}
 }
 
-static void process_declaration_type_hint(AST::Declaration* ast, TypeChecker& tc);
+static void process_type_hint(AST::Declaration* ast, TypeChecker& tc);
 
 // Literals
 
@@ -117,7 +117,7 @@ void typecheck(AST::FunctionLiteral* ast, TypeChecker& tc) {
 
 		for (auto& arg : ast->m_args) {
 			arg.m_value_type = tc.new_var();
-			process_declaration_type_hint(&arg, tc);
+			process_type_hint(&arg, tc);
 			arg_types.push_back(arg.m_value_type);
 		}
 
@@ -219,7 +219,7 @@ void typecheck(AST::MatchExpression* ast, TypeChecker& tc) {
 		// a typefunc, it should not ever get generalized. But we don't really
 		// do anything to prevent it.
 		case_data.m_declaration.m_value_type = tc.new_var();
-		process_declaration_type_hint(&case_data.m_declaration, tc);
+		process_type_hint(&case_data.m_declaration, tc);
 
 		// unify type of match with type of cases
 		typecheck(case_data.m_expression, tc);
@@ -304,7 +304,7 @@ void generalize(AST::Declaration* ast, TypeChecker& tc) {
 	print_information(ast, tc);
 }
 
-static void process_declaration_type_hint(AST::Declaration* ast, TypeChecker& tc) {
+static void process_type_hint(AST::Declaration* ast, TypeChecker& tc) {
 	if (!ast->m_type_hint)
 		return;
 
@@ -317,7 +317,7 @@ static void process_declaration_type_hint(AST::Declaration* ast, TypeChecker& tc
 // to its type
 // apply typehints if available
 void process_contents(AST::Declaration* ast, TypeChecker& tc) {
-	process_declaration_type_hint(ast, tc);
+	process_type_hint(ast, tc);
 
 	// it would be nicer to check this at an earlier stage
 	assert(ast->m_value);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -305,11 +305,12 @@ void generalize(AST::Declaration* ast, TypeChecker& tc) {
 }
 
 static void process_declaration_type_hint(AST::Declaration* ast, TypeChecker& tc) {
-	if (ast->m_type_hint) {
-		assert(ast->m_type_hint->type() == ASTTag::MonoTypeHandle);
-		auto handle = static_cast<AST::MonoTypeHandle*>(ast->m_type_hint);
-		tc.m_core.m_mono_core.unify(ast->m_value_type, handle->m_value);
-	}
+	if (!ast->m_type_hint)
+		return;
+
+	assert(ast->m_type_hint->type() == ASTTag::MonoTypeHandle);
+	auto handle = static_cast<AST::MonoTypeHandle*>(ast->m_type_hint);
+	tc.m_core.m_mono_core.unify(ast->m_value_type, handle->m_value);
 }
 
 // typecheck the value and make the type of the decl equal

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -186,6 +186,16 @@ PolyId TypeChecker::generalize(MonoId mono) {
 	return m_core.new_poly(base, std::move(new_vars));
 }
 
+void TypeChecker::bind_free_vars(MonoId mono) {
+	std::unordered_set<MonoId> free_vars;
+	m_core.gather_free_vars(mono, free_vars);
+	for (MonoId var : free_vars) {
+		if (!m_env.has_type_var(var)) {
+			m_env.current_scope().m_type_vars.insert(var);
+		}
+	}
+}
+
 // Hindley-Milner [App], modified for multiple argument functions.
 MonoId TypeChecker::rule_app(std::vector<MonoId> args_types, MonoId func_type) {
 	MonoId return_type = m_core.m_mono_core.new_var();

--- a/src/typechecker.hpp
+++ b/src/typechecker.hpp
@@ -30,6 +30,7 @@ struct TypeChecker {
 	MonoId new_hidden_var();
 	MonoId new_var();
 	PolyId generalize(MonoId mono);
+	void bind_free_vars(MonoId mono);
 	MonoId rule_app(std::vector<MonoId> args_types, MonoId func_type);
 
 	MetaTypeId new_meta_var();


### PR DESCRIPTION
closes #265 

## Introduction

In ML-style type systems with mutable data, there is a distinction between 'values' and 'references'. A value is, essentially, an immutable value, while a reference is a handle to a mutable value.

To prevent the problems outlined in #265, we want to treat values and references differently in certain cases: we never want to generalize free vars that belong to a reference.

This idea gives us this truth table:

|has free vars?|value or reference?|should generalize var?|
|-----|--------|----|
|yes|value|yes|
|no|value|no|
|yes|reference|no|
|no|reference|no|

## The algorithm

A first stab at implementing this can be reasoned like so: we only want to generalize immutable things, and the only immutable thing that we have are functions. Thus, we will only generalize declarations of function expressions (i.e. things that look like `f := fn(...) => expr`)

This actually fixes #265, but is much too restrictive, as the following fails to typecheck:

```rust
fn __invoke() {
  id := fn(x) => x; // infer id: forall a. a -> a
  id2 := id;        // b:=newvar(), instanciate with a=b, then id2: b -> b (note the lack of forall)
  id2(0);           // unify b = int<::>
  id2("0");         // unify b = string<::> (gives a type error because b = int<::>)
};
```

To prevent this, we will also generalize identifier expressions.

At first glance, it might seem like things like the following will typecheck, (much like in the current master branch):

```rust
fn __invoke() {
  f := fn() => array{};
  a := f(); // has type array<:a:> (note lack of forall, due to new logic)

  // seems like it would generalize and have type forall b. array<:b:>, due to it being an identifier
  b := a;
  a1 : array<:int<::>:> = b;
  a2 : array<:string<::>:> = b;

  array_append(a1, 10);
  array_append(a2, "");

  return 0;
};
```

In reality, this will not happen, because the free variables of `a` will be part of the environment by the time `b` is typechecked, meaning they will not be generalized, by the usual means. (This is not implemented in master because we generalize every declaration, but now, when a declaration is not generalized, its free vars will get bound to the environment)

All in all, what we are doing is creating an explicit check for column 2 of the truth table. Well we actually overestimate, and end up taking up some of the false cases, too. In particular, that means we don't generalize some things that fall into row 1.

```rust
// has type forall a. a -> a
id := fn(x) => x;
// id2 is not a function expression, nor an identifier expression, so it won't be generalized
// has type b -> b (no forall)
id2 := id(id);
// we can get around this by using eta-expansion (i.e write the function explicitly)
// has type forall c. c -> c
id2 := fn(x) => id(id)(x);
```

But i feel like it's a low price to pay, and the workaround is easy enough. The overall technique is called **"the value restriction"**, and it's quite common in ML-style languages with mutation. There are other techniques that get some (or a lot) of row 1 back, but they're a lot more complex to implement.

https://en.wikipedia.org/wiki/Value_restriction

http://mlton.org/ValueRestriction

--------------------

PS: I sneaked in a tiny refactoring as well

PSS: since this makes the type system strictly more restrictive (i.e programs that previously typechecked no longer do) we don't have a way to do automated testing