### PR TITLE
Neaten automaton initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ COMMON_TARGETS := \
 	utils/string_set \
 	utils/string_view \
 	ast \
-	automaton \
 	compile_time_environment \
 	compute_offsets \
 	cst \
 	ct_eval \
 	error_report \
+	lexer \
 	match_identifiers \
 	metacheck \
 	parser \

--- a/src/automaton.hpp
+++ b/src/automaton.hpp
@@ -1,5 +1,72 @@
-#pragma once
+#include <cstdint>
 
-#include "token_array.hpp"
+static constexpr int state_count = 200;
+using State = uint8_t;
 
-TokenArray tokenize(char const* p);
+struct Range {
+	unsigned char start;
+	unsigned char end;
+};
+
+struct Automaton {
+	int offset[state_count] {};
+	State transition[state_count][256] {};
+
+	constexpr State go(State s, unsigned char c) const {
+		return transition[s][c];
+	}
+};
+
+struct AutomatonBuilder {
+	int state_counter {state_count};
+	Automaton automaton {};
+
+	struct StateProxy {
+		AutomatonBuilder& builder;
+		State state;
+
+		constexpr StateProxy& transition(unsigned char c, State dst) {
+			builder.transition(state, c, dst);
+			return *this;
+		}
+
+		constexpr StateProxy& transition(Range r, State dst) {
+			builder.transition(state, r, dst);
+			return *this;
+		}
+
+		constexpr StateProxy& default_transition(State dst) {
+			builder.default_transition(state, dst);
+			return *this;
+		}
+
+		constexpr StateProxy from_state(State src) {
+			return {builder, src};
+		}
+	};
+
+	constexpr AutomatonBuilder& transition(State src, unsigned char c, State dst) {
+		automaton.transition[src][c] = dst;
+		return *this;
+	}
+
+	constexpr AutomatonBuilder& transition(State src, Range r, State dst) {
+		for (auto c = r.start;; ++c)  {
+			transition(src, c, dst);
+			if (c == r.end) break;
+		}
+		return *this;
+	}
+
+	constexpr AutomatonBuilder& default_transition(State src, State dst) {
+		return transition(src, Range {0, 255}, dst);
+	}
+
+	constexpr StateProxy from_state(State src) {
+		return {*this, src};
+	}
+
+	constexpr int new_state() {
+		return --state_counter;
+	}
+};

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -2,10 +2,10 @@
 
 #include "../ast.hpp"
 #include "../ast_allocator.hpp"
-#include "../automaton.hpp"
 #include "../compute_offsets.hpp"
 #include "../cst_allocator.hpp"
 #include "../ct_eval.hpp"
+#include "../lexer.hpp"
 #include "../match_identifiers.hpp"
 #include "../metacheck.hpp"
 #include "../parser.hpp"

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -5,8 +5,8 @@
 
 #include "../ast.hpp"
 #include "../ast_allocator.hpp"
-#include "../automaton.hpp"
 #include "../cst_allocator.hpp"
+#include "../lexer.hpp"
 #include "../parser.hpp"
 #include "../token_array.hpp"
 #include "eval.hpp"

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -8,30 +8,15 @@
 #include <cstdio>
 #include <cstring>
 
