### PR TITLE
Better xmacros

### DIFF
--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define AST_TAGS                                                         \
+#define AST_TAGS                                                               \
 	X(NumberLiteral)                                                           \
 	X(IntegerLiteral)                                                          \
 	X(StringLiteral)                                                           \

--- a/src/cst_tag.hpp
+++ b/src/cst_tag.hpp
@@ -37,15 +37,11 @@
 	X(StructExpression)
 
 #define X(name) #name,
-constexpr const char* cst_string[] = {
-	CST_TAGS
-};
+constexpr const char* cst_string[] = { CST_TAGS };
 #undef X
 
 #define X(name) name,
-enum class CSTTag {
-	CST_TAGS
-};
+enum class CSTTag { CST_TAGS };
 #undef X
 
 #undef CST_TAGS

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -21,7 +21,7 @@
 
 namespace Interpreter {
 
-ExitStatusTag execute(
+ExitStatus execute(
 	std::string const& source,
 	ExecuteSettings settings,
 	Runner* runner
@@ -33,7 +33,7 @@ ExitStatusTag execute(
 
 	if (not parse_result.ok()) {
 		parse_result.m_error.print();
-		return ExitStatusTag::ParseError;
+		return ExitStatus::ParseError;
 	}
 
 	auto cst = parse_result.m_result;
@@ -44,7 +44,7 @@ ExitStatusTag execute(
 	// Can this even happen? parse_program should always either return a
 	// DeclarationList or an error
 	if (cst->type() != CSTTag::DeclarationList)
-		return ExitStatusTag::TopLevelTypeError;
+		return ExitStatus::TopLevelTypeError;
 
 	AST::Allocator ast_allocator;
 	auto ast = AST::convert_ast(cst, ast_allocator);
@@ -60,7 +60,7 @@ ExitStatusTag execute(
 		auto err = Frontend::match_identifiers(ast, context);
 		if (!err.ok()) {
 			err.print();
-			return ExitStatusTag::StaticError;
+			return ExitStatus::StaticError;
 		}
 	}
 

--- a/src/interpreter/execute.hpp
+++ b/src/interpreter/execute.hpp
@@ -12,7 +12,7 @@ namespace Interpreter {
 struct Interpreter;
 struct Value;
 
-using Runner = auto(Interpreter&, Frontend::SymbolTable&) -> ExitStatusTag;
+using Runner = auto(Interpreter&, Frontend::SymbolTable&) -> ExitStatus;
 
 struct ExecuteSettings {
 	bool dump_cst {false};
@@ -20,7 +20,7 @@ struct ExecuteSettings {
 };
 
 // returns an exit status
-ExitStatusTag execute(
+ExitStatus execute(
 	std::string const& source,
 	ExecuteSettings settings,
 	Runner* runner

--- a/src/interpreter/exit_status_tag.hpp
+++ b/src/interpreter/exit_status_tag.hpp
@@ -1,28 +1,24 @@
 #pragma once
 
-#define EXIT_STATUS_TAGS \
-	X(Ok) \
-\
-	X(ParseError) \
-	X(StaticError) \
-	X(TopLevelTypeError) \
-\
-	X(NullError) \
-	X(TypeError) \
-\
-	X(ValueError) \
+#define EXIT_STATUS_TAGS                                                       \
+	X(Ok)                                                                      \
+                                                                               \
+	X(ParseError)                                                              \
+	X(StaticError)                                                             \
+	X(TopLevelTypeError)                                                       \
+                                                                               \
+	X(NullError)                                                               \
+	X(TypeError)                                                               \
+                                                                               \
+	X(ValueError)                                                              \
 	X(Empty)
 
 #define X(name) #name,
-constexpr const char* exit_status_string[] = {
-	EXIT_STATUS_TAGS
-};
+constexpr const char* exit_status_string[] = {EXIT_STATUS_TAGS};
 #undef X
 
 #define X(name) name,
-enum class ExitStatusTag {
-	EXIT_STATUS_TAGS
-};
+enum class ExitStatusTag { EXIT_STATUS_TAGS };
 #undef X
 
 #undef EXIT_STATUS_TAGS

--- a/src/interpreter/exit_status_tag.hpp
+++ b/src/interpreter/exit_status_tag.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define EXIT_STATUS_TAGS                                                       \
+#define EXIT_STATUS                                                            \
 	X(Ok)                                                                      \
                                                                                \
 	X(ParseError)                                                              \
@@ -14,11 +14,11 @@
 	X(Empty)
 
 #define X(name) #name,
-constexpr const char* exit_status_string[] = {EXIT_STATUS_TAGS};
+constexpr const char* exit_status_string[] = {EXIT_STATUS};
 #undef X
 
 #define X(name) name,
-enum class ExitStatusTag { EXIT_STATUS_TAGS };
+enum class ExitStatus { EXIT_STATUS };
 #undef X
 
-#undef EXIT_STATUS_TAGS
+#undef EXIT_STATUS

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -41,11 +41,11 @@ int main(int argc, char** argv) {
 
 	Interpreter::ExecuteSettings settings;
 
-	ExitStatusTag exit_code = execute(
+	ExitStatus exit_code = execute(
 	    source,
 	    settings,
 	    +[](Interpreter::Interpreter& env,
-	        Frontend::SymbolTable& context) -> ExitStatusTag {
+	        Frontend::SymbolTable& context) -> ExitStatus {
 		    // NOTE: We currently implement funcion evaluation in eval(ASTCallExpression)
 		    // this means we need to create a call expression node to run the program.
 		    // TODO: We need to clean this up
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
 				    std::cout << "(nullptr)\n";
 		    }
 
-		    return ExitStatusTag::Ok;
+		    return ExitStatus::Ok;
 	    });
 
 	return static_cast<int>(exit_code);

--- a/src/interpreter/value_tag.hpp
+++ b/src/interpreter/value_tag.hpp
@@ -22,15 +22,11 @@
 	X(RecordConstructor)
 
 #define X(name) #name,
-constexpr const char* value_string[] = {
-	VALUE_TAGS
-};
+constexpr const char* value_string[] = {VALUE_TAGS};
 #undef X
 
 #define X(name) name,
-enum class ValueTag {
-	VALUE_TAGS
-};
+enum class ValueTag { VALUE_TAGS };
 #undef X
 
 #undef VALUE_TAGS

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -11,146 +11,138 @@
 
 #define EQUALS(expr, value)                                                    \
 	+[](Interpreter::Interpreter& env,                                         \
-	    Frontend::SymbolTable& context) -> ExitStatusTag {                     \
+	    Frontend::SymbolTable& context) -> ExitStatus {                        \
 		return Assert::equals(eval_expression(expr, env, context), value);     \
 	}
 
 #define IS_TRUE(expr)                                                          \
 	+[](Interpreter::Interpreter& env,                                         \
-	    Frontend::SymbolTable& context) -> ExitStatusTag {                     \
+	    Frontend::SymbolTable& context) -> ExitStatus {                        \
 		return Assert::is_true(eval_expression(expr, env, context));           \
 	}
 
 #define IS_FALSE(expr)                                                         \
 	+[](Interpreter::Interpreter& env,                                         \
-	    Frontend::SymbolTable& context) -> ExitStatusTag {                     \
+	    Frontend::SymbolTable& context) -> ExitStatus {                        \
 		return Assert::is_false(eval_expression(expr, env, context));          \
 	}
 
 #define IS_NULL(expr)                                                          \
 	+[](Interpreter::Interpreter& env,                                         \
-	    Frontend::SymbolTable& context) -> ExitStatusTag {                     \
+	    Frontend::SymbolTable& context) -> ExitStatus {                        \
 		return Assert::is_null(eval_expression(expr, env, context));           \
 	}
 
 #define ARRAY_OF_SIZE(expr, size)                                                \
 	+[](Interpreter::Interpreter& env,                                           \
-	    Frontend::SymbolTable& context) -> ExitStatusTag {                       \
+	    Frontend::SymbolTable& context) -> ExitStatus {                          \
 		return Assert::array_of_size(eval_expression(expr, env, context), size); \
 	}
 
 void interpreter_tests(Test::Tester& tests) {
-	using TestCase = Test::InterpreterTestSet;
-	using Testers = std::vector<Test::Interpret>;
+	    using TestCase = Test::InterpreterTestSet;
+	    using Testers = std::vector<Test::Interpret>;
 
-	tests.add_test(std::make_unique<TestCase>(
-	    "tests/basic_op.jp",
-	    Testers {
-	        EQUALS("int_val", 10),
-	        EQUALS("float_val", 3.5),
-	        EQUALS("string_val", "testing."),
-	        EQUALS("int_div", 0),
-	        EQUALS("float_div", 0.5),
-	        IS_TRUE("litt()"),
-	        IS_FALSE("litf()"),
-	        IS_NULL("nullv()"),
-	        EQUALS("pizza()", 13),
-			EQUALS("issue261()", 13),
-	        IS_TRUE("if_else_if()"),
-	        EQUALS("ternary()", 2),
-	        EQUALS("array_access()", 12),
-	        EQUALS("a", 1),
-	        EQUALS("b", 1),
-	        EQUALS("c", 1),
-	        EQUALS("d", 1),
-	        EQUALS("e", -1),
-	        EQUALS("f", -1.1),
-	        EQUALS("g", 1),
-	        EQUALS("h", 1.1),
-	        EQUALS("ternary_disambiguations", 1),
-	    }));
+	    tests.add_test(std::make_unique<TestCase>(
+	        "tests/basic_op.jp",
+	        Testers {
+	            EQUALS("int_val", 10),
+	            EQUALS("float_val", 3.5),
+	            EQUALS("string_val", "testing."),
+	            EQUALS("int_div", 0),
+	            EQUALS("float_div", 0.5),
+	            IS_TRUE("litt()"),
+	            IS_FALSE("litf()"),
+	            IS_NULL("nullv()"),
+	            EQUALS("pizza()", 13),
+	            EQUALS("issue261()", 13),
+	            IS_TRUE("if_else_if()"),
+	            EQUALS("ternary()", 2),
+	            EQUALS("array_access()", 12),
+	            EQUALS("a", 1),
+	            EQUALS("b", 1),
+	            EQUALS("c", 1),
+	            EQUALS("d", 1),
+	            EQUALS("e", -1),
+	            EQUALS("f", -1.1),
+	            EQUALS("g", 1),
+	            EQUALS("h", 1.1),
+	            EQUALS("ternary_disambiguations", 1),
+	        }));
 
-	tests.add_test(std::make_unique<TestCase>(
-	    "tests/function.jp",
-	    Testers {
-	        EQUALS("normal()", 3),
-	        EQUALS("curry()", 42),
-	        EQUALS("I(42)", 42),
-	        EQUALS("capture_order()", "ABCD"),
-	        EQUALS("median_of_three(1,2,3)", 2),
-	        EQUALS("median_of_three(3,2,1)", 2),
-	        EQUALS("median_of_three(10,15,7)", 10),
-	        EQUALS("second(15,7)", 7),
-	        EQUALS("second(7,15)", 15),
-	    }));
+	    tests.add_test(std::make_unique<TestCase>(
+	        "tests/function.jp",
+	        Testers {
+	            EQUALS("normal()", 3),
+	            EQUALS("curry()", 42),
+	            EQUALS("I(42)", 42),
+	            EQUALS("capture_order()", "ABCD"),
+	            EQUALS("median_of_three(1,2,3)", 2),
+	            EQUALS("median_of_three(3,2,1)", 2),
+	            EQUALS("median_of_three(10,15,7)", 10),
+	            EQUALS("second(15,7)", 7),
+	            EQUALS("second(7,15)", 15),
+	        }));
 
-	tests.add_test(std::make_unique<TestCase>("tests/recursion.jp",
-	    Testers {
-	        EQUALS("fib(6)", 8),
-		IS_FALSE("even(11)"),
-		IS_TRUE("odd(15)"),
-		IS_TRUE("even(80)"),
-		IS_FALSE("odd(18)"),
-	        EQUALS("inner()", 2)
-	    }));
+	    tests.add_test(std::make_unique<TestCase>(
+	        "tests/recursion.jp",
+	        Testers {
+	            EQUALS("fib(6)", 8),
+	            IS_FALSE("even(11)"),
+	            IS_TRUE("odd(15)"),
+	            IS_TRUE("even(80)"),
+	            IS_FALSE("odd(18)"),
+	            EQUALS("inner()", 2)}));
 
-	tests.add_test(std::make_unique<TestCase>("tests/loops.jp",
-	    Testers {
-	        EQUALS("for_loop()", 120),
-	        EQUALS("while_loop()", 120)
-	    }));
+	    tests.add_test(std::make_unique<TestCase>(
+	        "tests/loops.jp",
+	        Testers {EQUALS("for_loop()", 120), EQUALS("while_loop()", 120)}));
 
-	tests.add_test(std::make_unique<TestCase>("tests/native.jp",
-	    Testers {
-	        ARRAY_OF_SIZE("append()", 1),
-	        EQUALS("append()[0]", 10),
-	        ARRAY_OF_SIZE("extend()", 1),
-	        EQUALS("extend()[0]", 10),
-	        EQUALS("size_of()", 2),
-	        EQUALS("join()", "10,10")
-	    }));
+	    tests.add_test(std::make_unique<TestCase>(
+	        "tests/native.jp",
+	        Testers {
+	            ARRAY_OF_SIZE("append()", 1),
+	            EQUALS("append()[0]", 10),
+	            ARRAY_OF_SIZE("extend()", 1),
+	            EQUALS("extend()[0]", 10),
+	            EQUALS("size_of()", 2),
+	            EQUALS("join()", "10,10")}));
 
-	tests.add_test(std::make_unique<Test::InterpreterTestSet>("tests/struct.jp",
-	    Testers {
-		EQUALS("access()", "ABCA")
-	    }));
+	    tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	        "tests/struct.jp", Testers {EQUALS("access()", "ABCA")}));
 
-	tests.add_test(std::make_unique<Test::InterpreterTestSet>("tests/typesystem.jp",
-	    Testers {
-	        EQUALS("a", 1),
-	        EQUALS("b", "hello"),
-	        ARRAY_OF_SIZE("c", 2),
-	        ARRAY_OF_SIZE("__invoke()", 3),
-		EQUALS("extract()", 4)
-	    }));
+	    tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	        "tests/typesystem.jp",
+	        Testers {
+	            EQUALS("a", 1),
+	            EQUALS("b", "hello"),
+	            ARRAY_OF_SIZE("c", 2),
+	            ARRAY_OF_SIZE("__invoke()", 3),
+	            EQUALS("extract()", 4)}));
 
-	tests.add_test(std::make_unique<Test::InterpreterTestSet>("tests/union.jp",
-	    Testers {
-	        EQUALS("serialize(from_number(10))", "(number)"),
-		EQUALS("serialize(from_string(\"xxx\"))", "xxx"),
-	        EQUALS("__invoke()", 3),
-		EQUALS("capture_inner()", 10)
-	    }));
+	    tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	        "tests/union.jp",
+	        Testers {
+	            EQUALS("serialize(from_number(10))", "(number)"),
+	            EQUALS("serialize(from_string(\"xxx\"))", "xxx"),
+	            EQUALS("__invoke()", 3),
+	            EQUALS("capture_inner()", 10)}));
 
-	tests.add_test(std::make_unique<Test::InterpreterTestSet>("tests/full_union.jp",
-	    Testers {
-	        EQUALS("__invoke()", 11)
-	    }));
+	    tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	        "tests/full_union.jp", Testers {EQUALS("__invoke()", 11)}));
 
-	tests.add_test(std::make_unique<Test::InterpreterTestSet>("tests/simple_language.jp",
-	    Testers {
-	        EQUALS("__invoke()", 42)
-	    }));
+	    tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	        "tests/simple_language.jp", Testers {EQUALS("__invoke()", 42)}));
 
-	tests.add_test(std::make_unique<Test::InterpreterTestSet>(
-	    "tests/seq_expressions.jp",
-	    Testers {
-	        EQUALS("return_const", 31415),
-	        EQUALS("return_call", 42),
-	        EQUALS("issue232_1()", 6),
-	        EQUALS("issue232_2()", 7),
-	        EQUALS("issue240_1", 10),
-	        EQUALS("issue240_2", 8)}));
+	    tests.add_test(std::make_unique<Test::InterpreterTestSet>(
+	        "tests/seq_expressions.jp",
+	        Testers {
+	            EQUALS("return_const", 31415),
+	            EQUALS("return_call", 42),
+	            EQUALS("issue232_1()", 6),
+	            EQUALS("issue232_2()", 7),
+	            EQUALS("issue240_1", 10),
+	            EQUALS("issue240_2", 8)}));
 }
 
 void tarjan_algorithm_tests(Test::Tester& tester) {

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -167,10 +167,10 @@ void tarjan_algorithm_tests(Test::Tester& tester) {
 
 		        if (cov[0] != cov[1] || cov[0] != cov[2])
 			        return {
-			            TestStatusTag::Fail,
+			            TestStatus::Fail,
 			            "All vertices in a 3-cycle should be in the same SCC"};
 
-		        return {TestStatusTag::Ok};
+		        return {TestStatus::Ok};
 	        },
 	        +[]() -> TestReport {
 		        TarjanSolver solver(2);
@@ -179,14 +179,14 @@ void tarjan_algorithm_tests(Test::Tester& tester) {
 
 		        auto const& cov = solver.component_of_vertices();
 		        if (cov[0] == cov[1])
-			        return {TestStatusTag::Fail, "Vertices that are only weakly connected should not be in the same SCC"};
+			        return {TestStatus::Fail, "Vertices that are only weakly connected should not be in the same SCC"};
 
 		        if (cov[0] < cov[1])
 			        return {
-			            TestStatusTag::Fail,
+			            TestStatus::Fail,
 			            "SCCs should be in reverse topological sort."};
 
-		        return {TestStatusTag::Ok};
+		        return {TestStatus::Ok};
 	        }}));
 }
 
