### PR TITLE
Optimize the lexer

### DIFF
--- a/src/algorithms/trie.hpp
+++ b/src/algorithms/trie.hpp
@@ -4,12 +4,13 @@
 #include <cstdint>
 
 #include "../utils/string_view.hpp"
+#include "../utils/interned_string.hpp"
 
 static constexpr uint8_t nil = ~uint8_t(0);
 
 struct Trie {
 	struct Entry {
-		string_view text;
+		InternedString text;
 		int data;
 	};
 

--- a/src/utils/interned_string.cpp
+++ b/src/utils/interned_string.cpp
@@ -3,6 +3,7 @@
 #include "string_set.hpp"
 
 #include <cassert>
+#include <cstring>
 
 StringSet& InternedString::database() {
 	static StringSet values;
@@ -22,6 +23,9 @@ InternedString::InternedString(char const* other) {
 	m_data = &(*insertion_result.first);
 }
 
+InternedString::InternedString(string_view other)
+    : InternedString {other.data(), other.size()} {}
+
 InternedString::InternedString(std::string const& other) {
 	auto insertion_result = database().insert(other);
 	m_data = &(*insertion_result.first);
@@ -35,6 +39,16 @@ InternedString::InternedString(std::string&& other) {
 std::string const& InternedString::str() const {
 	assert(m_data);
 	return *m_data;
+}
+
+bool operator== (string_view lhs, InternedString const& rhs) {
+	if (rhs.is_null()) return false;
+	return lhs.size() == rhs.size() && memcmp(rhs.str().data(), lhs.data(), lhs.size()) == 0;
+}
+
+bool operator== (InternedString const& lhs, string_view rhs) {
+	if (lhs.is_null()) return false;
+	return lhs.size() == rhs.size() && memcmp(lhs.str().data(), rhs.data(), rhs.size()) == 0;
 }
 
 std::ostream& operator<<(std::ostream& o, InternedString const& is) {

--- a/src/utils/interned_string.cpp
+++ b/src/utils/interned_string.cpp
@@ -3,7 +3,6 @@
 #include "string_set.hpp"
 
 #include <cassert>
-#include <cstring>
 
 StringSet& InternedString::database() {
 	static StringSet values;
@@ -39,16 +38,6 @@ InternedString::InternedString(std::string&& other) {
 std::string const& InternedString::str() const {
 	assert(m_data);
 	return *m_data;
-}
-
-bool operator== (string_view lhs, InternedString const& rhs) {
-	if (rhs.is_null()) return false;
-	return lhs.size() == rhs.size() && memcmp(rhs.str().data(), lhs.data(), lhs.size()) == 0;
-}
-
-bool operator== (InternedString const& lhs, string_view rhs) {
-	if (lhs.is_null()) return false;
-	return lhs.size() == rhs.size() && memcmp(lhs.str().data(), rhs.data(), rhs.size()) == 0;
 }
 
 std::ostream& operator<<(std::ostream& o, InternedString const& is) {

--- a/src/utils/interned_string.hpp
+++ b/src/utils/interned_string.hpp
@@ -2,6 +2,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <cstring>
 
 #include "string_view.hpp"
 
@@ -66,8 +67,14 @@ template<> struct std::hash<InternedString> {
 	};
 };
 
-bool operator== (string_view lhs, InternedString const& rhs);
+inline bool operator== (string_view lhs, InternedString const& rhs) {
+	if (rhs.is_null()) return false;
+	return lhs.size() == rhs.size() && memcmp(rhs.str().data(), lhs.data(), lhs.size()) == 0;
+}
 
-bool operator== (InternedString const& lhs, string_view rhs);
+inline bool operator== (InternedString const& lhs, string_view rhs) {
+	if (lhs.is_null()) return false;
+	return lhs.size() == rhs.size() && memcmp(lhs.str().data(), rhs.data(), rhs.size()) == 0;
+}
 
 std::ostream& operator<<(std::ostream&, InternedString const&);

--- a/src/utils/interned_string.hpp
+++ b/src/utils/interned_string.hpp
@@ -6,6 +6,9 @@
 struct StringSet;
 
 struct InternedString {
+	using const_iterator = char const*;
+	using iterator = const_iterator;
+
 	std::string const* m_data {nullptr};
 
 	InternedString() = default;
@@ -19,6 +22,10 @@ struct InternedString {
 		return !m_data;
 	}
 
+	size_t size() const {
+		return is_null() ? 0 : m_data->size();
+	}
+
 	bool operator==(InternedString const& other) const {
 		return m_data == other.m_data;
 	}
@@ -30,6 +37,22 @@ struct InternedString {
 	std::string const& str() const;
 
 	static StringSet& database();
+
+	const_iterator cbegin() const {
+		return m_data->data();
+	}
+
+	const_iterator cend() const {
+		return m_data->data() + m_data->size();
+	}
+
+	iterator begin() {
+		return cbegin();
+	}
+
+	iterator end() {
+		return cend();
+	}
 };
 
 // Specialize std::hash to implement hashing for this type

--- a/src/utils/interned_string.hpp
+++ b/src/utils/interned_string.hpp
@@ -3,6 +3,8 @@
 #include <iosfwd>
 #include <string>
 
+#include "string_view.hpp"
+
 struct StringSet;
 
 struct InternedString {
@@ -15,6 +17,7 @@ struct InternedString {
 	InternedString(InternedString const& other);
 	InternedString(char const* other);
 	InternedString(char const* other, size_t length);
+	explicit InternedString(string_view other);
 	explicit InternedString(std::string const& other);
 	explicit InternedString(std::string&& other);
 
@@ -62,5 +65,9 @@ template<> struct std::hash<InternedString> {
 		return (hash_bits >> 4) | (hash_bits << 60);
 	};
 };
+
+bool operator== (string_view lhs, InternedString const& rhs);
+
+bool operator== (InternedString const& lhs, string_view rhs);
 
 std::ostream& operator<<(std::ostream&, InternedString const&);

--- a/src/utils/string_view.hpp
+++ b/src/utils/string_view.hpp
@@ -11,6 +11,9 @@ struct string_view {
 	string_view(const std::string&);
 	string_view(char const*, size_t size);
 
+	char const* data() {
+		return m_data;
+	}
 	int size() {
 		return m_size;
 	}

--- a/src/utils/string_view.hpp
+++ b/src/utils/string_view.hpp
@@ -14,7 +14,7 @@ struct string_view {
 	char const* data() {
 		return m_data;
 	}
-	int size() {
+	size_t size() {
 		return m_size;
 	}
 	char const* cbegin() const {


### PR DESCRIPTION
I profiled and found that the frontend spent about 11% of time in the lexer.

### Optimization 1

A good chunk of that was spent inside `InternedString(char const*, size_t)`. Perf quickly showed me to see that it was mostly called from `Lexer::push_token`. In turn, that routine got a significant amount of calls from `Lexer::consume_symbol`. This is kinda silly: symbols are hard-coded into the language, and the lexer already knows which symbol was consumed when we push it, so there should be no need to do a hash-lookup on it, too.

To solve this, I stored `InternedString`s in the trie that we use to parse symbols. This way, each symbol gets looked up in the strings table only once: when we first initialize the lexer.

Turns out, most tokens are symbols in a typical Jasper program, so saving one hash-lookup per symbol is a pretty big deal.

### Optimization 2

Similarly to symbols, keywords are hard coded into the language, so we shouldn't need to do a hash lookup when we consume one.

We now put the possible keyword string into a `string_view` to compare it with the language's keywords, and take the `InternedString` from the keywords array, if we happen to match against one.

Although we now need to do string comparisons instead of pointer comparisons in that loop, because of the distribution of prefixes in the keywords (in particular, no two keywords have the same first and second letter as each other), the string comparisons are O(1).

> Side note: In my benchmark, the `InternedString` constructor spent 97% of time in `StringSet::scan`, so I tried to speed up that routine, but it didn't go too well. Instead, looking at where it was being used proved much more effective.

### Results

Tokenization used to take 11% of time, it now takes 9.9%. That would imply a speedup of 1.22% in the frontend, overall. Empirically, I measured a speedup of 1.8%, which is pretty close.