### PR TITLE
match_identifiers in eval_expression

### DIFF
--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -20,7 +20,7 @@
 
 namespace Interpreter {
 
-ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) {
+ExitStatusTag execute(std::string const& source, ExecuteSettings settings, Runner* runner) {
 
 	TokenArray const ta = tokenize(source.c_str());
 
@@ -34,7 +34,7 @@ ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) 
 
 	auto cst = parse_result.m_result;
 
-	if (dump_cst)
+	if (settings.dump_cst)
 		print(cst, 1);
 
 	// Can this even happen? parse_program should always either return a
@@ -58,9 +58,7 @@ ExitStatusTag execute(std::string const& source, bool dump_cst, Runner* runner) 
 
 	tc.m_env.compute_declaration_order(static_cast<AST::DeclarationList*>(ast));
 
-	// TODO: expose this flag
-	constexpr bool run_typechecking = true;
-	if (run_typechecking) {
+	if (settings.typecheck) {
 		TypeChecker::metacheck(ast, tc);
 		ast = TypeChecker::ct_eval(ast, tc, ast_allocator);
 		TypeChecker::typecheck(ast, tc);

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -9,6 +9,7 @@
 #include "../match_identifiers.hpp"
 #include "../metacheck.hpp"
 #include "../parser.hpp"
+#include "../symbol_table.hpp"
 #include "../token_array.hpp"
 #include "../typecheck.hpp"
 #include "../typechecker.hpp"
@@ -49,7 +50,11 @@ ExitStatusTag execute(std::string const& source, ExecuteSettings settings, Runne
 	TypeChecker::TypeChecker tc{ast_allocator};
 
 	{
-		auto err = Frontend::match_identifiers(ast, tc.m_builtin_declarations);
+		Frontend::SymbolTable context;
+		for (auto& bucket : tc.m_builtin_declarations.m_buckets)
+			for (auto& decl : bucket)
+				context.declare(&decl);
+		auto err = Frontend::match_identifiers(ast, context);
 		if (!err.ok()) {
 			err.print();
 			return ExitStatusTag::StaticError;
@@ -74,6 +79,7 @@ ExitStatusTag execute(std::string const& source, ExecuteSettings settings, Runne
 
 	return runner_exit_code;
 }
+
 
 // FIXME: This does not handle seq-expressions, or inline definitions of
 // functions, because it does not call `match_identifiers` or `compute_offsets`.

--- a/src/interpreter/execute.hpp
+++ b/src/interpreter/execute.hpp
@@ -10,8 +10,13 @@ struct Value;
 
 using Runner = auto(Interpreter&) -> ExitStatusTag;
 
+struct ExecuteSettings {
+	bool dump_cst {false};
+	bool typecheck {true};
+};
+
 // returns an exit status
-ExitStatusTag execute(std::string const& source, bool dump_ast, Runner* runner);
+ExitStatusTag execute(std::string const& source, ExecuteSettings, Runner* runner);
 
 // evaluates an expression and returns the resulting value
 Value* eval_expression(const std::string& expr, Interpreter& env);

--- a/src/interpreter/execute.hpp
+++ b/src/interpreter/execute.hpp
@@ -3,12 +3,16 @@
 #include "exit_status_tag.hpp"
 #include <string>
 
+namespace Frontend {
+struct SymbolTable;
+}
+
 namespace Interpreter {
 
 struct Interpreter;
 struct Value;
 
-using Runner = auto(Interpreter&) -> ExitStatusTag;
+using Runner = auto(Interpreter&, Frontend::SymbolTable&) -> ExitStatusTag;
 
 struct ExecuteSettings {
 	bool dump_cst {false};
@@ -16,9 +20,17 @@ struct ExecuteSettings {
 };
 
 // returns an exit status
-ExitStatusTag execute(std::string const& source, ExecuteSettings, Runner* runner);
+ExitStatusTag execute(
+	std::string const& source,
+	ExecuteSettings settings,
+	Runner* runner
+);
 
 // evaluates an expression and returns the resulting value
-Value* eval_expression(const std::string& expr, Interpreter& env);
+Value* eval_expression(
+	const std::string& expr,
+	Interpreter& env,
+	Frontend::SymbolTable&
+);
 
 } // namespace Interpreter

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -8,6 +8,7 @@
 #include "../automaton.hpp"
 #include "../cst_allocator.hpp"
 #include "../parser.hpp"
+#include "../symbol_table.hpp"
 #include "../token_array.hpp"
 #include "eval.hpp"
 #include "execute.hpp"
@@ -41,7 +42,10 @@ int main(int argc, char** argv) {
 	Interpreter::ExecuteSettings settings;
 
 	ExitStatusTag exit_code = execute(
-	    source, settings, +[](Interpreter::Interpreter& env) -> ExitStatusTag {
+	    source,
+	    settings,
+	    +[](Interpreter::Interpreter& env,
+	        Frontend::SymbolTable& context) -> ExitStatusTag {
 		    // NOTE: We currently implement funcion evaluation in eval(ASTCallExpression)
 		    // this means we need to create a call expression node to run the program.
 		    // TODO: We need to clean this up

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -38,8 +38,10 @@ int main(int argc, char** argv) {
 
 	std::string source = file_content.str();
 
+	Interpreter::ExecuteSettings settings;
+
 	ExitStatusTag exit_code = execute(
-	    source, false, +[](Interpreter::Interpreter& env) -> ExitStatusTag {
+	    source, settings, +[](Interpreter::Interpreter& env) -> ExitStatusTag {
 		    // NOTE: We currently implement funcion evaluation in eval(ASTCallExpression)
 		    // this means we need to create a call expression node to run the program.
 		    // TODO: We need to clean this up

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "./log/log.hpp"
-#include "./utils/chunked_array.hpp"
 #include "./utils/interned_string.hpp"
 #include "ast.hpp"
 #include "error_report.hpp"
@@ -302,14 +301,6 @@ namespace Frontend {
 #undef DO_NOTHING
 #undef DISPATCH
 	Log::fatal() << "(internal) Unhandled case in match_identifiers '" << ast_string[int(ast->type())] << "'";
-}
-
-ErrorReport match_identifiers(AST::AST* ast, ChunkedArray<AST::Declaration>& builtins) {
-	SymbolTable st;
-	for (auto& bucket : builtins.m_buckets)
-		for (auto& decl : bucket)
-			st.declare(&decl);
-	return match_identifiers(ast, st);
 }
 
 #undef CHECK_AND_RETURN

--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -66,7 +66,9 @@ namespace Frontend {
 	ast->m_declaration = declaration;
 	ast->m_surrounding_function = env.current_function();
 
-	env.current_top_level_declaration()->m_references.insert(declaration);
+	auto top_level_decl = env.current_top_level_declaration();
+	if (top_level_decl)
+		top_level_decl->m_references.insert(declaration);
 
 	if (declaration->is_global()) {
 		ast->m_origin = AST::Identifier::Origin::Global;

--- a/src/match_identifiers.hpp
+++ b/src/match_identifiers.hpp
@@ -7,16 +7,14 @@ struct AST;
 struct Declaration;
 }
 
-template<typename T>
-struct ChunkedArray;
-
 namespace Frontend {
+
+struct SymbolTable;
 
 /*
  * Matches every identifier in the given ast with a declaration.
  * This also includes captures in a closure.
  */
-[[nodiscard]] ErrorReport match_identifiers(
-    AST::AST* ast, ChunkedArray<AST::Declaration>&);
+[[nodiscard]] ErrorReport match_identifiers(AST::AST* ast, SymbolTable&);
 
 } // namespace Frontend

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -10,28 +10,33 @@
 #include "tester.hpp"
 
 #define EQUALS(expr, value)                                                    \
-	+[](Interpreter::Interpreter& env) -> ExitStatusTag {                  \
-		return Assert::equals(eval_expression(expr, env), value);      \
+	+[](Interpreter::Interpreter& env,                                         \
+	    Frontend::SymbolTable& context) -> ExitStatusTag {                     \
+		return Assert::equals(eval_expression(expr, env, context), value);     \
 	}
 
 #define IS_TRUE(expr)                                                          \
-	+[](Interpreter::Interpreter& env) -> ExitStatusTag {                  \
-		return Assert::is_true(eval_expression(expr, env));            \
+	+[](Interpreter::Interpreter& env,                                         \
+	    Frontend::SymbolTable& context) -> ExitStatusTag {                     \
+		return Assert::is_true(eval_expression(expr, env, context));           \
 	}
 
 #define IS_FALSE(expr)                                                         \
-	+[](Interpreter::Interpreter& env) -> ExitStatusTag {                  \
-		return Assert::is_false(eval_expression(expr, env));           \
+	+[](Interpreter::Interpreter& env,                                         \
+	    Frontend::SymbolTable& context) -> ExitStatusTag {                     \
+		return Assert::is_false(eval_expression(expr, env, context));          \
 	}
 
 #define IS_NULL(expr)                                                          \
-	+[](Interpreter::Interpreter& env) -> ExitStatusTag {                  \
-		return Assert::is_null(eval_expression(expr, env));            \
+	+[](Interpreter::Interpreter& env,                                         \
+	    Frontend::SymbolTable& context) -> ExitStatusTag {                     \
+		return Assert::is_null(eval_expression(expr, env, context));           \
 	}
 
-#define ARRAY_OF_SIZE(expr, size)                                              \
-	+[](Interpreter::Interpreter& env) -> ExitStatusTag {                  \
-		return Assert::array_of_size(eval_expression(expr, env), size);\
+#define ARRAY_OF_SIZE(expr, size)                                                \
+	+[](Interpreter::Interpreter& env,                                           \
+	    Frontend::SymbolTable& context) -> ExitStatusTag {                       \
+		return Assert::array_of_size(eval_expression(expr, env, context), size); \
 	}
 
 void interpreter_tests(Test::Tester& tests) {

--- a/src/test/test_set.cpp
+++ b/src/test/test_set.cpp
@@ -1,8 +1,9 @@
 #include <fstream>
 #include <sstream>
 
-#include "test_set.hpp"
 #include "../interpreter/execute.hpp"
+#include "../symbol_table.hpp"
+#include "test_set.hpp"
 
 namespace Test {
 

--- a/src/test/test_set.cpp
+++ b/src/test/test_set.cpp
@@ -32,8 +32,11 @@ TestReport InterpreterTestSet::execute() {
 		while (std::getline(in_fs, line))
 			file_content << line << '\n';
 
+		Interpreter::ExecuteSettings settings;
+		settings.dump_cst = m_dump;
+
 		for (auto* f : m_testers) {
-			ExitStatusTag answer = Interpreter::execute(file_content.str(), m_dump, f);
+			ExitStatusTag answer = Interpreter::execute(file_content.str(), settings, f);
 
 			if (ExitStatusTag::Ok != answer)
 				return {TestStatusTag::Fail};

--- a/src/test/test_set.hpp
+++ b/src/test/test_set.hpp
@@ -10,6 +10,10 @@ namespace Interpreter {
 struct Interpreter;
 }
 
+namespace Frontend {
+struct SymbolTable;
+}
+
 namespace Test {
 
 struct TestSet {
@@ -18,7 +22,7 @@ struct TestSet {
 	virtual ~TestSet() = default;
 };
 
-using Interpret = ExitStatusTag (*)(Interpreter::Interpreter&);
+using Interpret = ExitStatusTag (*)(Interpreter::Interpreter&, Frontend::SymbolTable&);
 
 struct InterpreterTestSet : public TestSet {
 


### PR DESCRIPTION
I did some plumbing so that eval_expression can call match_identifiers. This means that we will sometimes get a nicer error if a test fails.