### PR TITLE
More data unboxing

### DIFF
--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -216,7 +216,7 @@ void eval(AST::FunctionLiteral* ast, Interpreter& e) {
 		assert(capture.second.outer_frame_offset != INT_MIN);
 		auto value = e.m_stack.frame_at(capture.second.outer_frame_offset);
 		auto offset = capture.second.inner_frame_offset - ast->m_args.size();
-		captures[offset] = as<Reference>(value);
+		captures[offset] = value.get_cast<Reference>();
 	}
 
 	auto result = e.new_function(ast, std::move(captures));

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -75,16 +75,6 @@ gc_ptr<Array> GC::new_list(ArrayType elements) {
 	return result;
 }
 
-gc_ptr<Float> GC::new_float(float f) {
-	return new_float_raw(f);
-}
-
-Float* GC::new_float_raw(float f) {
-	auto result = new Float(f);
-	m_blocks.push_back(result);
-	return result;
-}
-
 gc_ptr<String> GC::new_string(std::string s) {
 	return new_string_raw(std::move(s));
 }

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -55,7 +55,7 @@ void GC::add_root(Value* new_root) {
 	m_roots.push_back(new_root);
 }
 
-gc_ptr<Variant> GC::new_variant(InternedString constructor, Value* v) {
+gc_ptr<Variant> GC::new_variant(InternedString constructor, Handle v) {
 	auto result = new Variant(constructor, v);
 	m_blocks.push_back(result);
 	return result;
@@ -71,16 +71,6 @@ gc_ptr<Record> GC::new_record(RecordType declarations) {
 gc_ptr<Array> GC::new_list(ArrayType elements) {
 	auto result = new Array;
 	result->m_value = std::move(elements);
-	m_blocks.push_back(result);
-	return result;
-}
-
-gc_ptr<Integer> GC::new_integer(int i) {
-	return new_integer_raw(i);
-}
-
-Integer* GC::new_integer_raw(int i) {
-	auto result = new Integer(i);
 	m_blocks.push_back(result);
 	return result;
 }

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -25,10 +25,9 @@ struct GC {
 
 	void add_root(Value* new_root);
 
-	auto new_variant(InternedString constructor, Value* v) -> gc_ptr<Variant>;
+	auto new_variant(InternedString constructor, Handle v) -> gc_ptr<Variant>;
 	auto new_record(RecordType) -> gc_ptr<Record>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;
-	auto new_integer(int) -> gc_ptr<Integer>;
 	auto new_float(float) -> gc_ptr<Float>;
 	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
@@ -37,7 +36,6 @@ struct GC {
 	auto new_reference(Value*) -> gc_ptr<Reference>;
 	auto new_reference(Handle) -> gc_ptr<Reference>;
 
-	auto new_integer_raw(int) -> Integer*;
 	auto new_float_raw(float) -> Float*;
 	auto new_string_raw(std::string) -> String*;
 	auto new_variant_constructor_raw(InternedString) -> VariantConstructor*;

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -28,7 +28,6 @@ struct GC {
 	auto new_variant(InternedString constructor, Handle v) -> gc_ptr<Variant>;
 	auto new_record(RecordType) -> gc_ptr<Record>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;
-	auto new_float(float) -> gc_ptr<Float>;
 	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
@@ -36,7 +35,6 @@ struct GC {
 	auto new_reference(Value*) -> gc_ptr<Reference>;
 	auto new_reference(Handle) -> gc_ptr<Reference>;
 
-	auto new_float_raw(float) -> Float*;
 	auto new_string_raw(std::string) -> String*;
 	auto new_variant_constructor_raw(InternedString) -> VariantConstructor*;
 	auto new_record_constructor_raw(std::vector<InternedString>) -> RecordConstructor*;

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -94,7 +94,7 @@ void Interpreter::push_integer(int i) {
 }
 
 void Interpreter::push_float(float f) {
-	m_stack.push(Handle{m_gc->new_float_raw(f)});
+	m_stack.push(Handle{f});
 	run_gc_if_needed();
 }
 

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -89,7 +89,7 @@ Handle Interpreter::null() {
 }
 
 void Interpreter::push_integer(int i) {
-	m_stack.push(Handle{m_gc->new_integer_raw(i)});
+	m_stack.push(Handle{i});
 	run_gc_if_needed();
 }
 

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -59,7 +59,7 @@ Handle Interpreter::fetch_return_value() {
 void Interpreter::assign(Handle dst, Handle src) {
 	// NOTE: copied by reference, matters if rhs is actually a reference
 	// TODO: change in another pr, perhaps adding Interpreter::copy_value?
-	as<Reference>(dst)->m_value = value_of(src);
+	dst.get_cast<Reference>()->m_value = value_of(src);
 }
 
 

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -28,8 +28,8 @@ void Interpreter::global_declare_direct(const Identifier& i, Reference* r) {
 	m_global_scope.declare(i, r);
 }
 
-void Interpreter::global_declare(const Identifier& i, Value* v) {
-	if (v->type() == ValueTag::Reference)
+void Interpreter::global_declare(const Identifier& i, Handle v) {
+	if (v.type() == ValueTag::Reference)
 		assert(0 && "declared a reference!");
 	auto r = new_reference(v);
 	global_declare_direct(i, r.get());

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -52,7 +52,7 @@ struct Interpreter {
 
 	// Binds a global name to the given reference
 	void global_declare_direct(const Identifier& i, Reference* v);
-	void global_declare(const Identifier& i, Value* v);
+	void global_declare(const Identifier& i, Handle v);
 	Reference* global_access(const Identifier& i);
 	void assign(Handle dst, Handle src);
 

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -62,10 +62,7 @@ int main(int argc, char** argv) {
 				eval(top_level_call, env);
 			    auto result = env.m_stack.pop_unsafe();
 
-			    if (result.get())
-				    Interpreter::print(result);
-			    else
-				    std::cout << "(nullptr)\n";
+				Interpreter::print(result);
 		    }
 
 		    return ExitStatus::Ok;

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -97,7 +97,7 @@ Handle value_add(ArgsType v, Interpreter& e) {
 	case ValueTag::Integer:
 		return {OP_(as_integer, lhs, +, rhs)};
 	case ValueTag::Float:
-		return {e.m_gc->new_float_raw(OP(Float, lhs, +, rhs))};
+		return {OP_(as_float, lhs, +, rhs)};
 	case ValueTag::String:
 		return {e.m_gc->new_string_raw(OP(String, lhs, +, rhs))};
 	default:
@@ -116,7 +116,7 @@ Handle value_sub(ArgsType v, Interpreter& e) {
 	case ValueTag::Integer:
 		return {OP_(as_integer, lhs, -, rhs)};
 	case ValueTag::Float:
-		return {e.m_gc->new_float_raw(OP(Float, lhs, -, rhs))};
+		return {OP_(as_float, lhs, -, rhs)};
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -133,7 +133,7 @@ Handle value_mul(ArgsType v, Interpreter& e) {
 	case ValueTag::Integer:
 		return {OP_(as_integer, lhs, *, rhs)};
 	case ValueTag::Float:
-		return {e.m_gc->new_float_raw(OP(Float, lhs, *, rhs))};
+		return {OP_(as_float, lhs, *, rhs)};
 	default:
 		std::cerr << "ERROR: can't multiply values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -150,7 +150,7 @@ Handle value_div(ArgsType v, Interpreter& e) {
 	case ValueTag::Integer:
 		return {OP_(as_integer, lhs, /, rhs)};
 	case ValueTag::Float:
-		return {e.m_gc->new_float_raw(OP(Float, lhs, /, rhs))};
+		return {OP_(as_float, lhs, /, rhs)};
 	default:
 		std::cerr << "ERROR: can't divide values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -206,7 +206,7 @@ Handle value_equals(ArgsType v, Interpreter& e) {
 	case ValueTag::Integer:
 		return {OP_(as_integer, lhs, ==, rhs)};
 	case ValueTag::Float:
-		return {OP(Float, lhs, ==, rhs)};
+		return {OP_(as_float, lhs, ==, rhs)};
 	case ValueTag::String:
 		return {OP(String, lhs, ==, rhs)};
 	case ValueTag::Boolean:
@@ -235,7 +235,7 @@ Handle value_less(ArgsType v, Interpreter& e) {
 	case ValueTag::Integer:
 		return {bool(OP_(as_integer, lhs, <, rhs))};
 	case ValueTag::Float:
-		return {bool(OP(Float, lhs, <, rhs))};
+		return {bool(OP_(as_float, lhs, <, rhs))};
 	case ValueTag::String:
 		return {bool(OP(String, lhs, <, rhs))};
 	default:
@@ -276,7 +276,7 @@ Handle read_number(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	float result;
 	std::cin >> result;
-	return {e.m_gc->new_float_raw(result)};
+	return {result};
 }
 
 Handle read_line(ArgsType v, Interpreter& e) {

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -58,7 +58,7 @@ Handle size(ArgsType v, Interpreter& e) {
 	assert(v.size() == 1);
 	Array* array = value_as<Array>(v[0]);
 
-	return {e.m_gc->new_integer_raw(array->m_value.size())};
+	return {int(array->m_value.size())};
 }
 
 // array_join(array, string) returns a string with
@@ -72,7 +72,7 @@ Handle array_join(ArgsType v, Interpreter& e) {
 	std::stringstream result;
 	for (unsigned int i = 0; i < array->m_value.size(); i++) {
 		if (i > 0) result << sep->m_value;
-		result << value_as<Integer>(array->m_value[i])->m_value;
+		result << array->m_value[i]->m_value.get_integer();
 	}
 	return {e.m_gc->new_string_raw(result.str())};
 }
@@ -82,10 +82,10 @@ Handle array_at(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 2);
 	Array* array = value_as<Array>(v[0]);
-	Integer* index = value_as<Integer>(v[1]);
-	assert(index->m_value >= 0);
-	assert(index->m_value < array->m_value.size());
-	return {array->m_value[index->m_value]};
+	int index = v[1].get_integer();
+	assert(index >= 0);
+	assert(index < array->m_value.size());
+	return {array->m_value[index]};
 }
 
 Handle value_add(ArgsType v, Interpreter& e) {
@@ -95,7 +95,7 @@ Handle value_add(ArgsType v, Interpreter& e) {
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return {e.m_gc->new_integer_raw(OP(Integer, lhs, +, rhs))};
+		return {OP_(as_integer, lhs, +, rhs)};
 	case ValueTag::Float:
 		return {e.m_gc->new_float_raw(OP(Float, lhs, +, rhs))};
 	case ValueTag::String:
@@ -114,7 +114,7 @@ Handle value_sub(ArgsType v, Interpreter& e) {
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return {e.m_gc->new_integer_raw(OP(Integer, lhs, -, rhs))};
+		return {OP_(as_integer, lhs, -, rhs)};
 	case ValueTag::Float:
 		return {e.m_gc->new_float_raw(OP(Float, lhs, -, rhs))};
 	default:
@@ -131,7 +131,7 @@ Handle value_mul(ArgsType v, Interpreter& e) {
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return {e.m_gc->new_integer_raw(OP(Integer, lhs, *, rhs))};
+		return {OP_(as_integer, lhs, *, rhs)};
 	case ValueTag::Float:
 		return {e.m_gc->new_float_raw(OP(Float, lhs, *, rhs))};
 	default:
@@ -148,7 +148,7 @@ Handle value_div(ArgsType v, Interpreter& e) {
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return {e.m_gc->new_integer_raw(OP(Integer, lhs, /, rhs))};
+		return {OP_(as_integer, lhs, /, rhs)};
 	case ValueTag::Float:
 		return {e.m_gc->new_float_raw(OP(Float, lhs, /, rhs))};
 	default:
@@ -204,7 +204,7 @@ Handle value_equals(ArgsType v, Interpreter& e) {
 	case ValueTag::Null:
 		return {true};
 	case ValueTag::Integer:
-		return {OP(Integer, lhs, ==, rhs)};
+		return {OP_(as_integer, lhs, ==, rhs)};
 	case ValueTag::Float:
 		return {OP(Float, lhs, ==, rhs)};
 	case ValueTag::String:
@@ -233,7 +233,7 @@ Handle value_less(ArgsType v, Interpreter& e) {
 
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return {bool(OP(Integer, lhs, <, rhs))};
+		return {bool(OP_(as_integer, lhs, <, rhs))};
 	case ValueTag::Float:
 		return {bool(OP(Float, lhs, <, rhs))};
 	case ValueTag::String:
@@ -269,7 +269,7 @@ Handle read_integer(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	int result;
 	std::cin >> result;
-	return {e.m_gc->new_integer_raw(result)};
+	return {result};
 }
 
 Handle read_number(ArgsType v, Interpreter& e) {

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -9,18 +9,9 @@ namespace Interpreter {
 Handle value_of(Handle value);
 
 template<typename T>
-T* as(Handle h) {
-	static_assert(std::is_base_of<Value, T>::value, "T is not a subclass of Value");
-	assert(h.type() == type_data<T>::tag);
-	T* result = h.get_cast<T>();
-	assert(result);
-	return result;
-}
-
-template<typename T>
 T* value_as(Handle h) {
 	static_assert(std::is_base_of<Value, T>::value, "T is not a subclass of Value");
-	return as<T>(value_of(h));
+	return value_of(h).get_cast<T>();
 }
 
 } // namespace Interpreter

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -6,21 +6,6 @@
 
 namespace Interpreter {
 
-template<typename T>
-struct type_data;
-
-template<> struct type_data<Integer> { static constexpr auto tag = ValueTag::Integer; };
-template<> struct type_data<Float> { static constexpr auto tag = ValueTag::Float; };
-template<> struct type_data<String> { static constexpr auto tag = ValueTag::String; };
-template<> struct type_data<Array> { static constexpr auto tag = ValueTag::Array; };
-template<> struct type_data<Record> { static constexpr auto tag = ValueTag::Record; };
-template<> struct type_data<Variant> { static constexpr auto tag = ValueTag::Variant; };
-template<> struct type_data<Function> { static constexpr auto tag = ValueTag::Function; };
-template<> struct type_data<NativeFunction> { static constexpr auto tag = ValueTag::NativeFunction; };
-template<> struct type_data<Reference> { static constexpr auto tag = ValueTag::Reference; };
-template<> struct type_data<VariantConstructor> { static constexpr auto tag = ValueTag::VariantConstructor; };
-template<> struct type_data<RecordConstructor> { static constexpr auto tag = ValueTag::RecordConstructor; };
-
 Handle value_of(Handle value);
 
 template<typename T>

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -6,12 +6,6 @@
 
 namespace Interpreter {
 
-Float::Float()
-    : Value(ValueTag::Float) {}
-Float::Float(float v)
-    : Value(ValueTag::Float)
-    , m_value(v) {}
-
 String::String()
     : Value(ValueTag::String) {}
 String::String(std::string s)
@@ -90,9 +84,6 @@ RecordConstructor::RecordConstructor(std::vector<InternedString> keys)
     : Value {ValueTag::RecordConstructor}
     , m_keys {std::move(keys)} {}
 
-void gc_visit(Float* v) {
-	v->m_visited = true;
-}
 void gc_visit(String* v) {
 	v->m_visited = true;
 }
@@ -155,8 +146,6 @@ void gc_visit(Reference* r) {
 
 void gc_visit(Value* v) {
 	switch (v->type()) {
-	case ValueTag::Float:
-		return gc_visit(static_cast<Float*>(v));
 	case ValueTag::String:
 		return gc_visit(static_cast<String*>(v));
 	case ValueTag::Error:
@@ -197,9 +186,9 @@ void print(int v, int d) {
 	std::cout << value_string[int(ValueTag::Integer)] << ' ' << v << '\n';
 }
 
-void print(Float* v, int d) {
+void print(float v, int d) {
 	print_spaces(d);
-	std::cout << value_string[int(v->type())] << ' ' << v->m_value << '\n';
+	std::cout << value_string[int(ValueTag::Float)] << ' ' << v << '\n';
 }
 
 void print(String* v, int d) {
@@ -274,8 +263,6 @@ void print(VariantConstructor* l, int d) {
 void print(Value* v, int d) {
 
 	switch (v->type()) {
-	case ValueTag::Float:
-		return print(static_cast<Float*>(v), d);
 	case ValueTag::String:
 		return print(static_cast<String*>(v), d);
 	case ValueTag::Error:
@@ -307,6 +294,8 @@ void print(Handle h, int d) {
 		return print(h.as_boolean, d);
 	case ValueTag::Integer:
 		return print(h.as_integer, d);
+	case ValueTag::Float:
+		return print(h.as_float, d);
 	case ValueTag::Null:
 		print_spaces(d);
 		return void(std::cout << "(null)\n");

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -73,9 +73,6 @@ Reference::Reference(Handle value)
     : Value {ValueTag::Reference}
     , m_value {value} {}
 
-Reference::Reference(Value* value)
-    : Reference {Handle{value}} {}
-
 VariantConstructor::VariantConstructor(InternedString constructor)
     : Value {ValueTag::VariantConstructor}
     , m_constructor {constructor} {}

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -68,6 +68,10 @@ struct Handle {
 	    : tag {ValueTag::Integer}
 	    , as_integer {integer} {}
 
+	Handle(float number)
+	    : tag {ValueTag::Float}
+	    , as_float {number} {}
+
 	Handle()
 	    : tag {ValueTag::Null}
 	    , ptr {nullptr} {}
@@ -88,6 +92,11 @@ struct Handle {
 		return as_integer;
 	}
 
+	float get_float() {
+		assert(tag == ValueTag::Float);
+		return as_float;
+	}
+
 	bool get_boolean() {
 		assert(tag == ValueTag::Boolean);
 		return as_boolean;
@@ -104,18 +113,12 @@ struct Handle {
 	Value* ptr;
 	bool as_boolean;
 	int as_integer;
+	float as_float;
 	};
 };
 
 void gc_visit(Handle);
 void print(Handle v, int d = 0);
-
-struct Float : Value {
-	float m_value = 0.0;
-
-	Float();
-	Float(float v);
-};
 
 struct String : Value {
 	std::string m_value = "";
@@ -187,7 +190,6 @@ struct RecordConstructor : Value {
 template<typename T>
 struct type_data;
 
-template<> struct type_data<Float> { static constexpr auto tag = ValueTag::Float; };
 template<> struct type_data<String> { static constexpr auto tag = ValueTag::String; };
 template<> struct type_data<Array> { static constexpr auto tag = ValueTag::Array; };
 template<> struct type_data<Record> { static constexpr auto tag = ValueTag::Record; };

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -174,7 +174,6 @@ struct Reference : Value {
 	Handle m_value;
 
 	Reference(Handle value);
-	Reference(Value* value);
 };
 
 struct VariantConstructor : Value {

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -48,7 +48,7 @@ struct Value {
 };
 
 inline bool is_heap_type(ValueTag tag) {
-	return tag != ValueTag::Null && tag != ValueTag::Boolean && tag != ValueTag::Integer;
+	return tag != ValueTag::Null && tag != ValueTag::Boolean && tag != ValueTag::Integer && tag != ValueTag::Float;
 }
 
 struct Handle {
@@ -103,8 +103,10 @@ struct Handle {
 	}
 
 	ValueTag type() {
-		if (is_heap_type(tag))
+		if (is_heap_type(tag)) {
+			assert(ptr);
 			assert(ptr->type() == tag);
+		}
 		return tag;
 	}
 

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -63,7 +63,8 @@ ExitStatus equals(Handle rv, std::string const& expected) {
 }
 
 ExitStatus equals(Handle rv, int expected) {
-	return detail::scalar_equals<Interpreter::Integer, int>(rv, ValueTag::Integer, expected);
+	return detail::scalar_equals_fn(
+	    rv, ValueTag::Integer, expected, [](Handle h) { return h.as_integer; });
 }
 
 ExitStatus equals(Handle rv, float expected) {

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -68,7 +68,8 @@ ExitStatus equals(Handle rv, int expected) {
 }
 
 ExitStatus equals(Handle rv, float expected) {
-	return detail::scalar_equals<Interpreter::Float, float>(rv, ValueTag::Float, expected);
+	return detail::scalar_equals_fn(
+	    rv, ValueTag::Float, expected, [](Handle h) { return h.as_float; });
 }
 
 // NOTE: allows literals to be used (e.g. 3.5), may need to change in the future?


### PR DESCRIPTION
I put integers and numbers directly inside handles.

Comparing with before #276, I measured a 40% speedup on a benchmark that's heavy on integer math and comparisons (essentially best case scenario for this optimization), and 19% in another one that does some function calls and other stuff on the side.

I also fixed a few bugs from my previous pr along the way, and removed some outdated interfaces.