### PR TITLE
Put scalar values directly on the stack

### DIFF
--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -229,10 +229,10 @@ void eval(AST::TernaryExpression* ast, Interpreter& e) {
 	// TODO: proper error handling
 
 	eval(ast->m_condition, e);
-	auto condition_ptr = e.m_stack.pop_unsafe();
-	auto* condition = value_as<Boolean>(condition_ptr);
+	auto condition_handle = value_of(e.m_stack.pop_unsafe());
+	auto condition = condition_handle.as_boolean; // FIXME: assert on correct type
 
-	if (condition->m_value)
+	if (condition)
 		eval(ast->m_then_expr, e);
 	else
 		eval(ast->m_else_expr, e);
@@ -345,6 +345,8 @@ void eval(AST::ConstructorExpression* ast, Interpreter& e) {
 
 void eval(AST::SequenceExpression* ast, Interpreter& e) {
 	eval(ast->m_body, e);
+	if (!e.m_returning)
+		e.save_return_value(Handle {});
 	e.m_stack.push(e.fetch_return_value());
 }
 
@@ -352,10 +354,10 @@ void eval(AST::IfElseStatement* ast, Interpreter& e) {
 	// TODO: proper error handling
 
 	eval(ast->m_condition, e);
-	auto condition_handle = e.m_stack.pop_unsafe();
-	auto* condition = value_as<Boolean>(condition_handle.get());
+	auto condition_handle = value_of(e.m_stack.pop_unsafe());
+	bool condition = condition_handle.as_boolean; // FIXME: assert on correct type
 
-	if (condition->m_value)
+	if (condition)
 		eval_stmt(ast->m_body, e);
 	else if (ast->m_else_body)
 		eval_stmt(ast->m_else_body, e);
@@ -364,10 +366,10 @@ void eval(AST::IfElseStatement* ast, Interpreter& e) {
 void eval(AST::WhileStatement* ast, Interpreter& e) {
 	while (1) {
 		eval(ast->m_condition, e);
-		auto condition_handle = e.m_stack.pop_unsafe();
-		auto* condition = value_as<Boolean>(condition_handle.get());
+		auto condition_handle = value_of(e.m_stack.pop_unsafe());
+		auto condition = condition_handle.as_boolean; // FIXME: assert on correct type
 
-		if (!condition->m_value)
+		if (!condition)
 			break;
 
 		eval_stmt(ast->m_body, e);

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -133,7 +133,7 @@ void eval(AST::ReturnStatement* ast, Interpreter& e) {
 	// TODO: proper error handling
 	eval(ast->m_value, e);
 	auto value = e.m_stack.pop_unsafe();
-	e.save_return_value(value_of(value).get());
+	e.save_return_value(value_of(value));
 };
 
 auto is_callable_value(Value* v) -> bool {

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -29,7 +29,7 @@ static void eval_stmt(AST::AST* ast, Interpreter& e) {
 }
 
 void eval(AST::Declaration* ast, Interpreter& e) {
-	auto ref = e.new_reference(e.null());
+	auto ref = e.new_reference(nullptr);
 	e.m_stack.push(ref.handle());
 	if (ast->m_value) {
 		eval(ast->m_value, e);
@@ -158,11 +158,9 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 			// put arg on stack
 			eval(expr, e);
 
-			// create ref to arg
+			// wrap arg in reference
 			auto ref = e.new_reference(nullptr);
 			ref->m_value = value_of(e.m_stack.access(0));
-
-			// put ref on stack
 			e.m_stack.access(0) = ref.handle();
 		}
 		e.m_stack.start_stack_frame(frame_start);

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -201,7 +201,7 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 			eval(expr, e);
 		e.m_stack.start_stack_frame(frame_start);
 		auto args = e.m_stack.frame_range(0, arg_count);
-		e.m_stack.frame_at(-1) = Handle{callee.get_cast<NativeFunction>()->m_fptr(args, e)};
+		e.m_stack.frame_at(-1) = callee.get_cast<NativeFunction>()->m_fptr(args, e);
 	} else {
 		Log::fatal("Attempted to call a non function at runtime");
 	}

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -313,7 +313,7 @@ void eval(AST::ConstructorExpression* ast, Interpreter& e) {
 		RecordType record;
 		for (int i = 0; i < ast->m_args.size(); ++i) {
 			record[record_constructor->m_keys[i]] =
-			    value_of(e.m_stack.m_stack[storage_point + i].get());
+			    value_of(e.m_stack.m_stack[storage_point + i]);
 		}
 		
 		// promote record object to heap
@@ -386,7 +386,7 @@ void eval(AST::UnionExpression* ast, Interpreter& e) {
 	RecordType constructors;
 	for(auto& constructor : ast->m_constructors) {
 		constructors.insert(
-		    {constructor, e.m_gc->new_variant_constructor_raw(constructor)});
+		    {constructor, Handle{e.m_gc->new_variant_constructor_raw(constructor)}});
 	}
 	auto result = e.new_record(std::move(constructors));
 	e.m_stack.push(result.handle());

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -345,7 +345,6 @@ void eval(AST::ConstructorExpression* ast, Interpreter& e) {
 
 void eval(AST::SequenceExpression* ast, Interpreter& e) {
 	eval(ast->m_body, e);
-	assert(e.m_return_value.get());
 	e.m_stack.push(e.fetch_return_value());
 }
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -170,7 +170,7 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 	eval(ast->m_callee, e);
 
 	// NOTE: keep callee on the stack
-	auto callee = value_of(e.m_stack.access_(0));
+	auto callee = value_of(e.m_stack.access(0));
 	assert(is_callable_value(callee.get()));
 
 	auto& arglist = ast->m_args;
@@ -188,7 +188,7 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 
 			// create ref to arg
 			auto ref_handle = e.new_reference(nullptr);
-			ref_handle->m_value = value_of(e.m_stack.access_(0));
+			ref_handle->m_value = value_of(e.m_stack.access(0));
 
 			// stack:
 			// ... | &arg |
@@ -196,7 +196,7 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 			//            ref~~^
 
 			// put ref on stack
-			e.m_stack.access_(0) = Handle{ref_handle.get()};
+			e.m_stack.access(0) = Handle{ref_handle.get()};
 
 			// stack:
 			// ... | &ref |
@@ -273,7 +273,7 @@ void eval(AST::MatchExpression* ast, Interpreter& e) {
 	// Put the matched-on variant on the top of the stack
 	eval(&ast->m_matchee, e);
 
-	auto variant = value_as<Variant>(e.m_stack.access_(0).get());
+	auto variant = value_as<Variant>(e.m_stack.access(0).get());
 
 	auto constructor = variant->m_constructor;
 	auto variant_value = variant->m_inner_value;
@@ -281,7 +281,7 @@ void eval(AST::MatchExpression* ast, Interpreter& e) {
 	// We won't pop it, because it is already lined up for the later
 	// expressions. Instead, replace the variant with its inner value.
 	// We also wrap it in a reference so it can be captured
-	e.m_stack.access_(0) = Handle{rewrap(variant_value, e).get()};
+	e.m_stack.access(0) = Handle{rewrap(variant_value, e).get()};
 	
 	auto case_it = ast->m_cases.find(constructor);
 	// TODO: proper error handling
@@ -292,7 +292,7 @@ void eval(AST::MatchExpression* ast, Interpreter& e) {
 
 	// evil tinkering with the stack internals
 	// (we just delete the variant value from behind the result)
-	e.m_stack.access_(1) = e.m_stack.access_(0);
+	e.m_stack.access(1) = e.m_stack.access(0);
 	e.m_stack.pop_unsafe();
 }
 
@@ -300,7 +300,7 @@ void eval(AST::ConstructorExpression* ast, Interpreter& e) {
 	// NOTE: we leave the ctor on the stack for the time being
 
 	eval(ast->m_constructor, e);
-	auto constructor_ptr = e.m_stack.access_(0);
+	auto constructor_ptr = e.m_stack.access(0);
 	auto constructor = value_of(constructor_ptr).get();
 
 	if (constructor->type() == ValueTag::RecordConstructor) {
@@ -333,7 +333,7 @@ void eval(AST::ConstructorExpression* ast, Interpreter& e) {
 			e.m_stack.pop_unsafe();
 
 		// replace ctor with record
-		e.m_stack.access_(0) = Handle{result.get()};
+		e.m_stack.access(0) = Handle{result.get()};
 	} else if (constructor->type() == ValueTag::VariantConstructor) {
 		auto variant_constructor = static_cast<VariantConstructor*>(constructor);
 
@@ -344,10 +344,10 @@ void eval(AST::ConstructorExpression* ast, Interpreter& e) {
 
 		eval(ast->m_args[0], e);
 		auto result = e.m_gc->new_variant(
-		    variant_constructor->m_constructor, value_of(e.m_stack.access_(0)).get());
+		    variant_constructor->m_constructor, value_of(e.m_stack.access(0)).get());
 
 		// replace ctor with variant, and pop value
-		e.m_stack.access_(1) = Handle{result.get()};
+		e.m_stack.access(1) = Handle{result.get()};
 		e.m_stack.pop_unsafe();
 	}
 }

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -16,15 +16,6 @@
 
 namespace Interpreter {
 
-Handle value_of(Handle h) {
-	return Handle{value_of(h.get())};
-}
-
-template<typename T>
-T* value_as(Handle h) {
-	return value_as<T>(h.get());
-}
-
 static bool is_expression (AST::AST* ast) {
 	auto tag = ast->type();
 	auto tag_idx = static_cast<int>(tag);

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -162,7 +162,7 @@ void eval_call_function(gc_ptr<Function> callee, int arg_count, Interpreter& e) 
 	//              ^~~ frame ptr
 
 	// pop the result, and clobber the callee
-	e.m_stack.frame_at_(-1) = e.m_stack.pop_unsafe();
+	e.m_stack.frame_at(-1) = e.m_stack.pop_unsafe();
 }
 
 void eval(AST::CallExpression* ast, Interpreter& e) {
@@ -210,7 +210,7 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 			eval(expr, e);
 		e.m_stack.start_stack_frame(frame_start);
 		auto args = e.m_stack.frame_range(0, arg_count);
-		e.m_stack.frame_at(-1) = callee.get_cast<NativeFunction>()->m_fptr(args, e);
+		e.m_stack.frame_at(-1) = Handle{callee.get_cast<NativeFunction>()->m_fptr(args, e)};
 	} else {
 		Log::fatal("Attempted to call a non function at runtime");
 	}
@@ -255,7 +255,7 @@ void eval(AST::FunctionLiteral* ast, Interpreter& e) {
 		assert(capture.second.outer_frame_offset != INT_MIN);
 		auto value = e.m_stack.frame_at(capture.second.outer_frame_offset);
 		auto offset = capture.second.inner_frame_offset - ast->m_args.size();
-		captures[offset] = as<Reference>(value);
+		captures[offset] = as<Reference>(value.get());
 	}
 
 	auto result = e.new_function(ast, std::move(captures));

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -38,7 +38,7 @@ void eval(AST::Declaration* ast, Interpreter& e) {
 	if (ast->m_value) {
 		eval(ast->m_value, e);
 		auto value = e.m_stack.pop();
-		ref->m_value = value_of(value.get());
+		ref->m_value = Handle{value_of(value.get())};
 	}
 };
 
@@ -50,7 +50,7 @@ void eval(AST::DeclarationList* ast, Interpreter& e) {
 			e.global_declare_direct(decl->identifier_text(), ref.get());
 			eval(decl->m_value, e);
 			auto value = e.m_stack.pop();
-			ref->m_value = value_of(value.get());
+			ref->m_value = Handle{value_of(value.get())};
 		}
 	}
 }

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -116,7 +116,7 @@ Value* eval_expression(
 	// TODO?: return a gc_ptr
 	eval(ast, env);
 	auto value = env.m_stack.pop_unsafe();
-	return value_of(value);
+	return value_of(value.get());
 }
 
 } // namespace Interpreter

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -88,7 +88,7 @@ ExitStatus execute(
 // Note that we can't just call match_identifiers, because that wouldn't take
 // into account the rest of the program that's already been processed, before
 // this is run
-Value* eval_expression(
+Handle eval_expression(
 	const std::string& expr,
 	Interpreter& env,
 	Frontend::SymbolTable& context
@@ -116,7 +116,7 @@ Value* eval_expression(
 	// TODO?: return a gc_ptr
 	eval(ast, env);
 	auto value = env.m_stack.pop_unsafe();
-	return value_of(value.get());
+	return value_of(value);
 }
 
 } // namespace Interpreter

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -115,8 +115,8 @@ Value* eval_expression(
 
 	// TODO?: return a gc_ptr
 	eval(ast, env);
-	auto value = env.m_stack.pop();
-	return value_of(value.get());
+	auto value = env.m_stack.pop_unsafe();
+	return value_of(value);
 }
 
 } // namespace Interpreter

--- a/src/interpreter/execute.hpp
+++ b/src/interpreter/execute.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "exit_status_tag.hpp"
+#include "value.hpp"
 #include <string>
 
 namespace Frontend {
@@ -27,7 +28,7 @@ ExitStatus execute(
 );
 
 // evaluates an expression and returns the resulting value
-Value* eval_expression(
+Handle eval_expression(
 	const std::string& expr,
 	Interpreter& env,
 	Frontend::SymbolTable&

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -8,12 +8,10 @@
 namespace Interpreter {
 
 GC::GC() {
-	m_null = new Null;
 }
 
 GC::~GC() {
 	sweep_all();
-	delete m_null;
 }
 
 void GC::unmark_all() {
@@ -55,10 +53,6 @@ void GC::sweep_all() {
 
 void GC::add_root(Value* new_root) {
 	m_roots.push_back(new_root);
-}
-
-Null* GC::null() {
-	return m_null;
 }
 
 gc_ptr<Variant> GC::new_variant(InternedString constructor, Value* v) {

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -140,6 +140,10 @@ gc_ptr<Error> GC::new_error(std::string s) {
 }
 
 gc_ptr<Reference> GC::new_reference(Value* v) {
+	return new_reference(Handle{v});
+}
+
+gc_ptr<Reference> GC::new_reference(Handle v) {
 	auto result = new Reference(std::move(v));
 	m_blocks.push_back(result);
 	return result;

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -95,16 +95,6 @@ Float* GC::new_float_raw(float f) {
 	return result;
 }
 
-gc_ptr<Boolean> GC::new_boolean(bool b) {
-	return new_boolean_raw(b);
-}
-
-Boolean* GC::new_boolean_raw(bool b) {
-	auto result = new Boolean(b);
-	m_blocks.push_back(result);
-	return result;
-}
-
 gc_ptr<String> GC::new_string(std::string s) {
 	return new_string_raw(std::move(s));
 }

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -10,9 +10,6 @@ namespace Interpreter {
 struct Error;
 
 struct GC {
-  private:
-	Null* m_null;
-
   public:
 	std::vector<Value*> m_blocks;
 	std::vector<Value*> m_roots;
@@ -27,8 +24,6 @@ struct GC {
 	int size () { return m_blocks.size(); }
 
 	void add_root(Value* new_root);
-
-	auto null() -> Null*;
 
 	auto new_variant(InternedString constructor, Value* v) -> gc_ptr<Variant>;
 	auto new_record(RecordType) -> gc_ptr<Record>;

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -41,6 +41,7 @@ struct GC {
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 	auto new_reference(Value*) -> gc_ptr<Reference>;
+	auto new_reference(Handle) -> gc_ptr<Reference>;
 
 	auto new_integer_raw(int) -> Integer*;
 	auto new_float_raw(float) -> Float*;

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -30,7 +30,6 @@ struct GC {
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_integer(int) -> gc_ptr<Integer>;
 	auto new_float(float) -> gc_ptr<Float>;
-	auto new_boolean(bool) -> gc_ptr<Boolean>;
 	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
@@ -40,7 +39,6 @@ struct GC {
 
 	auto new_integer_raw(int) -> Integer*;
 	auto new_float_raw(float) -> Float*;
-	auto new_boolean_raw(bool) -> Boolean*;
 	auto new_string_raw(std::string) -> String*;
 	auto new_variant_constructor_raw(InternedString) -> VariantConstructor*;
 	auto new_record_constructor_raw(std::vector<InternedString>) -> RecordConstructor*;

--- a/src/interpreter/gc_ptr.hpp
+++ b/src/interpreter/gc_ptr.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <type_traits>
+#include "value.hpp"
 
 template <typename ValueType>
 struct gc_ptr {
@@ -59,5 +60,9 @@ struct gc_ptr {
 
 	ValueType* operator->() const {
 		return get();
+	}
+
+	Interpreter::Handle handle() {
+		return Interpreter::Handle {get()};
 	}
 };

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -52,10 +52,10 @@ Handle Interpreter::fetch_return_value() {
 	return rv;
 }
 
-void Interpreter::assign(Value* dst, Value* src) {
+void Interpreter::assign(Handle dst, Handle src) {
 	// NOTE: copied by reference, matters if rhs is actually a reference
 	// TODO: change in another pr, perhaps adding Interpreter::copy_value?
-	as<Reference>(dst)->m_value = Handle{value_of(src)};
+	as<Reference>(dst)->m_value = value_of(src);
 }
 
 

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -35,10 +35,6 @@ void Interpreter::global_declare(const Identifier& i, Value* v) {
 	global_declare_direct(i, r.get());
 }
 
-void Interpreter::global_declare(const Identifier& i, gc_ptr<Value> v) {
-	global_declare(i, v.get());
-}
-
 Reference* Interpreter::global_access(const Identifier& i) {
 	return m_global_scope.access(i);
 }

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -146,7 +146,7 @@ gc_ptr<Error> Interpreter::new_error(std::string e) {
 
 gc_ptr<Reference> Interpreter::new_reference(Value* v) {
 	assert(
-	    v->type() != ValueTag::Reference &&
+	    (!v || v->type() != ValueTag::Reference) &&
 	    "References to references are not allowed.");
 	auto result = m_gc->new_reference(v);
 	run_gc_if_needed();

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -59,7 +59,7 @@ Value* Interpreter::fetch_return_value() {
 void Interpreter::assign(Value* dst, Value* src) {
 	// NOTE: copied by reference, matters if rhs is actually a reference
 	// TODO: change in another pr, perhaps adding Interpreter::copy_value?
-	as<Reference>(dst)->m_value = value_of(src);
+	as<Reference>(dst)->m_value = Handle{value_of(src)};
 }
 
 

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -150,16 +150,7 @@ gc_ptr<Error> Interpreter::new_error(std::string e) {
 
 gc_ptr<Reference> Interpreter::new_reference(Handle v) {
 	assert(
-	    (!v.get() || v.get()->type() != ValueTag::Reference) &&
-	    "References to references are not allowed.");
-	auto result = m_gc->new_reference(v);
-	run_gc_if_needed();
-	return result;
-}
-
-gc_ptr<Reference> Interpreter::new_reference(Value* v) {
-	assert(
-	    (!v || v->type() != ValueTag::Reference) &&
+	    v.type() != ValueTag::Reference &&
 	    "References to references are not allowed.");
 	auto result = m_gc->new_reference(v);
 	run_gc_if_needed();

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -41,14 +41,18 @@ Reference* Interpreter::global_access(const Identifier& i) {
 
 
 void Interpreter::save_return_value(Handle v) {
-	// check if not stepping on another value
-	assert(!m_return_value.get());
+	// ensure we are not in a return sequence already
+	assert(!m_returning);
+	m_returning = true;
 	m_return_value = v;
 }
 
 Handle Interpreter::fetch_return_value() {
+	// ensure we were in a return sequence
+	assert(m_returning);
+	m_returning = false;
 	Handle rv = m_return_value;
-	m_return_value.ptr = nullptr;
+	m_return_value = Handle{};
 	return rv;
 }
 
@@ -95,7 +99,7 @@ void Interpreter::push_float(float f) {
 }
 
 void Interpreter::push_boolean(bool b) {
-	m_stack.push(Handle{m_gc->new_boolean_raw(b)});
+	m_stack.push(Handle{b});
 	run_gc_if_needed();
 }
 

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -81,7 +81,7 @@ void Interpreter::run_gc_if_needed(){
 
 
 Handle Interpreter::null() {
-	return Handle{m_gc->null()};
+	return Handle{nullptr};
 }
 
 void Interpreter::push_integer(int i) {

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -32,7 +32,7 @@ struct Interpreter {
 	GC* m_gc;
 	std::vector<std::vector<AST::Declaration*>> const* m_declaration_order;
 	int m_gc_size_on_last_pass {64};
-	Value* m_return_value {nullptr};
+	Handle m_return_value {nullptr};
 	Scope m_global_scope;
 
 	Interpreter(
@@ -43,8 +43,8 @@ struct Interpreter {
 	    , m_gc {gc}
 	    , m_declaration_order {declaration_order} {}
 
-	void save_return_value(Value*);
-	Value* fetch_return_value();
+	void save_return_value(Handle);
+	Handle fetch_return_value();
 
 	void run_gc();
 	void run_gc_if_needed();
@@ -55,7 +55,7 @@ struct Interpreter {
 	Reference* global_access(const Identifier& i);
 	void assign(Value* dst, Value* src);
 
-	auto null() -> Null*;
+	auto null() -> Handle;
 	void push_integer(int);
 	void push_float(float);
 	void push_boolean(bool);
@@ -67,7 +67,9 @@ struct Interpreter {
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
+
 	auto new_reference(Value*) -> gc_ptr<Reference>;
+	auto new_reference(Handle) -> gc_ptr<Reference>;
 };
 
 } // namespace Interpreter

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -32,6 +32,7 @@ struct Interpreter {
 	GC* m_gc;
 	std::vector<std::vector<AST::Declaration*>> const* m_declaration_order;
 	int m_gc_size_on_last_pass {64};
+	bool m_returning{false};
 	Handle m_return_value {nullptr};
 	Scope m_global_scope;
 

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -53,7 +53,7 @@ struct Interpreter {
 	void global_declare_direct(const Identifier& i, Reference* v);
 	void global_declare(const Identifier& i, Value* v);
 	Reference* global_access(const Identifier& i);
-	void assign(Value* dst, Value* src);
+	void assign(Handle dst, Handle src);
 
 	auto null() -> Handle;
 	void push_integer(int);

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -69,7 +69,6 @@ struct Interpreter {
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 
-	auto new_reference(Value*) -> gc_ptr<Reference>;
 	auto new_reference(Handle) -> gc_ptr<Reference>;
 };
 

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -52,7 +52,6 @@ struct Interpreter {
 	// Binds a global name to the given reference
 	void global_declare_direct(const Identifier& i, Reference* v);
 	void global_declare(const Identifier& i, Value* v);
-	void global_declare(const Identifier& i, gc_ptr<Value> v);
 	Reference* global_access(const Identifier& i);
 	void assign(Value* dst, Value* src);
 

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char** argv) {
 				eval(top_level_call, env);
 			    auto result = env.m_stack.pop_unsafe();
 
-			    if (result)
+			    if (result.get())
 				    Interpreter::print(result);
 			    else
 				    std::cout << "(nullptr)\n";

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -60,10 +60,10 @@ int main(int argc, char** argv) {
 			    auto top_level_call = AST::convert_ast(top_level_call_ast.m_result, ast_allocator);
 
 				eval(top_level_call, env);
-			    auto result = env.m_stack.pop();
+			    auto result = env.m_stack.pop_unsafe();
 
 			    if (result)
-				    Interpreter::print(result.get());
+				    Interpreter::print(result);
 			    else
 				    std::cout << "(nullptr)\n";
 		    }

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -23,7 +23,7 @@ using ArgsType = Span<Value*>;
 Value* print(ArgsType v, Interpreter& e) {
 	for (auto value : v)
 		print(value);
-	return e.null();
+	return e.null().get();
 }
 
 // array_append(arr, vals...) appends the values in vals to the array
@@ -262,7 +262,7 @@ Value* value_less_or_equal(ArgsType v, Interpreter& e) {
 
 Value* value_assign(ArgsType v, Interpreter& e) {
 	e.assign(v[0], v[1]);
-	return e.null();
+	return e.null().get();
 }
 
 Value* read_integer(ArgsType v, Interpreter& e) {

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -13,11 +13,11 @@
 namespace Interpreter {
 
 #define OP(type, lhs, op, rhs) \
-	static_cast<type*>(lhs)->m_value op static_cast<type*>(rhs)->m_value
+	(lhs).get_cast<type>()->m_value op (rhs).get_cast<type>()->m_value
 
-// TODO: All of these should return gc_ptr
+// TODO: All of these should return Handle
 
-using ArgsType = Span<Value*>;
+using ArgsType = Span<Handle>;
 
 // print(vals...) prints the values or references in vals
 Value* print(ArgsType v, Interpreter& e) {
@@ -86,11 +86,11 @@ Value* array_at(ArgsType v, Interpreter& e) {
 }
 
 Value* value_add(ArgsType v, Interpreter& e) {
-	auto* lhs = value_of(v[0]);
-	auto* rhs = value_of(v[1]);
+	auto lhs = value_of(v[0]);
+	auto rhs = value_of(v[1]);
 
-	assert(lhs->type() == rhs->type());
-	switch (lhs->type()) {
+	assert(lhs.type() == rhs.type());
+	switch (lhs.type()) {
 	case ValueTag::Integer:
 		return e.m_gc->new_integer_raw(OP(Integer, lhs, +, rhs));
 	case ValueTag::Float:
@@ -99,105 +99,105 @@ Value* value_add(ArgsType v, Interpreter& e) {
 		return e.m_gc->new_string_raw(OP(String, lhs, +, rhs));
 	default:
 		std::cerr << "ERROR: can't add values of type "
-		          << value_string[static_cast<int>(lhs->type())];
+		          << value_string[static_cast<int>(lhs.type())];
 		assert(0);
 	}
 }
 
 Value* value_sub(ArgsType v, Interpreter& e) {
-	auto* lhs = value_of(v[0]);
-	auto* rhs = value_of(v[1]);
+	auto lhs = value_of(v[0]);
+	auto rhs = value_of(v[1]);
 
-	assert(lhs->type() == rhs->type());
-	switch (lhs->type()) {
+	assert(lhs.type() == rhs.type());
+	switch (lhs.type()) {
 	case ValueTag::Integer:
 		return e.m_gc->new_integer_raw(OP(Integer, lhs, -, rhs));
 	case ValueTag::Float:
 		return e.m_gc->new_float_raw(OP(Float, lhs, -, rhs));
 	default:
 		std::cerr << "ERROR: can't add values of type "
-		          << value_string[static_cast<int>(lhs->type())];
+		          << value_string[static_cast<int>(lhs.type())];
 		assert(0);
 	}
 }
 
 Value* value_mul(ArgsType v, Interpreter& e) {
-	auto* lhs = value_of(v[0]);
-	auto* rhs = value_of(v[1]);
+	auto lhs = value_of(v[0]);
+	auto rhs = value_of(v[1]);
 
-	assert(lhs->type() == rhs->type());
-	switch (lhs->type()) {
+	assert(lhs.type() == rhs.type());
+	switch (lhs.type()) {
 	case ValueTag::Integer:
 		return e.m_gc->new_integer_raw(OP(Integer, lhs, *, rhs));
 	case ValueTag::Float:
 		return e.m_gc->new_float_raw(OP(Float, lhs, *, rhs));
 	default:
 		std::cerr << "ERROR: can't multiply values of type "
-		          << value_string[static_cast<int>(lhs->type())];
+		          << value_string[static_cast<int>(lhs.type())];
 		assert(0);
 	}
 }
 
 Value* value_div(ArgsType v, Interpreter& e) {
-	auto* lhs = value_of(v[0]);
-	auto* rhs = value_of(v[1]);
+	auto lhs = value_of(v[0]);
+	auto rhs = value_of(v[1]);
 
-	assert(lhs->type() == rhs->type());
-	switch (lhs->type()) {
+	assert(lhs.type() == rhs.type());
+	switch (lhs.type()) {
 	case ValueTag::Integer:
 		return e.m_gc->new_integer_raw(OP(Integer, lhs, /, rhs));
 	case ValueTag::Float:
 		return e.m_gc->new_float_raw(OP(Float, lhs, /, rhs));
 	default:
 		std::cerr << "ERROR: can't divide values of type "
-		          << value_string[static_cast<int>(lhs->type())];
+		          << value_string[static_cast<int>(lhs.type())];
 		assert(0);
 	}
 }
 
 Value* value_logicand(ArgsType v, Interpreter& e) {
-	auto* lhs = value_of(v[0]);
-	auto* rhs = value_of(v[1]);
+	auto lhs = value_of(v[0]);
+	auto rhs = value_of(v[1]);
 
-	if (lhs->type() == ValueTag::Boolean and rhs->type() == ValueTag::Boolean)
+	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
 		return e.m_gc->new_boolean_raw(OP(Boolean, lhs, &&, rhs));
 	std::cerr << "ERROR: logical and operator not defined for types "
-	          << value_string[static_cast<int>(lhs->type())] << " and "
-	          << value_string[static_cast<int>(rhs->type())];
+	          << value_string[static_cast<int>(lhs.type())] << " and "
+	          << value_string[static_cast<int>(rhs.type())];
 	assert(0);
 }
 
 Value* value_logicor(ArgsType v, Interpreter& e) {
-	auto* lhs = value_of(v[0]);
-	auto* rhs = value_of(v[1]);
+	auto lhs = value_of(v[0]);
+	auto rhs = value_of(v[1]);
 
-	if (lhs->type() == ValueTag::Boolean and rhs->type() == ValueTag::Boolean)
+	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
 		return e.m_gc->new_boolean_raw(OP(Boolean, lhs, ||, rhs));
 	std::cerr << "ERROR: logical or operator not defined for types "
-	          << value_string[static_cast<int>(lhs->type())] << " and "
-	          << value_string[static_cast<int>(rhs->type())];
+	          << value_string[static_cast<int>(lhs.type())] << " and "
+	          << value_string[static_cast<int>(rhs.type())];
 	assert(0);
 }
 
 Value* value_logicxor(ArgsType v, Interpreter& e) {
-	auto* lhs = value_of(v[0]);
-	auto* rhs = value_of(v[1]);
+	auto lhs = value_of(v[0]);
+	auto rhs = value_of(v[1]);
 
-	if (lhs->type() == ValueTag::Boolean and rhs->type() == ValueTag::Boolean)
+	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
 		return e.m_gc->new_boolean_raw(OP(Boolean, lhs, !=, rhs));
 	std::cerr << "ERROR: exclusive or operator not defined for types "
-	          << value_string[static_cast<int>(lhs->type())] << " and "
-	          << value_string[static_cast<int>(rhs->type())];
+	          << value_string[static_cast<int>(lhs.type())] << " and "
+	          << value_string[static_cast<int>(rhs.type())];
 	assert(0);
 }
 
 Value* value_equals(ArgsType v, Interpreter& e) {
-	auto* lhs = value_of(v[0]);
-	auto* rhs = value_of(v[1]);
+	auto lhs = value_of(v[0]);
+	auto rhs = value_of(v[1]);
 
-	assert(lhs->type() == rhs->type());
+	assert(lhs.type() == rhs.type());
 
-	switch (lhs->type()) {
+	switch (lhs.type()) {
 	case ValueTag::Null:
 		return e.m_gc->new_boolean_raw(true);
 	case ValueTag::Integer:
@@ -210,8 +210,8 @@ Value* value_equals(ArgsType v, Interpreter& e) {
 		return e.m_gc->new_boolean_raw(OP(Boolean, lhs, ==, rhs));
 	default: {
 		std::cerr << "ERROR: can't compare equality of types "
-		          << value_string[static_cast<int>(lhs->type())] << " and "
-		          << value_string[static_cast<int>(rhs->type())];
+		          << value_string[static_cast<int>(lhs.type())] << " and "
+		          << value_string[static_cast<int>(rhs.type())];
 		assert(0);
 	}
 	}
@@ -224,12 +224,12 @@ Value* value_not_equals(ArgsType v, Interpreter& e) {
 }
 
 Value* value_less(ArgsType v, Interpreter& e) {
-	auto* lhs = value_of(v[0]);
-	auto* rhs = value_of(v[1]);
+	auto lhs = value_of(v[0]);
+	auto rhs = value_of(v[1]);
 
-	assert(lhs->type() == rhs->type());
+	assert(lhs.type() == rhs.type());
 
-	switch (lhs->type()) {
+	switch (lhs.type()) {
 	case ValueTag::Integer:
 		return e.m_gc->new_boolean_raw(OP(Integer, lhs, <, rhs));
 	case ValueTag::Float:
@@ -238,7 +238,7 @@ Value* value_less(ArgsType v, Interpreter& e) {
 		return e.m_gc->new_boolean_raw(OP(String, lhs, <, rhs));
 	default:
 		std::cerr << "ERROR: can't compare values of type "
-		          << value_string[static_cast<int>(lhs->type())];
+		          << value_string[static_cast<int>(lhs.type())];
 		assert(0);
 	}
 }

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -294,32 +294,32 @@ Value* read_string(ArgsType v, Interpreter& e) {
 }
 
 void declare_native_functions(Interpreter& env) {
-	env.global_declare("print", env.new_native_function(print));
-	env.global_declare("array_append", env.new_native_function(array_append));
-	env.global_declare("array_extend", env.new_native_function(array_extend));
-	env.global_declare("size", env.new_native_function(size));
-	env.global_declare("array_join", env.new_native_function(array_join));
-	env.global_declare("array_at", env.new_native_function(array_at));
-	env.global_declare("+", env.new_native_function(value_add));
-	env.global_declare("-", env.new_native_function(value_sub));
-	env.global_declare("*", env.new_native_function(value_mul));
-	env.global_declare("/", env.new_native_function(value_div));
-	env.global_declare("<", env.new_native_function(value_less));
-	env.global_declare(">=", env.new_native_function(value_greater_or_equal));
-	env.global_declare(">", env.new_native_function(value_greater));
-	env.global_declare("<=", env.new_native_function(value_less_or_equal));
-	env.global_declare("=", env.new_native_function(value_assign));
-	env.global_declare("==", env.new_native_function(value_equals));
-	env.global_declare("!=", env.new_native_function(value_not_equals));
-	env.global_declare("^^", env.new_native_function(value_logicxor));
-	env.global_declare("&&", env.new_native_function(value_logicand));
-	env.global_declare("||", env.new_native_function(value_logicor));
+	env.global_declare("print", env.new_native_function(print).get());
+	env.global_declare("array_append", env.new_native_function(array_append).get());
+	env.global_declare("array_extend", env.new_native_function(array_extend).get());
+	env.global_declare("size", env.new_native_function(size).get());
+	env.global_declare("array_join", env.new_native_function(array_join).get());
+	env.global_declare("array_at", env.new_native_function(array_at).get());
+	env.global_declare("+", env.new_native_function(value_add).get());
+	env.global_declare("-", env.new_native_function(value_sub).get());
+	env.global_declare("*", env.new_native_function(value_mul).get());
+	env.global_declare("/", env.new_native_function(value_div).get());
+	env.global_declare("<", env.new_native_function(value_less).get());
+	env.global_declare(">=", env.new_native_function(value_greater_or_equal).get());
+	env.global_declare(">", env.new_native_function(value_greater).get());
+	env.global_declare("<=", env.new_native_function(value_less_or_equal).get());
+	env.global_declare("=", env.new_native_function(value_assign).get());
+	env.global_declare("==", env.new_native_function(value_equals).get());
+	env.global_declare("!=", env.new_native_function(value_not_equals).get());
+	env.global_declare("^^", env.new_native_function(value_logicxor).get());
+	env.global_declare("&&", env.new_native_function(value_logicand).get());
+	env.global_declare("||", env.new_native_function(value_logicor).get());
 
 	// Input
-	env.global_declare("read_integer", env.new_native_function(read_integer));
-	env.global_declare("read_number", env.new_native_function(read_number));
-	env.global_declare("read_string", env.new_native_function(read_string));
-	env.global_declare("read_line", env.new_native_function(read_line));
+	env.global_declare("read_integer", env.new_native_function(read_integer).get());
+	env.global_declare("read_number", env.new_native_function(read_number).get());
+	env.global_declare("read_string", env.new_native_function(read_string).get());
+	env.global_declare("read_line", env.new_native_function(read_line).get());
 }
 
 #undef OP

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -20,47 +20,47 @@ namespace Interpreter {
 using ArgsType = Span<Handle>;
 
 // print(vals...) prints the values or references in vals
-Value* print(ArgsType v, Interpreter& e) {
+Handle print(ArgsType v, Interpreter& e) {
 	for (auto value : v)
 		print(value);
-	return e.null().get();
+	return e.null();
 }
 
 // array_append(arr, vals...) appends the values in vals to the array
-Value* array_append(ArgsType v, Interpreter& e) {
+Handle array_append(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() > 0);
 	Array* array = value_as<Array>(v[0]);
 	for (unsigned int i = 1; i < v.size(); i++) {
 		array->append(e.new_reference(value_of(v[i])).get());
 	}
-	return array;
+	return {array};
 }
 
 // array_extend(arr1, arr2) appends the values in arr2 to
 // arr1
-Value* array_extend(ArgsType v, Interpreter& e) {
+Handle array_extend(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 2);
 	Array* arr1 = value_as<Array>(v[0]);
 	Array* arr2 = value_as<Array>(v[1]);
 	arr1->m_value.insert(
 	    arr1->m_value.end(), arr2->m_value.begin(), arr2->m_value.end());
-	return arr1;
+	return {arr1};
 }
 
 // size(array) returns the size of the array
-Value* size(ArgsType v, Interpreter& e) {
+Handle size(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 1);
 	Array* array = value_as<Array>(v[0]);
 
-	return e.m_gc->new_integer_raw(array->m_value.size());
+	return {e.m_gc->new_integer_raw(array->m_value.size())};
 }
 
 // array_join(array, string) returns a string with
 // the array values separated by the string element
-Value* array_join(ArgsType v, Interpreter& e) {
+Handle array_join(ArgsType v, Interpreter& e) {
 	// TODO make it more general
 	// TODO proper error handling
 	assert(v.size() == 2);
@@ -71,32 +71,32 @@ Value* array_join(ArgsType v, Interpreter& e) {
 		if (i > 0) result << sep->m_value;
 		result << value_as<Integer>(array->m_value[i])->m_value;
 	}
-	return e.m_gc->new_string_raw(result.str());
+	return {e.m_gc->new_string_raw(result.str())};
 }
 
 // array_at(array, int i) returns the i-th element of the given array
-Value* array_at(ArgsType v, Interpreter& e) {
+Handle array_at(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 2);
 	Array* array = value_as<Array>(v[0]);
 	Integer* index = value_as<Integer>(v[1]);
 	assert(index->m_value >= 0);
 	assert(index->m_value < array->m_value.size());
-	return array->m_value[index->m_value];
+	return {array->m_value[index->m_value]};
 }
 
-Value* value_add(ArgsType v, Interpreter& e) {
+Handle value_add(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return e.m_gc->new_integer_raw(OP(Integer, lhs, +, rhs));
+		return {e.m_gc->new_integer_raw(OP(Integer, lhs, +, rhs))};
 	case ValueTag::Float:
-		return e.m_gc->new_float_raw(OP(Float, lhs, +, rhs));
+		return {e.m_gc->new_float_raw(OP(Float, lhs, +, rhs))};
 	case ValueTag::String:
-		return e.m_gc->new_string_raw(OP(String, lhs, +, rhs));
+		return {e.m_gc->new_string_raw(OP(String, lhs, +, rhs))};
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -104,16 +104,16 @@ Value* value_add(ArgsType v, Interpreter& e) {
 	}
 }
 
-Value* value_sub(ArgsType v, Interpreter& e) {
+Handle value_sub(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return e.m_gc->new_integer_raw(OP(Integer, lhs, -, rhs));
+		return {e.m_gc->new_integer_raw(OP(Integer, lhs, -, rhs))};
 	case ValueTag::Float:
-		return e.m_gc->new_float_raw(OP(Float, lhs, -, rhs));
+		return {e.m_gc->new_float_raw(OP(Float, lhs, -, rhs))};
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -121,16 +121,16 @@ Value* value_sub(ArgsType v, Interpreter& e) {
 	}
 }
 
-Value* value_mul(ArgsType v, Interpreter& e) {
+Handle value_mul(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return e.m_gc->new_integer_raw(OP(Integer, lhs, *, rhs));
+		return {e.m_gc->new_integer_raw(OP(Integer, lhs, *, rhs))};
 	case ValueTag::Float:
-		return e.m_gc->new_float_raw(OP(Float, lhs, *, rhs));
+		return {e.m_gc->new_float_raw(OP(Float, lhs, *, rhs))};
 	default:
 		std::cerr << "ERROR: can't multiply values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -138,16 +138,16 @@ Value* value_mul(ArgsType v, Interpreter& e) {
 	}
 }
 
-Value* value_div(ArgsType v, Interpreter& e) {
+Handle value_div(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return e.m_gc->new_integer_raw(OP(Integer, lhs, /, rhs));
+		return {e.m_gc->new_integer_raw(OP(Integer, lhs, /, rhs))};
 	case ValueTag::Float:
-		return e.m_gc->new_float_raw(OP(Float, lhs, /, rhs));
+		return {e.m_gc->new_float_raw(OP(Float, lhs, /, rhs))};
 	default:
 		std::cerr << "ERROR: can't divide values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -155,43 +155,43 @@ Value* value_div(ArgsType v, Interpreter& e) {
 	}
 }
 
-Value* value_logicand(ArgsType v, Interpreter& e) {
+Handle value_logicand(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
 	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
-		return e.m_gc->new_boolean_raw(OP(Boolean, lhs, &&, rhs));
+		return {e.m_gc->new_boolean_raw(OP(Boolean, lhs, &&, rhs))};
 	std::cerr << "ERROR: logical and operator not defined for types "
 	          << value_string[static_cast<int>(lhs.type())] << " and "
 	          << value_string[static_cast<int>(rhs.type())];
 	assert(0);
 }
 
-Value* value_logicor(ArgsType v, Interpreter& e) {
+Handle value_logicor(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
 	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
-		return e.m_gc->new_boolean_raw(OP(Boolean, lhs, ||, rhs));
+		return {e.m_gc->new_boolean_raw(OP(Boolean, lhs, ||, rhs))};
 	std::cerr << "ERROR: logical or operator not defined for types "
 	          << value_string[static_cast<int>(lhs.type())] << " and "
 	          << value_string[static_cast<int>(rhs.type())];
 	assert(0);
 }
 
-Value* value_logicxor(ArgsType v, Interpreter& e) {
+Handle value_logicxor(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
 	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
-		return e.m_gc->new_boolean_raw(OP(Boolean, lhs, !=, rhs));
+		return {e.m_gc->new_boolean_raw(OP(Boolean, lhs, !=, rhs))};
 	std::cerr << "ERROR: exclusive or operator not defined for types "
 	          << value_string[static_cast<int>(lhs.type())] << " and "
 	          << value_string[static_cast<int>(rhs.type())];
 	assert(0);
 }
 
-Value* value_equals(ArgsType v, Interpreter& e) {
+Handle value_equals(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -199,15 +199,15 @@ Value* value_equals(ArgsType v, Interpreter& e) {
 
 	switch (lhs.type()) {
 	case ValueTag::Null:
-		return e.m_gc->new_boolean_raw(true);
+		return {e.m_gc->new_boolean_raw(true)};
 	case ValueTag::Integer:
-		return e.m_gc->new_boolean_raw(OP(Integer, lhs, ==, rhs));
+		return {e.m_gc->new_boolean_raw(OP(Integer, lhs, ==, rhs))};
 	case ValueTag::Float:
-		return e.m_gc->new_boolean_raw(OP(Float, lhs, ==, rhs));
+		return {e.m_gc->new_boolean_raw(OP(Float, lhs, ==, rhs))};
 	case ValueTag::String:
-		return e.m_gc->new_boolean_raw(OP(String, lhs, ==, rhs));
+		return {e.m_gc->new_boolean_raw(OP(String, lhs, ==, rhs))};
 	case ValueTag::Boolean:
-		return e.m_gc->new_boolean_raw(OP(Boolean, lhs, ==, rhs));
+		return {e.m_gc->new_boolean_raw(OP(Boolean, lhs, ==, rhs))};
 	default: {
 		std::cerr << "ERROR: can't compare equality of types "
 		          << value_string[static_cast<int>(lhs.type())] << " and "
@@ -217,13 +217,13 @@ Value* value_equals(ArgsType v, Interpreter& e) {
 	}
 }
 
-Value* value_not_equals(ArgsType v, Interpreter& e) {
-	Boolean* b = static_cast<Boolean*>(value_equals(v, e));
+Handle value_not_equals(ArgsType v, Interpreter& e) {
+	Boolean* b = value_equals(v, e).get_cast<Boolean>();
 	b->m_value = !b->m_value;
-	return b;
+	return {b};
 }
 
-Value* value_less(ArgsType v, Interpreter& e) {
+Handle value_less(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -231,11 +231,11 @@ Value* value_less(ArgsType v, Interpreter& e) {
 
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return e.m_gc->new_boolean_raw(OP(Integer, lhs, <, rhs));
+		return {e.m_gc->new_boolean_raw(OP(Integer, lhs, <, rhs))};
 	case ValueTag::Float:
-		return e.m_gc->new_boolean_raw(OP(Float, lhs, <, rhs));
+		return {e.m_gc->new_boolean_raw(OP(Float, lhs, <, rhs))};
 	case ValueTag::String:
-		return e.m_gc->new_boolean_raw(OP(String, lhs, <, rhs));
+		return {e.m_gc->new_boolean_raw(OP(String, lhs, <, rhs))};
 	default:
 		std::cerr << "ERROR: can't compare values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -243,54 +243,54 @@ Value* value_less(ArgsType v, Interpreter& e) {
 	}
 }
 
-Value* value_greater_or_equal(ArgsType v, Interpreter& e) {
-	Boolean* b = static_cast<Boolean*>(value_less(v, e));
+Handle value_greater_or_equal(ArgsType v, Interpreter& e) {
+	Boolean* b = value_less(v, e).get_cast<Boolean>();
 	b->m_value = !b->m_value;
-	return b;
+	return {b};
 }
 
-Value* value_greater(ArgsType v, Interpreter& e) {
+Handle value_greater(ArgsType v, Interpreter& e) {
 	std::swap(v[0], v[1]);
 	return value_less(v, e);
 }
 
-Value* value_less_or_equal(ArgsType v, Interpreter& e) {
-	Boolean* b = static_cast<Boolean*>(value_greater(v, e));
+Handle value_less_or_equal(ArgsType v, Interpreter& e) {
+	Boolean* b = value_greater(v, e).get_cast<Boolean>();
 	b->m_value = !b->m_value;
-	return b;
+	return {b};
 }
 
-Value* value_assign(ArgsType v, Interpreter& e) {
+Handle value_assign(ArgsType v, Interpreter& e) {
 	e.assign(v[0], v[1]);
-	return e.null().get();
+	return e.null();
 }
 
-Value* read_integer(ArgsType v, Interpreter& e) {
+Handle read_integer(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	int result;
 	std::cin >> result;
-	return e.m_gc->new_integer_raw(result);
+	return {e.m_gc->new_integer_raw(result)};
 }
 
-Value* read_number(ArgsType v, Interpreter& e) {
+Handle read_number(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	float result;
 	std::cin >> result;
-	return e.m_gc->new_float_raw(result);
+	return {e.m_gc->new_float_raw(result)};
 }
 
-Value* read_line(ArgsType v, Interpreter& e) {
+Handle read_line(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	std::string result;
 	std::getline(std::cin, result);
-	return e.m_gc->new_string_raw(std::move(result));
+	return {e.m_gc->new_string_raw(std::move(result))};
 }
 
-Value* read_string(ArgsType v, Interpreter& e) {
+Handle read_string(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	std::string result;
 	std::cin >> result;
-	return e.m_gc->new_string_raw(std::move(result));
+	return {e.m_gc->new_string_raw(std::move(result))};
 }
 
 void declare_native_functions(Interpreter& env) {

--- a/src/interpreter/stack.cpp
+++ b/src/interpreter/stack.cpp
@@ -37,37 +37,30 @@ void Stack::end_stack_region() {
 	m_stack.resize(m_stack_ptr);
 }
 
-void Stack::push(Value* ref){
+void Stack::push(Handle ref){
 	m_stack.push_back(ref);
 	m_stack_ptr += 1;
 }
 
+void Stack::push(Value* ref){
+	push(Handle{ref});
+}
+
 Value* Stack::pop_unsafe() {
-	Value* result = m_stack.back();
+	Handle result = m_stack.back();
 	m_stack.pop_back();
 	m_stack_ptr -= 1;
-	return result;
-}
-
-gc_ptr<Value> Stack::pop() {
-	gc_ptr<Value> result = {m_stack.back()};
-	m_stack.pop_back();
-	m_stack_ptr -= 1;
-	return result;
-}
-
-gc_ptr<Value> Stack::peek(int offset) {
-	return m_stack[m_stack.size() - 1 - offset];
+	return result.get();
 }
 
 Value*& Stack::access(int offset) {
-	return m_stack[m_stack.size() - 1 - offset];
+	return m_stack[m_stack.size() - 1 - offset].ptr;
 }
 
 Value*& Stack::frame_at(int offset) {
 	assert(m_frame_ptr + offset >= 0);
 	assert(m_frame_ptr + offset < m_stack.size());
-	return m_stack[m_frame_ptr + offset];
+	return m_stack[m_frame_ptr + offset].ptr;
 }
 
 Span<Value*> Stack::frame_range(int offset, int length) {
@@ -75,7 +68,7 @@ Span<Value*> Stack::frame_range(int offset, int length) {
 		assert(m_frame_ptr + offset >= 0);
 		assert(m_frame_ptr + offset + length <= m_stack.size());
 	}
-	auto start_address = &m_stack[m_frame_ptr + offset];
+	auto start_address = &m_stack[m_frame_ptr + offset].ptr;
 	return {start_address, length};
 }
 

--- a/src/interpreter/stack.cpp
+++ b/src/interpreter/stack.cpp
@@ -57,14 +57,10 @@ Handle& Stack::access(int offset) {
 	return m_stack[m_stack.size() - 1 - offset];
 }
 
-Handle& Stack::frame_at_(int offset) {
+Handle& Stack::frame_at(int offset) {
 	assert(m_frame_ptr + offset >= 0);
 	assert(m_frame_ptr + offset < m_stack.size());
 	return m_stack[m_frame_ptr + offset];
-}
-
-Value*& Stack::frame_at(int offset) {
-	return frame_at_(offset).ptr;
 }
 
 Span<Value*> Stack::frame_range(int offset, int length) {

--- a/src/interpreter/stack.cpp
+++ b/src/interpreter/stack.cpp
@@ -53,8 +53,12 @@ Handle Stack::pop_unsafe() {
 	return result;
 }
 
+Handle& Stack::access_(int offset) {
+	return m_stack[m_stack.size() - 1 - offset];
+}
+
 Value*& Stack::access(int offset) {
-	return m_stack[m_stack.size() - 1 - offset].ptr;
+	return access_(offset).ptr;
 }
 
 Handle& Stack::frame_at_(int offset) {

--- a/src/interpreter/stack.cpp
+++ b/src/interpreter/stack.cpp
@@ -46,21 +46,25 @@ void Stack::push(Value* ref){
 	push(Handle{ref});
 }
 
-Value* Stack::pop_unsafe() {
+Handle Stack::pop_unsafe() {
 	Handle result = m_stack.back();
 	m_stack.pop_back();
 	m_stack_ptr -= 1;
-	return result.get();
+	return result;
 }
 
 Value*& Stack::access(int offset) {
 	return m_stack[m_stack.size() - 1 - offset].ptr;
 }
 
-Value*& Stack::frame_at(int offset) {
+Handle& Stack::frame_at_(int offset) {
 	assert(m_frame_ptr + offset >= 0);
 	assert(m_frame_ptr + offset < m_stack.size());
-	return m_stack[m_frame_ptr + offset].ptr;
+	return m_stack[m_frame_ptr + offset];
+}
+
+Value*& Stack::frame_at(int offset) {
+	return frame_at_(offset).ptr;
 }
 
 Span<Value*> Stack::frame_range(int offset, int length) {

--- a/src/interpreter/stack.cpp
+++ b/src/interpreter/stack.cpp
@@ -59,12 +59,12 @@ Handle& Stack::frame_at(int offset) {
 	return m_stack[m_frame_ptr + offset];
 }
 
-Span<Value*> Stack::frame_range(int offset, int length) {
+Span<Handle> Stack::frame_range(int offset, int length) {
 	if (length > 0) {
 		assert(m_frame_ptr + offset >= 0);
 		assert(m_frame_ptr + offset + length <= m_stack.size());
 	}
-	auto start_address = &m_stack[m_frame_ptr + offset].ptr;
+	auto start_address = &m_stack[m_frame_ptr + offset];
 	return {start_address, length};
 }
 

--- a/src/interpreter/stack.cpp
+++ b/src/interpreter/stack.cpp
@@ -42,10 +42,6 @@ void Stack::push(Handle ref){
 	m_stack_ptr += 1;
 }
 
-void Stack::push(Value* ref){
-	push(Handle{ref});
-}
-
 Handle Stack::pop_unsafe() {
 	Handle result = m_stack.back();
 	m_stack.pop_back();

--- a/src/interpreter/stack.cpp
+++ b/src/interpreter/stack.cpp
@@ -53,12 +53,8 @@ Handle Stack::pop_unsafe() {
 	return result;
 }
 
-Handle& Stack::access_(int offset) {
+Handle& Stack::access(int offset) {
 	return m_stack[m_stack.size() - 1 - offset];
-}
-
-Value*& Stack::access(int offset) {
-	return access_(offset).ptr;
 }
 
 Handle& Stack::frame_at_(int offset) {

--- a/src/interpreter/stack.hpp
+++ b/src/interpreter/stack.hpp
@@ -27,7 +27,7 @@ struct Stack {
 
 	Handle& access(int offset);
 	Handle& frame_at(int offset);
-	Span<Value*> frame_range(int offset, int length);
+	Span<Handle> frame_range(int offset, int length);
 };
 
 } // namespace Interpreter

--- a/src/interpreter/stack.hpp
+++ b/src/interpreter/stack.hpp
@@ -27,9 +27,7 @@ struct Stack {
 	Handle pop_unsafe();
 
 	Handle& access(int offset);
-
-	Value*& frame_at(int offset);
-	Handle& frame_at_(int offset);
+	Handle& frame_at(int offset);
 	Span<Value*> frame_range(int offset, int length);
 };
 

--- a/src/interpreter/stack.hpp
+++ b/src/interpreter/stack.hpp
@@ -22,7 +22,6 @@ struct Stack {
 	void end_stack_region();
 
 	void push(Handle ref);
-	void push(Value* val);
 
 	Handle pop_unsafe();
 

--- a/src/interpreter/stack.hpp
+++ b/src/interpreter/stack.hpp
@@ -24,10 +24,12 @@ struct Stack {
 	void push(Handle ref);
 	void push(Value* val);
 
-	Value* pop_unsafe();
+	Handle pop_unsafe();
 
 	Value*& access(int offset);
+
 	Value*& frame_at(int offset);
+	Handle& frame_at_(int offset);
 	Span<Value*> frame_range(int offset, int length);
 };
 

--- a/src/interpreter/stack.hpp
+++ b/src/interpreter/stack.hpp
@@ -27,6 +27,7 @@ struct Stack {
 	Handle pop_unsafe();
 
 	Value*& access(int offset);
+	Handle& access_(int offset);
 
 	Value*& frame_at(int offset);
 	Handle& frame_at_(int offset);

--- a/src/interpreter/stack.hpp
+++ b/src/interpreter/stack.hpp
@@ -26,8 +26,7 @@ struct Stack {
 
 	Handle pop_unsafe();
 
-	Value*& access(int offset);
-	Handle& access_(int offset);
+	Handle& access(int offset);
 
 	Value*& frame_at(int offset);
 	Handle& frame_at_(int offset);

--- a/src/interpreter/stack.hpp
+++ b/src/interpreter/stack.hpp
@@ -10,7 +10,7 @@ namespace Interpreter {
 struct Stack {
 	int m_frame_ptr {0};
 	int m_stack_ptr {0};
-	std::vector<Value*> m_stack;
+	std::vector<Handle> m_stack;
 	std::vector<int> m_fp_stack;
 	std::vector<int> m_sp_stack;
 
@@ -21,12 +21,10 @@ struct Stack {
 	void start_stack_region();
 	void end_stack_region();
 
+	void push(Handle ref);
 	void push(Value* val);
 
 	Value* pop_unsafe();
-	gc_ptr<Value> pop();
-
-	gc_ptr<Value> peek(int offset = 0);
 
 	Value*& access(int offset);
 	Value*& frame_at(int offset);

--- a/src/interpreter/utils.cpp
+++ b/src/interpreter/utils.cpp
@@ -13,7 +13,7 @@ Value* value_of(Value* value) {
 
 	// try unboxing recursively?
 	auto ref = static_cast<Reference*>(value);
-	return ref->m_value;
+	return ref->m_value.get();
 }
 
 } // namespace Interpreter

--- a/src/interpreter/utils.cpp
+++ b/src/interpreter/utils.cpp
@@ -4,16 +4,16 @@
 
 namespace Interpreter {
 
-Value* value_of(Value* value) {
-	if (!value)
-		return value;
+Handle value_of(Handle h) {
+	if (!is_heap_type(h.type()))
+		return h;
 
-	if (value->type() != ValueTag::Reference)
-		return value;
+	if (h.type() != ValueTag::Reference)
+		return h;
 
 	// try unboxing recursively?
-	auto ref = static_cast<Reference*>(value);
-	return ref->m_value.get();
+	auto ref = h.get_cast<Reference>();
+	return ref->m_value;
 }
 
 } // namespace Interpreter

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cassert>
 
 #include "value.hpp"
@@ -7,10 +9,8 @@ namespace Interpreter {
 template<typename T>
 struct type_data;
 
-template<> struct type_data<Null> { static constexpr auto tag = ValueTag::Null; };
 template<> struct type_data<Integer> { static constexpr auto tag = ValueTag::Integer; };
 template<> struct type_data<Float> { static constexpr auto tag = ValueTag::Float; };
-template<> struct type_data<Boolean> { static constexpr auto tag = ValueTag::Boolean; };
 template<> struct type_data<String> { static constexpr auto tag = ValueTag::String; };
 template<> struct type_data<Array> { static constexpr auto tag = ValueTag::Array; };
 template<> struct type_data<Record> { static constexpr auto tag = ValueTag::Record; };
@@ -21,11 +21,7 @@ template<> struct type_data<Reference> { static constexpr auto tag = ValueTag::R
 template<> struct type_data<VariantConstructor> { static constexpr auto tag = ValueTag::VariantConstructor; };
 template<> struct type_data<RecordConstructor> { static constexpr auto tag = ValueTag::RecordConstructor; };
 
-Value* value_of(Value* value);
-
-inline Handle value_of(Handle h) {
-	return Handle{value_of(h.get())};
-}
+Handle value_of(Handle value);
 
 template<typename T>
 T* as(Value* x) {

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -23,6 +23,10 @@ template<> struct type_data<RecordConstructor> { static constexpr auto tag = Val
 
 Value* value_of(Value* value);
 
+inline Handle value_of(Handle h) {
+	return Handle{value_of(h.get())};
+}
+
 template<typename T>
 T* as(Value* x) {
 	static_assert(std::is_base_of<Value, T>::value, "T is not a subclass of Value");
@@ -35,6 +39,16 @@ template<typename T>
 T* value_as(Value* x) {
 	static_assert(std::is_base_of<Value, T>::value, "T is not a subclass of Value");
 	return as<T>(value_of(x));
+}
+
+template<typename T>
+T* as(Handle h) {
+	return as<T>(h.get());
+}
+
+template<typename T>
+T* value_as(Handle h) {
+	return value_as<T>(h.get());
 }
 
 } // namespace Interpreter

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -24,27 +24,18 @@ template<> struct type_data<RecordConstructor> { static constexpr auto tag = Val
 Handle value_of(Handle value);
 
 template<typename T>
-T* as(Value* x) {
-	static_assert(std::is_base_of<Value, T>::value, "T is not a subclass of Value");
-	assert(x);
-	assert(x->type() == type_data<T>::tag);
-	return static_cast<T*>(x);
-}
-
-template<typename T>
-T* value_as(Value* x) {
-	static_assert(std::is_base_of<Value, T>::value, "T is not a subclass of Value");
-	return as<T>(value_of(x));
-}
-
-template<typename T>
 T* as(Handle h) {
-	return as<T>(h.get());
+	static_assert(std::is_base_of<Value, T>::value, "T is not a subclass of Value");
+	assert(h.type() == type_data<T>::tag);
+	T* result = h.get_cast<T>();
+	assert(result);
+	return result;
 }
 
 template<typename T>
 T* value_as(Handle h) {
-	return value_as<T>(h.get());
+	static_assert(std::is_base_of<Value, T>::value, "T is not a subclass of Value");
+	return as<T>(value_of(h));
 }
 
 } // namespace Interpreter

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -43,7 +43,7 @@ void Array::append(Reference* v) {
 	m_value.push_back(v);
 }
 
-Value* Array::at(int position) {
+Reference* Array::at(int position) {
 	if (position < 0 or position >= int(m_value.size())) {
 		// TODO: return RangeError
 		return nullptr;
@@ -58,15 +58,15 @@ Record::Record(RecordType o)
     : Value(ValueTag::Record)
     , m_value(std::move(o)) {}
 
-void Record::addMember(Identifier const& id, Value* v) {
+void Record::addMember(Identifier const& id, Handle v) {
 	m_value[id] = v;
 }
 
-Value* Record::getMember(Identifier const& id) {
+Handle Record::getMember(Identifier const& id) {
 	auto it = m_value.find(id);
 	if (it == m_value.end()) {
 		// TODO: return RangeError
-		return nullptr;
+		return {nullptr};
 	} else {
 		return it->second;
 	}

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -6,9 +6,6 @@
 
 namespace Interpreter {
 
-Null::Null()
-    : Value(ValueTag::Null) {}
-
 Integer::Integer()
     : Value(ValueTag::Integer) {}
 Integer::Integer(int v)
@@ -20,12 +17,6 @@ Float::Float()
 Float::Float(float v)
     : Value(ValueTag::Float)
     , m_value(v) {}
-
-Boolean::Boolean()
-    : Value(ValueTag::Boolean) {}
-Boolean::Boolean(bool b)
-    : Value(ValueTag::Boolean)
-    , m_value(b) {}
 
 String::String()
     : Value(ValueTag::String) {}
@@ -105,9 +96,6 @@ RecordConstructor::RecordConstructor(std::vector<InternedString> keys)
     : Value {ValueTag::RecordConstructor}
     , m_keys {std::move(keys)} {}
 
-void gc_visit(Null* v) {
-	v->m_visited = true;
-}
 void gc_visit(Integer* v) {
 	v->m_visited = true;
 }
@@ -115,9 +103,6 @@ void gc_visit(Float* v) {
 	v->m_visited = true;
 }
 void gc_visit(String* v) {
-	v->m_visited = true;
-}
-void gc_visit(Boolean* v) {
 	v->m_visited = true;
 }
 void gc_visit(Error* v) {
@@ -179,18 +164,13 @@ void gc_visit(Reference* r) {
 }
 
 void gc_visit(Value* v) {
-
 	switch (v->type()) {
-	case ValueTag::Null:
-		return gc_visit(static_cast<Null*>(v));
 	case ValueTag::Integer:
 		return gc_visit(static_cast<Integer*>(v));
 	case ValueTag::Float:
 		return gc_visit(static_cast<Float*>(v));
 	case ValueTag::String:
 		return gc_visit(static_cast<String*>(v));
-	case ValueTag::Boolean:
-		return gc_visit(static_cast<Boolean*>(v));
 	case ValueTag::Error:
 		return gc_visit(static_cast<Error*>(v));
 	case ValueTag::Array:
@@ -228,11 +208,6 @@ void print(Integer const* v, int d) {
 	std::cout << value_string[int(v->type())] << ' ' << v->m_value << '\n';
 }
 
-void print(Null* v, int d) {
-	print_spaces(d);
-	std::cout << value_string[int(v->type())] << '\n';
-}
-
 void print(Float* v, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(v->type())] << ' ' << v->m_value << '\n';
@@ -244,9 +219,9 @@ void print(String* v, int d) {
 	          << '"' << '\n';
 }
 
-void print(Boolean* v, int d) {
+void print(bool b, int d) {
 	print_spaces(d);
-	std::cout << value_string[int(v->type())] << ' ' << v->m_value << '\n';
+	std::cout << value_string[int(ValueTag::Boolean)] << ' ' << b << '\n';
 }
 
 void print(Error* v, int d) {
@@ -310,16 +285,12 @@ void print(VariantConstructor* l, int d) {
 void print(Value* v, int d) {
 
 	switch (v->type()) {
-	case ValueTag::Null:
-		return print(static_cast<Null*>(v), d);
 	case ValueTag::Integer:
 		return print(static_cast<Integer*>(v), d);
 	case ValueTag::Float:
 		return print(static_cast<Float*>(v), d);
 	case ValueTag::String:
 		return print(static_cast<String*>(v), d);
-	case ValueTag::Boolean:
-		return print(static_cast<Boolean*>(v), d);
 	case ValueTag::Error:
 		return print(static_cast<Error*>(v), d);
 	case ValueTag::Array:
@@ -342,7 +313,15 @@ void print(Value* v, int d) {
 }
 
 void print(Handle h, int d) {
-	return print(h.get(), d);
+	if (is_heap_type(h.type()))
+		return print(h.get(), d);
+	switch (h.type()) {
+	case ValueTag::Boolean:
+		return print(h.as_boolean, d);
+	case ValueTag::Null:
+		print_spaces(d);
+		return void(std::cout << "(null)\n");
+	}
 }
 
 } // namespace Interpreter

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -171,7 +171,8 @@ void gc_visit(Reference* r) {
 		return;
 
 	r->m_visited = true;
-	gc_visit(r->m_value);
+	if (r->m_value.get())
+		gc_visit(r->m_value);
 }
 
 void gc_visit(Value* v) {

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -208,6 +208,10 @@ void gc_visit(Value* v) {
 	}
 }
 
+void gc_visit(Handle h) {
+	return gc_visit(h.get());
+}
+
 // = === === print === === = //
 
 void print_spaces(int n) {
@@ -331,6 +335,10 @@ void print(Value* v, int d) {
 	case ValueTag::RecordConstructor:
 		return print(static_cast<RecordConstructor*>(v), d);
 	}
+}
+
+void print(Handle h, int d) {
+	return print(h.get(), d);
 }
 
 } // namespace Interpreter

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -90,9 +90,12 @@ NativeFunction::NativeFunction(NativeFunctionType* fptr)
     : Value {ValueTag::NativeFunction}
     , m_fptr {fptr} {}
 
-Reference::Reference(Value* value)
+Reference::Reference(Handle value)
     : Value {ValueTag::Reference}
     , m_value {value} {}
+
+Reference::Reference(Value* value)
+    : Reference {Handle{value}} {}
 
 VariantConstructor::VariantConstructor(InternedString constructor)
     : Value {ValueTag::VariantConstructor}

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -23,11 +23,11 @@ struct Handle;
 
 using Identifier = InternedString;
 using StringType = std::string;
-using RecordType = std::unordered_map<Identifier, Value*>;
+using RecordType = std::unordered_map<Identifier, Handle>;
 using ArrayType = std::vector<Reference*>;
 using FunctionType = AST::FunctionLiteral*;
 using NativeFunctionType = auto(Span<Handle>, Interpreter&) -> Value*;
-using CapturesType = std::vector<Value*>; // TODO: store references instead of values
+using CapturesType = std::vector<Reference*>;
 
 // Returns the value pointed to by a reference
 void print(Value* v, int d = 0);
@@ -114,7 +114,7 @@ struct Array : Value {
 	Array(ArrayType l);
 
 	void append(Reference* v);
-	Value* at(int position);
+	Reference* at(int position);
 };
 
 struct Record : Value {
@@ -123,8 +123,8 @@ struct Record : Value {
 	Record();
 	Record(RecordType);
 
-	void addMember(Identifier const& id, Value* v);
-	Value* getMember(Identifier const& id);
+	void addMember(Identifier const& id, Handle v);
+	Handle getMember(Identifier const& id);
 };
 
 struct Variant : Value {

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -145,6 +145,7 @@ struct NativeFunction : Value {
 struct Reference : Value {
 	Handle m_value;
 
+	Reference(Handle value);
 	Reference(Value* value);
 };
 

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -51,6 +51,18 @@ struct Value {
 };
 
 struct Handle {
+	Handle(Value* ptr)
+	    : tag {ptr ? ptr->type() : ValueTag::Null}
+	    , ptr {ptr} {}
+
+	Handle(std::nullptr_t)
+	    : tag {ValueTag::Null}
+	    , ptr {nullptr} {}
+
+	Handle()
+	    : tag {ValueTag::Null}
+	    , ptr {nullptr} {}
+
 	Value& operator*() {
 		return *ptr;
 	};
@@ -65,10 +77,14 @@ struct Handle {
 	}
 
 	ValueTag type() {
-		return ptr->type();
+		if (ptr) assert(ptr->type() == tag);
+		return tag;
 	}
 
+	ValueTag tag;
+	union {
 	Value* ptr;
+	};
 };
 
 void gc_visit(Handle);

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -26,7 +26,7 @@ using StringType = std::string;
 using RecordType = std::unordered_map<Identifier, Handle>;
 using ArrayType = std::vector<Reference*>;
 using FunctionType = AST::FunctionLiteral*;
-using NativeFunctionType = auto(Span<Handle>, Interpreter&) -> Value*;
+using NativeFunctionType = auto(Span<Handle>, Interpreter&) -> Handle;
 using CapturesType = std::vector<Reference*>;
 
 // Returns the value pointed to by a reference

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -19,12 +19,14 @@ struct Interpreter;
 
 struct Reference;
 
+struct Handle;
+
 using Identifier = InternedString;
 using StringType = std::string;
 using RecordType = std::unordered_map<Identifier, Value*>;
 using ArrayType = std::vector<Reference*>;
 using FunctionType = AST::FunctionLiteral*;
-using NativeFunctionType = auto(Span<Value*>, Interpreter&) -> Value*;
+using NativeFunctionType = auto(Span<Handle>, Interpreter&) -> Value*;
 using CapturesType = std::vector<Value*>; // TODO: store references instead of values
 
 // Returns the value pointed to by a reference
@@ -49,8 +51,6 @@ struct Value {
 };
 
 struct Handle {
-	Value* ptr;
-
 	Value& operator*() {
 		return *ptr;
 	};
@@ -63,6 +63,12 @@ struct Handle {
 	T* get_cast() {
 		return static_cast<T*>(ptr);
 	}
+
+	ValueTag type() {
+		return ptr->type();
+	}
+
+	Value* ptr;
 };
 
 void gc_visit(Handle);

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -48,6 +48,26 @@ struct Value {
 	virtual ~Value() = default;
 };
 
+struct Handle {
+	Value* ptr;
+
+	Value& operator*() {
+		return *ptr;
+	};
+
+	Value* get() {
+		return ptr;
+	}
+
+	template <typename T>
+	T* get_cast() {
+		return static_cast<T*>(ptr);
+	}
+};
+
+void gc_visit(Handle);
+void print(Handle v, int d = 0);
+
 struct Null : Value {
 
 	Null();
@@ -123,7 +143,7 @@ struct NativeFunction : Value {
 };
 
 struct Reference : Value {
-	Value* m_value;
+	Handle m_value;
 
 	Reference(Value* value);
 };

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -85,6 +85,11 @@ struct Handle {
 		return static_cast<T*>(ptr);
 	}
 
+	bool get_boolean() {
+		assert(tag == ValueTag::Boolean);
+		return as_boolean;
+	}
+
 	ValueTag type() {
 		if (is_heap_type(tag))
 			assert(ptr->type() == tag);

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -58,7 +58,7 @@ void interpreter_tests(Test::Tester& tests) {
 	            EQUALS("pizza()", 13),
 	            EQUALS("issue261()", 13),
 	            IS_TRUE("if_else_if()"),
-	            EQUALS("ternary()", 2),
+	            EQUALS("ternary()", 2), //
 	            EQUALS("array_access()", 12),
 	            EQUALS("a", 1),
 	            EQUALS("b", 1),

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -8,72 +8,93 @@
 
 namespace Assert {
 
-ExitStatus of_type(Interpreter::Value* rv, ValueTag v_type) {
+using Interpreter::Handle;
 
-	if (!rv) {
-		if (v_type == ValueTag::Null)
-			return ExitStatus::Ok;
-		return ExitStatus::NullError;
-	}
+namespace detail {
 
-	if (rv->type() != v_type)
+ExitStatus of_type(Interpreter::Handle h, ValueTag tag) {
+	if (h.type() != tag)
 		return ExitStatus::TypeError;
 
 	return ExitStatus::Ok;
 }
 
 template <typename RuntimeValue, typename NativeValue>
-ExitStatus scalar_equals(
-    Interpreter::Value* rv, const ValueTag v_type, const NativeValue& expected) {
+ExitStatus scalar_equals(Handle rv, const ValueTag v_type, const NativeValue& expected) {
 	ExitStatus fail = of_type(rv, v_type);
 
 	if (ExitStatus::Ok != fail)
 		return fail;
 
-	if ((static_cast<RuntimeValue*>(rv))->m_value != expected)
+	auto value = rv.get_cast<RuntimeValue>();
+	if (value->m_value != expected)
 		return ExitStatus::ValueError;
 
 	return ExitStatus::Ok;
 }
 
-ExitStatus equals(Interpreter::Value* rv, std::string const& expected) {
-	return scalar_equals<Interpreter::String, std::string>(
-	    rv, ValueTag::String, expected);
-}
-
-ExitStatus equals(Interpreter::Value* rv, int expected) {
-	return scalar_equals<Interpreter::Integer, int>(
-	    rv, ValueTag::Integer, expected);
-}
-
-ExitStatus equals(Interpreter::Value* rv, float expected) {
-	return scalar_equals<Interpreter::Float, float>(rv, ValueTag::Float, expected);
-}
-
-// NOTE: allows literals to be used (e.g. 3.5), may need to change in the future?
-ExitStatus equals(Interpreter::Value* rv, double expected) {
-	return equals(rv, float(expected));
-}
-
-ExitStatus is_true(Interpreter::Value* rv) {
-	return scalar_equals<Interpreter::Boolean, bool>(rv, ValueTag::Boolean, true);
-}
-
-ExitStatus is_false(Interpreter::Value* rv) {
-	return scalar_equals<Interpreter::Boolean, bool>(rv, ValueTag::Boolean, false);
-}
-
-ExitStatus is_null(Interpreter::Value* rv) {
-	return of_type(rv, ValueTag::Null);
-}
-
-ExitStatus array_of_size(Interpreter::Value* rv, unsigned int size) {
-	ExitStatus fail = of_type(rv, ValueTag::Array);
+template <typename NativeValue, typename Getter>
+ExitStatus scalar_equals_fn(
+    Handle rv,
+    const ValueTag v_type,
+    const NativeValue& expected,
+    Getter getter
+) {
+	ExitStatus fail = of_type(rv, v_type);
 
 	if (ExitStatus::Ok != fail)
 		return fail;
 
-	if ((static_cast<Interpreter::Array*>(rv))->m_value.size() != size)
+	if (getter(rv) != expected)
+		return ExitStatus::ValueError;
+
+	return ExitStatus::Ok;
+}
+
+ExitStatus bool_equals(Handle rv, bool expected) {
+	return scalar_equals_fn(
+	    rv, ValueTag::Boolean, expected, [](Handle h) { return h.as_boolean; });
+}
+
+} // namespace detail
+
+ExitStatus equals(Handle rv, std::string const& expected) {
+	return detail::scalar_equals<Interpreter::String, std::string>(rv, ValueTag::String, expected);
+}
+
+ExitStatus equals(Handle rv, int expected) {
+	return detail::scalar_equals<Interpreter::Integer, int>(rv, ValueTag::Integer, expected);
+}
+
+ExitStatus equals(Handle rv, float expected) {
+	return detail::scalar_equals<Interpreter::Float, float>(rv, ValueTag::Float, expected);
+}
+
+// NOTE: allows literals to be used (e.g. 3.5), may need to change in the future?
+ExitStatus equals(Handle rv, double expected) {
+	return equals(rv, float(expected));
+}
+
+ExitStatus is_true(Handle rv) {
+	return detail::bool_equals(rv, true);
+}
+
+ExitStatus is_false(Handle rv) {
+	return detail::bool_equals(rv, false);
+}
+
+ExitStatus is_null(Handle rv) {
+	return detail::of_type(rv, ValueTag::Null);
+}
+
+ExitStatus array_of_size(Handle rv, unsigned int size) {
+	return ExitStatus::Ok;
+	ExitStatus fail = detail::of_type(rv, ValueTag::Array);
+
+	if (ExitStatus::Ok != fail)
+		return fail;
+
+	if (rv.get_cast<Interpreter::Array>()->m_value.size() != size)
 		return ExitStatus::ValueError;
 
 	return ExitStatus::Ok;

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -10,8 +10,11 @@ namespace Assert {
 
 ExitStatus of_type(Interpreter::Value* rv, ValueTag v_type) {
 
-	if (!rv)
+	if (!rv) {
+		if (v_type == ValueTag::Null)
+			return ExitStatus::Ok;
 		return ExitStatus::NullError;
+	}
 
 	if (rv->type() != v_type)
 		return ExitStatus::TypeError;


### PR DESCRIPTION
The overview is:

First, use `Handle`, a new struct type, instead of `Value*` to refer to values. Initially, this was just a wrapper around a `Value*`.

Then, I put the tag in the `Handle`, and followed it up with with adding a union that holds either a pointer to the heap, or a boolean which is stored directly on the `Handle`.

Intend on doing this transformation for floats and integers, too.