@@ -200,18 +200,18 @@ void string_set_tests(Test::Tester& tester) {
 		    StringSet s;
 		    s.insert("AAA");
 		    if (!s.includes("AAA"))
-			    return {TestStatusTag::Fail, "AAA is not in the set after inserting it"};
+			    return {TestStatus::Fail, "AAA is not in the set after inserting it"};
 
 		    s.insert("BBB");
 		    if (!s.includes("AAA"))
 			    return {
-			        TestStatusTag::Fail,
+			        TestStatus::Fail,
 			        "AAA is no longer in the set after inserting BBB"};
 
 		    if (!s.includes("BBB"))
-			    return {TestStatusTag::Fail, "BBB is not in the set after inserting it"};
+			    return {TestStatus::Fail, "BBB is not in the set after inserting it"};
 
-		    return {TestStatusTag::Ok};
+		    return {TestStatus::Ok};
 	    }}));
 }
 
@@ -222,7 +222,7 @@ int main() {
 	string_set_tests(tests);
 	interpreter_tests(tests);
 	auto test_result = tests.execute();
-	if (test_result.m_code != TestStatusTag::Ok)
+	if (test_result.m_code != TestStatus::Ok)
 		return 1;
 	return 0;
 }

--- a/src/test/test_set.cpp
+++ b/src/test/test_set.cpp
@@ -20,12 +20,12 @@ InterpreterTestSet::InterpreterTestSet(std::string s, std::vector<Interpret> tfs
 
 TestReport InterpreterTestSet::execute() {
 	if (m_testers.empty())
-		return {TestStatusTag::Empty};
+		return {TestStatus::Empty};
 
 	try {
 		std::ifstream in_fs(m_source_file);
 		if (!in_fs.good())
-			return {TestStatusTag::MissingFile};
+			return {TestStatus::MissingFile};
 
 		std::stringstream file_content;
 		std::string line;
@@ -40,13 +40,13 @@ TestReport InterpreterTestSet::execute() {
 			ExitStatusTag answer = Interpreter::execute(file_content.str(), settings, f);
 
 			if (ExitStatusTag::Ok != answer)
-				return {TestStatusTag::Fail};
+				return {TestStatus::Fail};
 		}
 	} catch (const std::exception& e) {
-		return {TestStatusTag::Error, e.what()};
+		return {TestStatus::Error, e.what()};
 	}
 
-	return {TestStatusTag::Ok};
+	return {TestStatus::Ok};
 }
 
 NormalTestSet::NormalTestSet() {}
@@ -59,21 +59,21 @@ NormalTestSet::NormalTestSet(std::vector<TestFunction> testers)
 
 TestReport NormalTestSet::execute() {
 	if (m_testers.empty())
-		return {TestStatusTag::Empty};
+		return {TestStatus::Empty};
 
 	try {
 		for (auto* test : m_testers) {
 			auto report = test();
 
 			// FUTURE: Accumulate failed tests
-			if (report.m_code != TestStatusTag::Ok)
+			if (report.m_code != TestStatus::Ok)
 				return report;
 		}
 	} catch (std::exception const& e) {
-		return {TestStatusTag::Error, e.what()};
+		return {TestStatus::Error, e.what()};
 	}
 
-	return {TestStatusTag::Ok};
+	return {TestStatus::Ok};
 }
 
 } // namespace Test