-constexpr void add_default_transition(Automaton& a, State src, State dst) {
-	for (int i = 256; i--;)
-		a.transition[src][i] = dst;
-}
-
-constexpr void add_transition(Automaton& a, State src, unsigned char c, State dst) {
-	a.transition[src][c] = dst;
-}
-
-constexpr void add_self_transition(Automaton& a, State src, unsigned char c) {
-	add_transition(a, src, c, src);
-}
-
-constexpr void add_string(Automaton& a, int& state_counter, State end_state, char const* str) {
-#define new_state() (--state_counter)
+constexpr void add_string(AutomatonBuilder& builder, char const* str, State end_state) {
 	int state = state_count - 1;
 	while (*str) {
 		if (*(str+1) == '\0')
-			add_transition(a, state, *str, end_state);
-		else if (a.go(state, *str) == 0)
-			add_transition(a, state, *str, new_state());
-		state = a.go(state, *str++);
+			builder.transition(state, *str, end_state);
+		else if (builder.automaton.go(state, *str) == 0)
+			builder.transition(state, *str, builder.new_state());
+		state = builder.automaton.go(state, *str++);
 	}
-#undef new_state
 }
 
 namespace MainLexer {
@@ -351,32 +336,28 @@ static InternedString fixed_strings[] = { END_STATES };
 #undef END_STATES
 
 constexpr Automaton make() {
-#define new_state() (--state_counter)
-	Automaton a{};
+	AutomatonBuilder builder{};
 
-	int state_counter = state_count;
+	int start_state = builder.new_state();
 
-	int start_state = new_state();
+	add_string(builder, "if", EndStates::If);
+	add_string(builder, "for", EndStates::For);
+	add_string(builder, "else", EndStates::Else);
+	add_string(builder, "fn", EndStates::Fn);
+	add_string(builder, "then", EndStates::Then);
+	add_string(builder, "return", EndStates::Return);
+	add_string(builder, "while", EndStates::While);
+	add_string(builder, "match", EndStates::Match);
+	add_string(builder, "true", EndStates::True);
+	add_string(builder, "false", EndStates::False);
+	add_string(builder, "array", EndStates::Array);
+	add_string(builder, "null", EndStates::Null);
+	add_string(builder, "seq", EndStates::Seq);
+	add_string(builder, "tuple", EndStates::Tuple);
+	add_string(builder, "struct", EndStates::Struct);
+	add_string(builder, "union", EndStates::Union);
 
-	add_string(a, state_counter, EndStates::If, "if");
-	add_string(a, state_counter, EndStates::For, "for");
-	add_string(a, state_counter, EndStates::Else, "else");
-	add_string(a, state_counter, EndStates::Fn, "fn");
-	add_string(a, state_counter, EndStates::Then, "then");
-	add_string(a, state_counter, EndStates::Return, "return");
-	add_string(a, state_counter, EndStates::While, "while");
-	add_string(a, state_counter, EndStates::Match, "match");
-	add_string(a, state_counter, EndStates::True, "true");
-	add_string(a, state_counter, EndStates::False, "false");
-	add_string(a, state_counter, EndStates::Array, "array");
-	add_string(a, state_counter, EndStates::Null, "null");
-	add_string(a, state_counter, EndStates::Seq, "seq");
-	add_string(a, state_counter, EndStates::Tuple, "tuple");
-	add_string(a, state_counter, EndStates::Struct, "struct");
-	add_string(a, state_counter, EndStates::Union, "union");
-
-	return a;
-#undef new_state
+	return builder.automaton;
 }
 
 } // namespace KeywordLexer

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "token_array.hpp"
+
+TokenArray tokenize(char const* p);

--- a/src/playground/main.cpp
+++ b/src/playground/main.cpp
@@ -6,7 +6,7 @@
 #include "../ast.hpp"
 #include "../ast_allocator.hpp"
 #include "../cst_allocator.hpp"
-#include "../automaton.hpp"
+#include "../lexer.hpp"
 #include "../parser.hpp"
 #include "../token_array.hpp"
 


### PR DESCRIPTION
I implemented an AutomatonBuilder class that makes initalizing automata a lot neater, through a sort of embedded DSL.

Now, instead of

```cpp
Automaton make() {
    Atomaton a;
    int state_counter = state_count;
    auto start = --state_counter;
    auto saw_plus = --state_counter;
    auto saw_dash = --state_counter;
    add_transition(start, '+', saw_plus);
    add_transition(start, '-', saw_dash);
    add_default_transition(saw_plus, Plus);
    add_transition(saw_plus, '=', PlusEq);
    add_transition(saw_plus, '+', PlusPlus);
    add_default_transition(saw_dash, Minus);
    add_transition(saw_dash, '=', MinusEq);
    add_transition(saw_dash, '-', MinusMinus);
    return a;
}
```
we can write
```cpp
Automaton make() {
    AtomatonBuilder builder{};
    auto start = builder.new_state();
    auto saw_plus = builder.new_state();
    auto saw_dash = builder.new_state();
    builder
    .from_state(start)
        .transition('+', saw_plus);
        .transition('-', saw_dash);
    .from_state(saw_plus)
        .default_transition(Plus);
        .transition('=', PlusEq);
        .transition('+', PlusPlus);
    .from_state(saw_dash)
        .default_transition(Minus);
        .transition('=', MinusEq);
        .transition('-', MinusMinus);
    return builder.automaton;
}
```

Which I think is neater and more readable, if a bit more verbose, line-wise