### PR TITLE
Simplify expression parser loop, and improve some error messages

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -92,7 +92,7 @@ Declaration convert_declaration(CST::Declaration* cst, CST::DeclarationData& dat
 }
 
 std::vector<Declaration> convert_args(
-    CST::FuncArguments& cst_args,
+    CST::FuncParameters& cst_args,
     FunctionLiteral* surrounding_function,
     Allocator& alloc) {
 

--- a/src/cst.cpp
+++ b/src/cst.cpp
@@ -92,7 +92,7 @@ void print_impl(Block* cst, int d) {
 	std::cout << ")";
 }
 
-void print_impl(FuncArguments& args, int d) {
+void print_impl(FuncParameters& args, int d) {
 	for (DeclarationData& arg : args) {
 		std::cout << "\n";
 		print(arg, d + indent_width);

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -37,7 +37,7 @@ struct DeclarationData {
 	}
 };
 
-using FuncArguments = std::vector<DeclarationData>;
+using FuncParameters = std::vector<DeclarationData>;
 
 struct Declaration : public CST {
 	// This function is very cold -- it's ok to use virtuals
@@ -64,7 +64,7 @@ struct PlainDeclaration : public Declaration {
 
 struct FuncDeclaration : public Declaration {
 	Token const* m_identifier;
-	FuncArguments m_args;
+	FuncParameters m_args;
 	CST* m_body;
 
 	InternedString const& identifier() const {
@@ -81,7 +81,7 @@ struct FuncDeclaration : public Declaration {
 
 struct BlockFuncDeclaration : public Declaration {
 	Token const* m_identifier;
-	FuncArguments m_args;
+	FuncParameters m_args;
 	Block* m_body;
 
 	InternedString const& identifier() const {
@@ -166,7 +166,7 @@ struct ArrayLiteral : public CST {
 
 struct BlockFunctionLiteral : public CST {
 	Block* m_body;
-	FuncArguments m_args;
+	FuncParameters m_args;
 
 	BlockFunctionLiteral()
 	    : CST {CSTTag::BlockFunctionLiteral} {}
@@ -174,7 +174,7 @@ struct BlockFunctionLiteral : public CST {
 
 struct FunctionLiteral : public CST {
 	CST* m_body;
-	FuncArguments m_args;
+	FuncParameters m_args;
 
 	FunctionLiteral()
 	    : CST {CSTTag::FunctionLiteral} {}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -84,7 +84,7 @@ struct Parser {
 	Writer<CST::CST*> parse_terminal();
 	Writer<CST::CST*> parse_ternary_expression();
 	Writer<CST::CST*> parse_ternary_expression(CST::CST* parsed_condition);
-	Writer<CST::FuncArguments> parse_function_arguments();
+	Writer<CST::FuncParameters> parse_function_parameters();
 	Writer<CST::CST*> parse_function();
 	Writer<CST::CST*> parse_array_literal();
 	Writer<std::vector<CST::CST*>> parse_argument_list();
@@ -226,7 +226,7 @@ Writer<CST::Declaration*> Parser::parse_func_declaration() {
 	auto identifier = require(TokenTag::IDENTIFIER);
 	CHECK_AND_RETURN(result, identifier);
 
-	auto args = parse_function_arguments();
+	auto args = parse_function_parameters();
 	CHECK_AND_RETURN(result, identifier);
 
 	if (consume(TokenTag::ARROW)) {
@@ -713,7 +713,7 @@ Writer<CST::CST*> Parser::parse_array_literal() {
 	return make_writer<CST::CST*>(e);
 }
 
-Writer<CST::FuncArguments> Parser::parse_function_arguments() {
+Writer<CST::FuncParameters> Parser::parse_function_parameters() {
 
 	auto open_paren = require(TokenTag::PAREN_OPEN);
 	if (!open_paren.ok())
@@ -759,7 +759,7 @@ Writer<CST::FuncArguments> Parser::parse_function_arguments() {
 		}
 	}
 
-	return make_writer(CST::FuncArguments {std::move(args_data)});
+	return make_writer(CST::FuncParameters {std::move(args_data)});
 }
 
 /*
@@ -773,7 +773,7 @@ Writer<CST::CST*> Parser::parse_function() {
 
 	REQUIRE(result, TokenTag::KEYWORD_FN);
 
-	auto func_args = parse_function_arguments();
+	auto func_args = parse_function_parameters();
 	if (!func_args.ok())
 		return std::move(func_args).error();
 


### PR DESCRIPTION
I moved a bunch of stuff around, made it easier to read, and made some of the parse errors less noisy.

In particular, we no longer see

```
- failed to parse expression
-- failed to parse terminal expression
--- failed to parse expression
---- failed to parse terminal expression
----- failed to parse expression
------ failed to parse terminal expression
------- failed to parse expression
-------- failed to parse terminal expression
--------- at xx:xx -- expected so and so but got so and so
```

but

```
- failed to parse expression
-- at xx:xx -- expected so and so but got so and so
```

when a heavily nested expression (e.g. `((((1 + 2!) + 3) + 4) + 5)` ) fails to parse very deep within.