--- a/src/test/test_set.cpp
+++ b/src/test/test_set.cpp
@@ -37,9 +37,9 @@ TestReport InterpreterTestSet::execute() {
 		settings.dump_cst = m_dump;
 
 		for (auto* f : m_testers) {
-			ExitStatusTag answer = Interpreter::execute(file_content.str(), settings, f);
+			ExitStatus answer = Interpreter::execute(file_content.str(), settings, f);
 
-			if (ExitStatusTag::Ok != answer)
+			if (ExitStatus::Ok != answer)
 				return {TestStatus::Fail};
 		}
 	} catch (const std::exception& e) {

--- a/src/test/test_set.hpp
+++ b/src/test/test_set.hpp
@@ -22,7 +22,7 @@ struct TestSet {
 	virtual ~TestSet() = default;
 };
 
-using Interpret = ExitStatusTag (*)(Interpreter::Interpreter&, Frontend::SymbolTable&);
+using Interpret = ExitStatus (*)(Interpreter::Interpreter&, Frontend::SymbolTable&);
 
 struct InterpreterTestSet : public TestSet {
 

--- a/src/test/test_status_tag.hpp
+++ b/src/test/test_status_tag.hpp
@@ -1,22 +1,18 @@
 #pragma once
 
-#define TEST_STATUS_TAGS \
-	X(Ok) \
-	X(Error) \
-	X(Fail) \
-	X(Empty) \
+#define TEST_STATUS_TAGS                                                       \
+	X(Ok)                                                                      \
+	X(Error)                                                                   \
+	X(Fail)                                                                    \
+	X(Empty)                                                                   \
 	X(MissingFile)
 
 #define X(name) #name,
-constexpr const char* test_status_string[] = {
-	TEST_STATUS_TAGS
-};
+constexpr const char* test_status_string[] = {TEST_STATUS_TAGS};
 #undef X
 
 #define X(name) name,
-enum class TestStatusTag {
-	TEST_STATUS_TAGS
-};
+enum class TestStatusTag { TEST_STATUS_TAGS };
 #undef X
 
 #undef TEST_STATUS_TAGS

--- a/src/test/test_status_tag.hpp
+++ b/src/test/test_status_tag.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define TEST_STATUS_TAGS                                                       \
+#define TEST_STATUS                                                            \
 	X(Ok)                                                                      \
 	X(Error)                                                                   \
 	X(Fail)                                                                    \
@@ -8,16 +8,16 @@
 	X(MissingFile)
 
 #define X(name) #name,
-constexpr const char* test_status_string[] = {TEST_STATUS_TAGS};
+constexpr const char* test_status_string[] = {TEST_STATUS};
 #undef X
 
 #define X(name) name,
-enum class TestStatusTag { TEST_STATUS_TAGS };
+enum class TestStatus { TEST_STATUS };
 #undef X
 
-#undef TEST_STATUS_TAGS
+#undef TEST_STATUS
 
 struct TestReport {
-	TestStatusTag m_code;
+	TestStatus m_code;
 	std::string m_msg;
 };

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -8,72 +8,72 @@
 
 namespace Assert {
 
-ExitStatusTag of_type(Interpreter::Value* rv, ValueTag v_type) {
+ExitStatus of_type(Interpreter::Value* rv, ValueTag v_type) {
 
 	if (!rv)
-		return ExitStatusTag::NullError;
+		return ExitStatus::NullError;
 
 	if (rv->type() != v_type)
-		return ExitStatusTag::TypeError;
+		return ExitStatus::TypeError;
 
-	return ExitStatusTag::Ok;
+	return ExitStatus::Ok;
 }
 
 template <typename RuntimeValue, typename NativeValue>
-ExitStatusTag scalar_equals(
+ExitStatus scalar_equals(
     Interpreter::Value* rv, const ValueTag v_type, const NativeValue& expected) {
-	ExitStatusTag fail = of_type(rv, v_type);
+	ExitStatus fail = of_type(rv, v_type);
 
-	if (ExitStatusTag::Ok != fail)
+	if (ExitStatus::Ok != fail)
 		return fail;
 
 	if ((static_cast<RuntimeValue*>(rv))->m_value != expected)
-		return ExitStatusTag::ValueError;
+		return ExitStatus::ValueError;
 
-	return ExitStatusTag::Ok;
+	return ExitStatus::Ok;
 }
 
-ExitStatusTag equals(Interpreter::Value* rv, std::string const& expected) {
+ExitStatus equals(Interpreter::Value* rv, std::string const& expected) {
 	return scalar_equals<Interpreter::String, std::string>(
 	    rv, ValueTag::String, expected);
 }
 
-ExitStatusTag equals(Interpreter::Value* rv, int expected) {
+ExitStatus equals(Interpreter::Value* rv, int expected) {
 	return scalar_equals<Interpreter::Integer, int>(
 	    rv, ValueTag::Integer, expected);
 }
 
-ExitStatusTag equals(Interpreter::Value* rv, float expected) {
+ExitStatus equals(Interpreter::Value* rv, float expected) {
 	return scalar_equals<Interpreter::Float, float>(rv, ValueTag::Float, expected);
 }
 
 // NOTE: allows literals to be used (e.g. 3.5), may need to change in the future?
-ExitStatusTag equals(Interpreter::Value* rv, double expected) {
+ExitStatus equals(Interpreter::Value* rv, double expected) {
 	return equals(rv, float(expected));
 }
 
-ExitStatusTag is_true(Interpreter::Value* rv) {
+ExitStatus is_true(Interpreter::Value* rv) {
 	return scalar_equals<Interpreter::Boolean, bool>(rv, ValueTag::Boolean, true);
 }
 
-ExitStatusTag is_false(Interpreter::Value* rv) {
+ExitStatus is_false(Interpreter::Value* rv) {
 	return scalar_equals<Interpreter::Boolean, bool>(rv, ValueTag::Boolean, false);
 }
 
-ExitStatusTag is_null(Interpreter::Value* rv) {
+ExitStatus is_null(Interpreter::Value* rv) {
 	return of_type(rv, ValueTag::Null);
 }
 
-ExitStatusTag array_of_size(Interpreter::Value* rv, unsigned int size) {
-	ExitStatusTag fail = of_type(rv, ValueTag::Array);
+ExitStatus array_of_size(Interpreter::Value* rv, unsigned int size) {
+	ExitStatus fail = of_type(rv, ValueTag::Array);
 
-	if (ExitStatusTag::Ok != fail)
+	if (ExitStatus::Ok != fail)
 		return fail;
 
 	if ((static_cast<Interpreter::Array*>(rv))->m_value.size() != size)
-		return ExitStatusTag::ValueError;
+		return ExitStatus::ValueError;
 
-	return ExitStatusTag::Ok;
+	return ExitStatus::Ok;
 }
 
 } // namespace Assert

--- a/src/test/tester.cpp
+++ b/src/test/tester.cpp
@@ -29,30 +29,30 @@ void Tester::add_tests(std::vector<Own<TestSet>> tss) {
 TestReport Tester::execute() {
 	std::vector<std::string> reports;
 
-	auto veredict = TestStatusTag::Ok;
+	auto veredict = TestStatus::Ok;
 
 	for (int i = 0; i < m_test_sets.size(); ++i) {
 		TestReport ts_answer = m_test_sets[i]->execute();
 
 		switch (ts_answer.m_code) {
-		case TestStatusTag::Ok:
+		case TestStatus::Ok:
 			std::cout << '.';
 			break;
-		case TestStatusTag::Error:
-			veredict = TestStatusTag::Error;
+		case TestStatus::Error:
+			veredict = TestStatus::Error;
 			std::cout << 'E';
 			break;
-		case TestStatusTag::Fail:
-			if (veredict != TestStatusTag::Error)
-				veredict = TestStatusTag::Fail;
+		case TestStatus::Fail:
+			if (veredict != TestStatus::Error)
+				veredict = TestStatus::Fail;
 			std::cout << 'F';
 			break;
-		case TestStatusTag::Empty:
-			if (veredict != TestStatusTag::Error && veredict != TestStatusTag::Fail)
-				veredict = TestStatusTag::Empty;
+		case TestStatus::Empty:
+			if (veredict != TestStatus::Error && veredict != TestStatus::Fail)
+				veredict = TestStatus::Empty;
 			std::cout << 'R';
 			break;
-		case TestStatusTag::MissingFile:
+		case TestStatus::MissingFile:
 			std::cout << '?';
 			break;
 		default:

--- a/src/token_tag.hpp
+++ b/src/token_tag.hpp
@@ -1,171 +1,81 @@
 #pragma once
 
+#define TOKEN_TAGS                                                             \
+	X(ADD, "+")                                                                \
+	X(SUB, "-")                                                                \
+	X(DIV, "/")                                                                \
+	X(MUL, "*")                                                                \
+	X(AND, "&")                                                                \
+	X(IOR, "|")                                                                \
+	X(XOR, "^")                                                                \
+	X(LT, "<")                                                                 \
+	X(GT, ">")                                                                 \
+	X(LTE, "<=")                                                               \
+	X(GTE, ">=")                                                               \
+	X(COMPL, "COMPL")                                                          \
+	X(LOGIC_COMPL, "LOGIC_COMPL")                                              \
+	X(LOGIC_AND, "LOGIC_AND")                                                  \
+	X(LOGIC_IOR, "LOGIC_IOR")                                                  \
+	X(EQUAL, "==")                                                             \
+	X(NOT_EQUAL, "!=")                                                         \
+	X(ASSIGN, "=")                                                             \
+	X(DECLARE_ASSIGN, ":=")                                                    \
+	X(DECLARE, ":")                                                            \
+	X(INCREMENT, "INCREMENT")                                                  \
+	X(DECREMENT, "DECREMENT")                                                  \
+	X(ADD_TO, "ADD_TO")                                                        \
+	X(SUB_TO, "SUB_TO")                                                        \
+	X(MUL_TO, "MUL_TO")                                                        \
+	X(DIV_TO, "DIV_TO")                                                        \
+	X(AND_TO, "AND_TO")                                                        \
+	X(IOR_TO, "IOR_TO")                                                        \
+	X(XOR_TO, "XOR_TO")                                                        \
+	X(AT, "AT")                                                                \
+	X(DOT, "DOT")                                                              \
+	X(COMMA, "COMMA")                                                          \
+	X(PIZZA, "PIZZA")                                                          \
+	X(ARROW, "ARROW")                                                          \
+	X(BRACE_OPEN, "BRACE_OPEN")                                                \
+	X(BRACKET_OPEN, "BRACKET_OPEN")                                            \
+	X(PAREN_OPEN, "PAREN_OPEN")                                                \
+	X(POLY_OPEN, "POLY_OPEN")                                                  \
+	X(BRACE_CLOSE, "BRACE_CLOSE")                                              \
+	X(BRACKET_CLOSE, "BRACKET_CLOSE")                                          \
+	X(PAREN_CLOSE, "PAREN_CLOSE")                                              \
+	X(POLY_CLOSE, "POLY_CLOSE")                                                \
+	X(SEMICOLON, "SEMICOLON")                                                  \
+	X(COLON, "COLON")                                                          \
+	X(NUMBER, "NUMBER")                                                        \
+	X(INTEGER, "INTEGER")                                                      \
+	X(STRING, "STRING")                                                        \
+	X(KEYWORD_FALSE, "KEYWORD_FALSE")                                          \
+	X(KEYWORD_TRUE, "KEYWORD_TRUE")                                            \
+	X(KEYWORD_NULL, "KEYWORD_NULL")                                            \
+	X(IDENTIFIER, "IDENTIFIER")                                                \
+	X(KEYWORD, "KEYWORD")                                                      \
+	X(KEYWORD_FN, "KEYWORD_FN")                                                \
+	X(KEYWORD_ARRAY, "KEYWORD_ARRAY")                                          \
+	X(KEYWORD_RETURN, "KEYWORD_RETURN")                                        \
+	X(KEYWORD_IF, "KEYWORD_IF")                                                \
+	X(KEYWORD_THEN, "KEYWORD_THEN")                                            \
+	X(KEYWORD_ELSE, "KEYWORD_ELSE")                                            \
+	X(KEYWORD_FOR, "KEYWORD_FOR")                                              \
+	X(KEYWORD_WHILE, "KEYWORD_WHILE")                                          \
+	X(KEYWORD_MATCH, "KEYWORD_MATCH")                                          \
+	X(KEYWORD_SEQ, "KEYWORD_SEQ")                                              \
+	X(KEYWORD_UNION, "KEYWORD_UNION")                                          \
+	X(KEYWORD_TUPLE, "KEYWORD_TUPLE")                                          \
+	X(KEYWORD_STRUCT, "KEYWORD_STRUCT")                                        \
+	X(END, "(end of file)")
+
 /* printable representation */
-constexpr const char* token_string[] = {
-	"+",
-	"-",
-	"/",
-	"*",
-	"&",
-	"|",
-	"^",
-
-	"<",
-	">",
-	"<=",
-	">=",
-
-	"COMPL",
-
-	"LOGIC_COMPL",
-	"LOGIC_AND",
-	"LOGIC_IOR",
-
-	"==",
-	"!=",
-
-	"=",
-	":=",
-	":",
-
-	"INCREMENT",
-	"DECREMENT",
-
-	"ADD_TO",
-	"SUB_TO",
-	"MUL_TO",
-	"DIV_TO",
-	"AND_TO",
-	"IOR_TO",
-	"XOR_TO",
-
-	"AT",
-	"DOT",
-	"COMMA",
-	"PIZZA",
-	"ARROW",
-
-	"BRACE_OPEN",
-	"BRACKET_OPEN",
-	"PAREN_OPEN",
-	"POLY_OPEN",
-
-	"BRACE_CLOSE",
-	"BRACKET_CLOSE",
-	"PAREN_CLOSE",
-	"POLY_CLOSE",
-
-	"SEMICOLON",
-	"COLON",
-
-	"NUMBER",
-	"INTEGER",
-	"STRING",
-	"KEYWORD_FALSE",
-	"KEYWORD_TRUE",
-	"KEYWORD_NULL",
-	"IDENTIFIER",
-	"KEYWORD",
-
-	"KEYWORD_FN",
-	"KEYWORD_ARRAY",
-	"KEYWORD_RETURN",
-	"KEYWORD_IF",
-	"KEYWORD_THEN",
-	"KEYWORD_ELSE",
-	"KEYWORD_FOR",
-	"KEYWORD_WHILE",
-	"KEYWORD_MATCH",
-	"KEYWORD_SEQ",
-
-	"KEYWORD_UNION",
-	"KEYWORD_TUPLE",
-	"KEYWORD_STRUCT",
-
-	"END",
-};
+#define X(name, str) str,
+constexpr const char* token_string[] = {TOKEN_TAGS};
+#undef X
 
 /* internal representation */
-enum class TokenTag {
-	ADD,
-	SUB,
-	DIV,
-	MUL,
-	AND,
-	IOR,
-	XOR,
+#define X(name, str) name,
+enum class TokenTag { TOKEN_TAGS };
+#undef X
 
-	LT,
-	GT,
-	LTE,
-	GTE,
-
-	COMPL,
-
-	LOGIC_COMPL,
-	LOGIC_AND,
-	LOGIC_IOR,
-
-	EQUAL,
-	NOT_EQUAL,
-
-	ASSIGN,
-	DECLARE_ASSIGN,
-	DECLARE,
-
-	INCREMENT,
-	DECREMENT,
-
-	ADD_TO,
-	SUB_TO,
-	MUL_TO,
-	DIV_TO,
-	AND_TO,
-	IOR_TO,
-	XOR_TO,
-
-	AT,
-	DOT,
-	COMMA,
-	PIZZA,
-	ARROW,
-
-	BRACE_OPEN,
-	BRACKET_OPEN,
-	PAREN_OPEN,
-	POLY_OPEN,
-
-	BRACE_CLOSE,
-	BRACKET_CLOSE,
-	PAREN_CLOSE,
-	POLY_CLOSE,
-
-	SEMICOLON,
-	COLON,
-
-	NUMBER,
-	INTEGER,
-	STRING,
-	KEYWORD_FALSE,
-	KEYWORD_TRUE,
-	KEYWORD_NULL,
-	IDENTIFIER,
-	KEYWORD,
-
-	KEYWORD_FN,
-	KEYWORD_ARRAY,
-	KEYWORD_RETURN,
-	KEYWORD_IF,
-	KEYWORD_THEN,
-	KEYWORD_ELSE,
-	KEYWORD_FOR,
-	KEYWORD_WHILE,
-	KEYWORD_MATCH,
-	KEYWORD_SEQ,
-
-	KEYWORD_UNION,
-	KEYWORD_TUPLE,
-	KEYWORD_STRUCT,
-
-	END,
-};
+#undef TOKEN_TAGS


### PR DESCRIPTION
While making the new lexer, I noticed we can use X-macros with multiple fields. So, I figured I would apply this newfound knowledge to the codebase.

I also renamed `ExitStatusTag` to `ExitStatus`, as it is not a tag (in the sense that we don't use it to discriminate between members of a sum type). Same thing for `TestStatusTag`