### PR TITLE
Post refactor interpreter cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ INTERPRETER_TARGETS := \
 	execute \
 	garbage_collector \
 	gc_ptr \
+	gc_cell \
 	interpreter \
 	native \
 	stack \

--- a/src/interpreter/error.cpp
+++ b/src/interpreter/error.cpp
@@ -5,9 +5,9 @@
 namespace Interpreter {
 
 Error::Error()
-    : Value(ValueTag::Error) {}
+    : GcCell(ValueTag::Error) {}
 Error::Error(std::string message)
-    : Value(ValueTag::Error)
+    : GcCell(ValueTag::Error)
     , m_error(message) {}
 
 Error make_reference_error(const Identifier& i) {

--- a/src/interpreter/error.hpp
+++ b/src/interpreter/error.hpp
@@ -4,7 +4,7 @@
 
 namespace Interpreter {
 
-struct Error : Value {
+struct Error : GcCell {
 	std::string m_error;
 
 	Error();

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -29,7 +29,7 @@ static void eval_stmt(AST::AST* ast, Interpreter& e) {
 }
 
 void eval(AST::Declaration* ast, Interpreter& e) {
-	auto ref = e.new_reference(nullptr);
+	auto ref = e.new_reference(Value {nullptr});
 	e.m_stack.push(ref.as_value());
 	if (ast->m_value) {
 		eval(ast->m_value, e);
@@ -76,7 +76,7 @@ void eval(AST::ArrayLiteral* ast, Interpreter& e) {
 	result->m_value.reserve(ast->m_elements.size());
 	for (auto& element : ast->m_elements) {
 		eval(element, e);
-		auto ref = e.new_reference(nullptr);
+		auto ref = e.new_reference(Value {nullptr});
 		ref->m_value = value_of(e.m_stack.pop_unsafe());
 		result->append(ref.get());
 	}
@@ -156,7 +156,7 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 			eval(expr, e);
 
 			// wrap arg in reference
-			auto ref = e.new_reference(nullptr);
+			auto ref = e.new_reference(Value {nullptr});
 			ref->m_value = value_of(e.m_stack.access(0));
 			e.m_stack.access(0) = ref.as_value();
 		}
@@ -242,7 +242,7 @@ void eval(AST::MatchExpression* ast, Interpreter& e) {
 	// We won't pop it, because it is already lined up for the later
 	// expressions. Instead, replace the variant with its inner value.
 	// We also wrap it in a reference so it can be captured
-	auto ref = e.new_reference(nullptr);
+	auto ref = e.new_reference(Value {nullptr});
 	ref->m_value = variant_value;
 	e.m_stack.access(0) = ref.as_value();
 	

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -173,7 +173,7 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 		auto args = e.m_stack.frame_range(0, arg_count);
 
 		// compute the result of the function, and clobber the callee
-		e.m_stack.frame_at(-1) = callee.get_cast<NativeFunction>()->m_fptr(args, e);
+		e.m_stack.frame_at(-1) = callee.get_native_func()(args, e);
 	} else {
 		Log::fatal("Attempted to call a non function at runtime");
 	}

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -107,7 +107,7 @@ Value eval_expression(
 		auto err = Frontend::match_identifiers(ast, context);
 		if (!err.ok()) {
 			err.print();
-			return nullptr;
+			return env.null();
 		}
 	}
 

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -88,7 +88,7 @@ ExitStatus execute(
 // Note that we can't just call match_identifiers, because that wouldn't take
 // into account the rest of the program that's already been processed, before
 // this is run
-Handle eval_expression(
+Value eval_expression(
 	const std::string& expr,
 	Interpreter& env,
 	Frontend::SymbolTable& context

--- a/src/interpreter/execute.hpp
+++ b/src/interpreter/execute.hpp
@@ -27,7 +27,7 @@ ExitStatus execute(
 );
 
 // evaluates an expression and returns the resulting value
-Handle eval_expression(
+Value eval_expression(
 	const std::string& expr,
 	Interpreter& env,
 	Frontend::SymbolTable&

--- a/src/interpreter/execute.hpp
+++ b/src/interpreter/execute.hpp
@@ -11,7 +11,6 @@ struct SymbolTable;
 namespace Interpreter {
 
 struct Interpreter;
-struct Value;
 
 using Runner = auto(Interpreter&, Frontend::SymbolTable&) -> ExitStatus;
 

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -21,15 +21,12 @@ void GC::unmark_all() {
 }
 
 void GC::mark_roots() {
-	for (auto* root : m_roots) {
-		gc_visit(root);
-	}
+	for (auto* root : m_roots)
+		root->visit();
 
-	for (auto* val : m_blocks) {
-		if (val->m_cpp_refcount != 0) {
-			gc_visit(val);
-		}
-	}
+	for (auto* val : m_blocks)
+		if (val->m_cpp_refcount != 0)
+			val->visit();
 }
 
 void GC::sweep() {

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -88,12 +88,6 @@ gc_ptr<Function> GC::new_function(FunctionType def, CapturesType captures) {
 	return result;
 }
 
-gc_ptr<NativeFunction> GC::new_native_function(NativeFunctionType* fptr) {
-	auto result = new NativeFunction(fptr);
-	m_blocks.push_back(result);
-	return result;
-}
-
 gc_ptr<Error> GC::new_error(std::string s) {
 	auto result = new Error(std::move(s));
 	m_blocks.push_back(result);

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -55,7 +55,7 @@ void GC::add_root(GcCell* new_root) {
 	m_roots.push_back(new_root);
 }
 
-gc_ptr<Variant> GC::new_variant(InternedString constructor, Handle v) {
+gc_ptr<Variant> GC::new_variant(InternedString constructor, Value v) {
 	auto result = new Variant(constructor, v);
 	m_blocks.push_back(result);
 	return result;
@@ -103,7 +103,7 @@ gc_ptr<Error> GC::new_error(std::string s) {
 	return result;
 }
 
-gc_ptr<Reference> GC::new_reference(Handle v) {
+gc_ptr<Reference> GC::new_reference(Value v) {
 	auto result = new Reference(std::move(v));
 	m_blocks.push_back(result);
 	return result;

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -40,7 +40,7 @@ void GC::sweep() {
 		}
 	}
 
-	auto is_null = [&](Value* p) { return p == nullptr; };
+	auto is_null = [&](GcCell* p) { return p == nullptr; };
 
 	m_blocks.erase(
 	    std::remove_if(m_blocks.begin(), m_blocks.end(), is_null), m_blocks.end());
@@ -51,7 +51,7 @@ void GC::sweep_all() {
 	sweep();
 }
 
-void GC::add_root(Value* new_root) {
+void GC::add_root(GcCell* new_root) {
 	m_roots.push_back(new_root);
 }
 
@@ -101,10 +101,6 @@ gc_ptr<Error> GC::new_error(std::string s) {
 	auto result = new Error(std::move(s));
 	m_blocks.push_back(result);
 	return result;
-}
-
-gc_ptr<Reference> GC::new_reference(Value* v) {
-	return new_reference(Handle{v});
 }
 
 gc_ptr<Reference> GC::new_reference(Handle v) {

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -30,7 +30,6 @@ struct GC {
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
-	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 	auto new_reference(Value) -> gc_ptr<Reference>;
 

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -25,14 +25,14 @@ struct GC {
 
 	void add_root(GcCell* new_root);
 
-	auto new_variant(InternedString constructor, Handle v) -> gc_ptr<Variant>;
+	auto new_variant(InternedString constructor, Value v) -> gc_ptr<Variant>;
 	auto new_record(RecordType) -> gc_ptr<Record>;
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
-	auto new_reference(Handle) -> gc_ptr<Reference>;
+	auto new_reference(Value) -> gc_ptr<Reference>;
 
 	auto new_string_raw(std::string) -> String*;
 	auto new_variant_constructor_raw(InternedString) -> VariantConstructor*;

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -11,8 +11,8 @@ struct Error;
 
 struct GC {
   public:
-	std::vector<Value*> m_blocks;
-	std::vector<Value*> m_roots;
+	std::vector<GcCell*> m_blocks;
+	std::vector<GcCell*> m_roots;
 
 	GC();
 	~GC();
@@ -23,7 +23,7 @@ struct GC {
 	void sweep_all();
 	int size () { return m_blocks.size(); }
 
-	void add_root(Value* new_root);
+	void add_root(GcCell* new_root);
 
 	auto new_variant(InternedString constructor, Handle v) -> gc_ptr<Variant>;
 	auto new_record(RecordType) -> gc_ptr<Record>;
@@ -32,7 +32,6 @@ struct GC {
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
-	auto new_reference(Value*) -> gc_ptr<Reference>;
 	auto new_reference(Handle) -> gc_ptr<Reference>;
 
 	auto new_string_raw(std::string) -> String*;

--- a/src/interpreter/gc_cell.cpp
+++ b/src/interpreter/gc_cell.cpp
@@ -5,6 +5,8 @@
 
 namespace Interpreter {
 
+static void gc_visit(GcCell* v);
+
 static void gc_visit(Value h) {
 	if (is_heap_type(h.type()))
 		return gc_visit(h.get());
@@ -70,7 +72,7 @@ static void gc_visit(Reference* r) {
 	gc_visit(r->m_value);
 }
 
-void gc_visit(GcCell* v) {
+static void gc_visit(GcCell* v) {
 	switch (v->type()) {
 	case ValueTag::String:
 		return gc_visit(static_cast<String*>(v));
@@ -95,6 +97,10 @@ void gc_visit(GcCell* v) {
 	default:
 		assert(0);
 	}
+}
+
+void GcCell::visit() {
+	return gc_visit(this);
 }
 
 } // namespace Interpreter

--- a/src/interpreter/gc_cell.cpp
+++ b/src/interpreter/gc_cell.cpp
@@ -18,9 +18,6 @@ static void gc_visit(String* v) {
 static void gc_visit(Error* v) {
 	v->m_visited = true;
 }
-static void gc_visit(NativeFunction* v) {
-	v->m_visited = true;
-}
 static void gc_visit(VariantConstructor* v) {
 	v->m_visited = true;
 }
@@ -86,8 +83,6 @@ static void gc_visit(GcCell* v) {
 		return gc_visit(static_cast<Variant*>(v));
 	case ValueTag::Function:
 		return gc_visit(static_cast<Function*>(v));
-	case ValueTag::NativeFunction:
-		return gc_visit(static_cast<NativeFunction*>(v));
 	case ValueTag::Reference:
 		return gc_visit(static_cast<Reference*>(v));
 	case ValueTag::VariantConstructor:

--- a/src/interpreter/gc_cell.cpp
+++ b/src/interpreter/gc_cell.cpp
@@ -1,1 +1,100 @@
 #include "gc_cell.hpp"
+
+#include "value.hpp"
+#include "error.hpp"
+
+namespace Interpreter {
+
+static void gc_visit(Value h) {
+	if (is_heap_type(h.type()))
+		return gc_visit(h.get());
+}
+
+static void gc_visit(String* v) {
+	v->m_visited = true;
+}
+static void gc_visit(Error* v) {
+	v->m_visited = true;
+}
+static void gc_visit(NativeFunction* v) {
+	v->m_visited = true;
+}
+static void gc_visit(VariantConstructor* v) {
+	v->m_visited = true;
+}
+static void gc_visit(RecordConstructor* v) {
+	v->m_visited = true;
+}
+
+static void gc_visit(Array* l) {
+	if (l->m_visited)
+		return;
+
+	l->m_visited = true;
+	for (auto* child : l->m_value) {
+		gc_visit(child);
+	}
+}
+
+static void gc_visit(Record* o) {
+	if (o->m_visited)
+		return;
+
+	o->m_visited = true;
+	for (auto child : o->m_value)
+		gc_visit(child.second);
+}
+
+static void gc_visit(Variant* u) {
+	if (u->m_visited)
+		return;
+
+	u->m_visited = true;
+	gc_visit(u->m_inner_value);
+}
+
+static void gc_visit(Function* f) {
+	if (f->m_visited)
+		return;
+
+	f->m_visited = true;
+	for (auto& capture : f->m_captures)
+		gc_visit(capture);
+}
+
+static void gc_visit(Reference* r) {
+	if (r->m_visited)
+		return;
+
+	r->m_visited = true;
+	gc_visit(r->m_value);
+}
+
+void gc_visit(GcCell* v) {
+	switch (v->type()) {
+	case ValueTag::String:
+		return gc_visit(static_cast<String*>(v));
+	case ValueTag::Error:
+		return gc_visit(static_cast<Error*>(v));
+	case ValueTag::Array:
+		return gc_visit(static_cast<Array*>(v));
+	case ValueTag::Record:
+		return gc_visit(static_cast<Record*>(v));
+	case ValueTag::Variant:
+		return gc_visit(static_cast<Variant*>(v));
+	case ValueTag::Function:
+		return gc_visit(static_cast<Function*>(v));
+	case ValueTag::NativeFunction:
+		return gc_visit(static_cast<NativeFunction*>(v));
+	case ValueTag::Reference:
+		return gc_visit(static_cast<Reference*>(v));
+	case ValueTag::VariantConstructor:
+		return gc_visit(static_cast<VariantConstructor*>(v));
+	case ValueTag::RecordConstructor:
+		return gc_visit(static_cast<RecordConstructor*>(v));
+	default:
+		assert(0);
+	}
+}
+
+} // namespace Interpreter

--- a/src/interpreter/gc_cell.cpp
+++ b/src/interpreter/gc_cell.cpp
@@ -1,0 +1,1 @@
+#include "gc_cell.hpp"

--- a/src/interpreter/gc_cell.hpp
+++ b/src/interpreter/gc_cell.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "value_tag.hpp"
+
+struct GcCell {
+  protected:
+	ValueTag m_tag;
+
+  public:
+	bool m_visited = false;
+	int m_cpp_refcount = 0;
+
+	GcCell(ValueTag type)
+	    : m_tag(type) {}
+
+	ValueTag type() const {
+		return m_tag;
+	}
+
+	virtual ~GcCell() = default;
+};

--- a/src/interpreter/gc_cell.hpp
+++ b/src/interpreter/gc_cell.hpp
@@ -19,9 +19,9 @@ struct GcCell {
 		return m_tag;
 	}
 
+	void visit();
+
 	virtual ~GcCell() = default;
 };
-
-void gc_visit(GcCell*);
 
 } // namespace Interpreter

--- a/src/interpreter/gc_cell.hpp
+++ b/src/interpreter/gc_cell.hpp
@@ -2,6 +2,8 @@
 
 #include "value_tag.hpp"
 
+namespace Interpreter {
+
 struct GcCell {
   protected:
 	ValueTag m_tag;
@@ -19,3 +21,7 @@ struct GcCell {
 
 	virtual ~GcCell() = default;
 };
+
+void gc_visit(GcCell*);
+
+} // namespace Interpreter

--- a/src/interpreter/gc_ptr.hpp
+++ b/src/interpreter/gc_ptr.hpp
@@ -62,7 +62,7 @@ struct gc_ptr {
 		return get();
 	}
 
-	Interpreter::Handle handle() {
-		return Interpreter::Handle {get()};
+	Interpreter::Value as_value() {
+		return Interpreter::Value {get()};
 	}
 };

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -68,7 +68,8 @@ void Interpreter::run_gc() {
 	m_gc->mark_roots();
 
 	for (auto p : m_stack.m_stack)
-		gc_visit(p);
+		if (is_heap_type(p.type()))
+				gc_visit(p.get());
 
 	for (auto& p : m_global_scope.m_declarations)
 		gc_visit(p.second);

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -137,12 +137,6 @@ gc_ptr<Function> Interpreter::new_function(FunctionType def, CapturesType s) {
 	return result;
 }
 
-gc_ptr<NativeFunction> Interpreter::new_native_function(NativeFunctionType* fptr) {
-	auto result = m_gc->new_native_function(fptr);
-	run_gc_if_needed();
-	return result;
-}
-
 gc_ptr<Error> Interpreter::new_error(std::string e) {
 	auto result = m_gc->new_error(e);
 	run_gc_if_needed();

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -28,7 +28,7 @@ void Interpreter::global_declare_direct(const Identifier& i, Reference* r) {
 	m_global_scope.declare(i, r);
 }
 
-void Interpreter::global_declare(const Identifier& i, Handle v) {
+void Interpreter::global_declare(const Identifier& i, Value v) {
 	if (v.type() == ValueTag::Reference)
 		assert(0 && "declared a reference!");
 	auto r = new_reference(v);
@@ -40,23 +40,23 @@ Reference* Interpreter::global_access(const Identifier& i) {
 }
 
 
-void Interpreter::save_return_value(Handle v) {
+void Interpreter::save_return_value(Value v) {
 	// ensure we are not in a return sequence already
 	assert(!m_returning);
 	m_returning = true;
 	m_return_value = v;
 }
 
-Handle Interpreter::fetch_return_value() {
+Value Interpreter::fetch_return_value() {
 	// ensure we were in a return sequence
 	assert(m_returning);
 	m_returning = false;
-	Handle rv = m_return_value;
-	m_return_value = Handle{};
+	Value rv = m_return_value;
+	m_return_value = Value{};
 	return rv;
 }
 
-void Interpreter::assign(Handle dst, Handle src) {
+void Interpreter::assign(Value dst, Value src) {
 	// NOTE: copied by reference, matters if rhs is actually a reference
 	// TODO: change in another pr, perhaps adding Interpreter::copy_value?
 	dst.get_cast<Reference>()->m_value = value_of(src);
@@ -84,37 +84,37 @@ void Interpreter::run_gc_if_needed(){
 }
 
 
-Handle Interpreter::null() {
-	return Handle{nullptr};
+Value Interpreter::null() {
+	return Value{nullptr};
 }
 
 void Interpreter::push_integer(int i) {
-	m_stack.push(Handle{i});
+	m_stack.push(Value{i});
 	run_gc_if_needed();
 }
 
 void Interpreter::push_float(float f) {
-	m_stack.push(Handle{f});
+	m_stack.push(Value{f});
 	run_gc_if_needed();
 }
 
 void Interpreter::push_boolean(bool b) {
-	m_stack.push(Handle{b});
+	m_stack.push(Value{b});
 	run_gc_if_needed();
 }
 
 void Interpreter::push_string(std::string s) {
-	m_stack.push(Handle{m_gc->new_string_raw(std::move(s))});
+	m_stack.push(Value{m_gc->new_string_raw(std::move(s))});
 	run_gc_if_needed();
 }
 
 void Interpreter::push_variant_constructor(InternedString constructor) {
-	m_stack.push(Handle{m_gc->new_variant_constructor_raw(constructor)});
+	m_stack.push(Value{m_gc->new_variant_constructor_raw(constructor)});
 	run_gc_if_needed();
 }
 
 void Interpreter::push_record_constructor(std::vector<InternedString> keys) {
-	m_stack.push(Handle{m_gc->new_record_constructor_raw(std::move(keys))});
+	m_stack.push(Value{m_gc->new_record_constructor_raw(std::move(keys))});
 	run_gc_if_needed();
 }
 
@@ -148,7 +148,7 @@ gc_ptr<Error> Interpreter::new_error(std::string e) {
 	return result;
 }
 
-gc_ptr<Reference> Interpreter::new_reference(Handle v) {
+gc_ptr<Reference> Interpreter::new_reference(Value v) {
 	assert(
 	    v.type() != ValueTag::Reference &&
 	    "References to references are not allowed.");

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -69,10 +69,10 @@ void Interpreter::run_gc() {
 
 	for (auto p : m_stack.m_stack)
 		if (is_heap_type(p.type()))
-				gc_visit(p.get());
+				p.get()->visit();
 
 	for (auto& p : m_global_scope.m_declarations)
-		gc_visit(p.second);
+		p.second->visit();
 
 	m_gc->sweep();
 }

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -66,9 +66,7 @@ struct Interpreter {
 	auto new_list(ArrayType) -> gc_ptr<Array>;
 	auto new_record(RecordType) -> gc_ptr<Record>;
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
-	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
-
 	auto new_reference(Value) -> gc_ptr<Reference>;
 };
 

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -33,7 +33,7 @@ struct Interpreter {
 	std::vector<std::vector<AST::Declaration*>> const* m_declaration_order;
 	int m_gc_size_on_last_pass {64};
 	bool m_returning{false};
-	Handle m_return_value {nullptr};
+	Value m_return_value {nullptr};
 	Scope m_global_scope;
 
 	Interpreter(
@@ -44,19 +44,19 @@ struct Interpreter {
 	    , m_gc {gc}
 	    , m_declaration_order {declaration_order} {}
 
-	void save_return_value(Handle);
-	Handle fetch_return_value();
+	void save_return_value(Value);
+	Value fetch_return_value();
 
 	void run_gc();
 	void run_gc_if_needed();
 
 	// Binds a global name to the given reference
 	void global_declare_direct(const Identifier& i, Reference* v);
-	void global_declare(const Identifier& i, Handle v);
+	void global_declare(const Identifier& i, Value v);
 	Reference* global_access(const Identifier& i);
-	void assign(Handle dst, Handle src);
+	void assign(Value dst, Value src);
 
-	auto null() -> Handle;
+	auto null() -> Value;
 	void push_integer(int);
 	void push_float(float);
 	void push_boolean(bool);
@@ -69,7 +69,7 @@ struct Interpreter {
 	auto new_native_function(NativeFunctionType*) -> gc_ptr<NativeFunction>;
 	auto new_error(std::string) -> gc_ptr<Error>;
 
-	auto new_reference(Handle) -> gc_ptr<Reference>;
+	auto new_reference(Value) -> gc_ptr<Reference>;
 };
 
 } // namespace Interpreter

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -13,7 +13,6 @@
 #include "eval.hpp"
 #include "execute.hpp"
 #include "exit_status_tag.hpp"
-#include "gc_ptr.hpp"
 #include "interpreter.hpp"
 #include "value.hpp"
 

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -16,7 +16,7 @@ namespace Interpreter {
 	(lhs).get_cast<type>()->m_value op (rhs).get_cast<type>()->m_value
 
 #define OP_(field, lhs, op, rhs)                                               \
-	(lhs).field op (rhs).field
+	Value {(lhs).field op (rhs).field}
 
 using ArgsType = Span<Value>;
 
@@ -35,7 +35,7 @@ Value array_append(ArgsType v, Interpreter& e) {
 	for (unsigned int i = 1; i < v.size(); i++) {
 		array->append(e.new_reference(value_of(v[i])).get());
 	}
-	return {array};
+	return Value {array};
 }
 
 // array_extend(arr1, arr2) appends the values in arr2 to
@@ -47,7 +47,7 @@ Value array_extend(ArgsType v, Interpreter& e) {
 	Array* arr2 = value_as<Array>(v[1]);
 	arr1->m_value.insert(
 	    arr1->m_value.end(), arr2->m_value.begin(), arr2->m_value.end());
-	return {arr1};
+	return Value {arr1};
 }
 
 // size(array) returns the size of the array
@@ -72,7 +72,7 @@ Value array_join(ArgsType v, Interpreter& e) {
 		if (i > 0) result << sep->m_value;
 		result << array->m_value[i]->m_value.get_integer();
 	}
-	return {e.m_gc->new_string_raw(result.str())};
+	return Value{e.m_gc->new_string_raw(result.str())};
 }
 
 // array_at(array, int i) returns the i-th element of the given array
@@ -83,7 +83,7 @@ Value array_at(ArgsType v, Interpreter& e) {
 	int index = v[1].get_integer();
 	assert(index >= 0);
 	assert(index < array->m_value.size());
-	return {array->m_value[index]};
+	return Value{array->m_value[index]};
 }
 
 Value value_add(ArgsType v, Interpreter& e) {
@@ -93,11 +93,11 @@ Value value_add(ArgsType v, Interpreter& e) {
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return {OP_(as_integer, lhs, +, rhs)};
+		return OP_(as_integer, lhs, +, rhs);
 	case ValueTag::Float:
-		return {OP_(as_float, lhs, +, rhs)};
+		return OP_(as_float, lhs, +, rhs);
 	case ValueTag::String:
-		return {e.m_gc->new_string_raw(OP(String, lhs, +, rhs))};
+		return Value {e.m_gc->new_string_raw(OP(String, lhs, +, rhs))};
 	default:
 		std::cerr << "ERROR: can't add values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -161,7 +161,7 @@ Value value_logicand(ArgsType v, Interpreter& e) {
 	auto rhs = value_of(v[1]);
 
 	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
-		return {OP_(as_boolean, lhs, &&, rhs)};
+		return OP_(as_boolean, lhs, &&, rhs);
 	std::cerr << "ERROR: logical and operator not defined for types "
 	          << value_string[static_cast<int>(lhs.type())] << " and "
 	          << value_string[static_cast<int>(rhs.type())];
@@ -173,7 +173,7 @@ Value value_logicor(ArgsType v, Interpreter& e) {
 	auto rhs = value_of(v[1]);
 
 	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
-		return {OP_(as_boolean, lhs, ||, rhs)};
+		return OP_(as_boolean, lhs, ||, rhs);
 	std::cerr << "ERROR: logical or operator not defined for types "
 	          << value_string[static_cast<int>(lhs.type())] << " and "
 	          << value_string[static_cast<int>(rhs.type())];
@@ -185,7 +185,7 @@ Value value_logicxor(ArgsType v, Interpreter& e) {
 	auto rhs = value_of(v[1]);
 
 	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
-		return {OP_(as_boolean, lhs, !=, rhs)};
+		return OP_(as_boolean, lhs, !=, rhs);
 	std::cerr << "ERROR: exclusive or operator not defined for types "
 	          << value_string[static_cast<int>(lhs.type())] << " and "
 	          << value_string[static_cast<int>(rhs.type())];
@@ -200,15 +200,15 @@ Value value_equals(ArgsType v, Interpreter& e) {
 
 	switch (lhs.type()) {
 	case ValueTag::Null:
-		return {true};
+		return Value {true};
 	case ValueTag::Integer:
-		return {OP_(as_integer, lhs, ==, rhs)};
+		return OP_(as_integer, lhs, ==, rhs);
 	case ValueTag::Float:
-		return {OP_(as_float, lhs, ==, rhs)};
+		return OP_(as_float, lhs, ==, rhs);
 	case ValueTag::String:
-		return {OP(String, lhs, ==, rhs)};
+		return Value {OP(String, lhs, ==, rhs)};
 	case ValueTag::Boolean:
-		return {OP_(as_boolean, lhs, ==, rhs)};
+		return OP_(as_boolean, lhs, ==, rhs);
 	default: {
 		std::cerr << "ERROR: can't compare equality of types "
 		          << value_string[static_cast<int>(lhs.type())] << " and "
@@ -220,7 +220,7 @@ Value value_equals(ArgsType v, Interpreter& e) {
 
 Value value_not_equals(ArgsType v, Interpreter& e) {
 	bool b = value_equals(v, e).as_boolean;
-	return {bool(!b)};
+	return Value {bool(!b)};
 }
 
 Value value_less(ArgsType v, Interpreter& e) {
@@ -231,11 +231,11 @@ Value value_less(ArgsType v, Interpreter& e) {
 
 	switch (lhs.type()) {
 	case ValueTag::Integer:
-		return {bool(OP_(as_integer, lhs, <, rhs))};
+		return OP_(as_integer, lhs, <, rhs);
 	case ValueTag::Float:
-		return {bool(OP_(as_float, lhs, <, rhs))};
+		return OP_(as_float, lhs, <, rhs);
 	case ValueTag::String:
-		return {bool(OP(String, lhs, <, rhs))};
+		return OP(String, lhs, <, rhs);
 	default:
 		std::cerr << "ERROR: can't compare values of type "
 		          << value_string[static_cast<int>(lhs.type())];
@@ -245,7 +245,7 @@ Value value_less(ArgsType v, Interpreter& e) {
 
 Value value_greater_or_equal(ArgsType v, Interpreter& e) {
 	bool b = value_less(v, e).as_boolean;
-	return {bool(!b)};
+	return Value {bool(!b)};
 }
 
 Value value_greater(ArgsType v, Interpreter& e) {
@@ -255,7 +255,7 @@ Value value_greater(ArgsType v, Interpreter& e) {
 
 Value value_less_or_equal(ArgsType v, Interpreter& e) {
 	bool b = value_greater(v, e).as_boolean;
-	return bool(!b);
+	return Value {bool(!b)};
 }
 
 Value value_assign(ArgsType v, Interpreter& e) {
@@ -267,57 +267,61 @@ Value read_integer(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	int result;
 	std::cin >> result;
-	return {result};
+	return Value {result};
 }
 
 Value read_number(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	float result;
 	std::cin >> result;
-	return {result};
+	return Value {result};
 }
 
 Value read_line(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	std::string result;
 	std::getline(std::cin, result);
-	return {e.m_gc->new_string_raw(std::move(result))};
+	return Value {e.m_gc->new_string_raw(std::move(result))};
 }
 
 Value read_string(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	std::string result;
 	std::cin >> result;
-	return {e.m_gc->new_string_raw(std::move(result))};
+	return Value {e.m_gc->new_string_raw(std::move(result))};
 }
 
 void declare_native_functions(Interpreter& env) {
-	env.global_declare("print", env.new_native_function(print).get());
-	env.global_declare("array_append", env.new_native_function(array_append).get());
-	env.global_declare("array_extend", env.new_native_function(array_extend).get());
-	env.global_declare("size", env.new_native_function(size).get());
-	env.global_declare("array_join", env.new_native_function(array_join).get());
-	env.global_declare("array_at", env.new_native_function(array_at).get());
-	env.global_declare("+", env.new_native_function(value_add).get());
-	env.global_declare("-", env.new_native_function(value_sub).get());
-	env.global_declare("*", env.new_native_function(value_mul).get());
-	env.global_declare("/", env.new_native_function(value_div).get());
-	env.global_declare("<", env.new_native_function(value_less).get());
-	env.global_declare(">=", env.new_native_function(value_greater_or_equal).get());
-	env.global_declare(">", env.new_native_function(value_greater).get());
-	env.global_declare("<=", env.new_native_function(value_less_or_equal).get());
-	env.global_declare("=", env.new_native_function(value_assign).get());
-	env.global_declare("==", env.new_native_function(value_equals).get());
-	env.global_declare("!=", env.new_native_function(value_not_equals).get());
-	env.global_declare("^^", env.new_native_function(value_logicxor).get());
-	env.global_declare("&&", env.new_native_function(value_logicand).get());
-	env.global_declare("||", env.new_native_function(value_logicor).get());
+	auto declare = [&](char const* name, NativeFunctionType func) {
+		env.global_declare(name, env.new_native_function(func).as_value());
+	};
+
+	declare("print", print);
+	declare("array_append", array_append);
+	declare("array_extend", array_extend);
+	declare("size", size);
+	declare("array_join", array_join);
+	declare("array_at", array_at);
+	declare("+", value_add);
+	declare("-", value_sub);
+	declare("*", value_mul);
+	declare("/", value_div);
+	declare("<", value_less);
+	declare(">=", value_greater_or_equal);
+	declare(">", value_greater);
+	declare("<=", value_less_or_equal);
+	declare("=", value_assign);
+	declare("==", value_equals);
+	declare("!=", value_not_equals);
+	declare("^^", value_logicxor);
+	declare("&&", value_logicand);
+	declare("||", value_logicor);
 
 	// Input
-	env.global_declare("read_integer", env.new_native_function(read_integer).get());
-	env.global_declare("read_number", env.new_native_function(read_number).get());
-	env.global_declare("read_string", env.new_native_function(read_string).get());
-	env.global_declare("read_line", env.new_native_function(read_line).get());
+	declare("read_integer", read_integer);
+	declare("read_number", read_number);
+	declare("read_string", read_string);
+	declare("read_line", read_line);
 }
 
 #undef OP

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -56,7 +56,7 @@ Value size(ArgsType v, Interpreter& e) {
 	assert(v.size() == 1);
 	Array* array = value_as<Array>(v[0]);
 
-	return {int(array->m_value.size())};
+	return Value {int(array->m_value.size())};
 }
 
 // array_join(array, string) returns a string with
@@ -235,7 +235,7 @@ Value value_less(ArgsType v, Interpreter& e) {
 	case ValueTag::Float:
 		return OP_(as_float, lhs, <, rhs);
 	case ValueTag::String:
-		return OP(String, lhs, <, rhs);
+		return Value {OP(String, lhs, <, rhs)};
 	default:
 		std::cerr << "ERROR: can't compare values of type "
 		          << value_string[static_cast<int>(lhs.type())];

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -292,8 +292,8 @@ Value read_string(ArgsType v, Interpreter& e) {
 }
 
 void declare_native_functions(Interpreter& env) {
-	auto declare = [&](char const* name, NativeFunctionType func) {
-		env.global_declare(name, env.new_native_function(func).as_value());
+	auto declare = [&](char const* name, NativeFunction* func) {
+		env.global_declare(name, Value {func});
 	};
 
 	declare("print", print);

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -18,19 +18,17 @@ namespace Interpreter {
 #define OP_(field, lhs, op, rhs)                                               \
 	(lhs).field op (rhs).field
 
-// TODO: All of these should return Handle
-
-using ArgsType = Span<Handle>;
+using ArgsType = Span<Value>;
 
 // print(vals...) prints the values or references in vals
-Handle print(ArgsType v, Interpreter& e) {
+Value print(ArgsType v, Interpreter& e) {
 	for (auto value : v)
 		print(value);
 	return e.null();
 }
 
 // array_append(arr, vals...) appends the values in vals to the array
-Handle array_append(ArgsType v, Interpreter& e) {
+Value array_append(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() > 0);
 	Array* array = value_as<Array>(v[0]);
@@ -42,7 +40,7 @@ Handle array_append(ArgsType v, Interpreter& e) {
 
 // array_extend(arr1, arr2) appends the values in arr2 to
 // arr1
-Handle array_extend(ArgsType v, Interpreter& e) {
+Value array_extend(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 2);
 	Array* arr1 = value_as<Array>(v[0]);
@@ -53,7 +51,7 @@ Handle array_extend(ArgsType v, Interpreter& e) {
 }
 
 // size(array) returns the size of the array
-Handle size(ArgsType v, Interpreter& e) {
+Value size(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 1);
 	Array* array = value_as<Array>(v[0]);
@@ -63,7 +61,7 @@ Handle size(ArgsType v, Interpreter& e) {
 
 // array_join(array, string) returns a string with
 // the array values separated by the string element
-Handle array_join(ArgsType v, Interpreter& e) {
+Value array_join(ArgsType v, Interpreter& e) {
 	// TODO make it more general
 	// TODO proper error handling
 	assert(v.size() == 2);
@@ -78,7 +76,7 @@ Handle array_join(ArgsType v, Interpreter& e) {
 }
 
 // array_at(array, int i) returns the i-th element of the given array
-Handle array_at(ArgsType v, Interpreter& e) {
+Value array_at(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 2);
 	Array* array = value_as<Array>(v[0]);
@@ -88,7 +86,7 @@ Handle array_at(ArgsType v, Interpreter& e) {
 	return {array->m_value[index]};
 }
 
-Handle value_add(ArgsType v, Interpreter& e) {
+Value value_add(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -107,7 +105,7 @@ Handle value_add(ArgsType v, Interpreter& e) {
 	}
 }
 
-Handle value_sub(ArgsType v, Interpreter& e) {
+Value value_sub(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -124,7 +122,7 @@ Handle value_sub(ArgsType v, Interpreter& e) {
 	}
 }
 
-Handle value_mul(ArgsType v, Interpreter& e) {
+Value value_mul(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -141,7 +139,7 @@ Handle value_mul(ArgsType v, Interpreter& e) {
 	}
 }
 
-Handle value_div(ArgsType v, Interpreter& e) {
+Value value_div(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -158,7 +156,7 @@ Handle value_div(ArgsType v, Interpreter& e) {
 	}
 }
 
-Handle value_logicand(ArgsType v, Interpreter& e) {
+Value value_logicand(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -170,7 +168,7 @@ Handle value_logicand(ArgsType v, Interpreter& e) {
 	assert(0);
 }
 
-Handle value_logicor(ArgsType v, Interpreter& e) {
+Value value_logicor(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -182,7 +180,7 @@ Handle value_logicor(ArgsType v, Interpreter& e) {
 	assert(0);
 }
 
-Handle value_logicxor(ArgsType v, Interpreter& e) {
+Value value_logicxor(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -194,7 +192,7 @@ Handle value_logicxor(ArgsType v, Interpreter& e) {
 	assert(0);
 }
 
-Handle value_equals(ArgsType v, Interpreter& e) {
+Value value_equals(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -220,12 +218,12 @@ Handle value_equals(ArgsType v, Interpreter& e) {
 	}
 }
 
-Handle value_not_equals(ArgsType v, Interpreter& e) {
+Value value_not_equals(ArgsType v, Interpreter& e) {
 	bool b = value_equals(v, e).as_boolean;
 	return {bool(!b)};
 }
 
-Handle value_less(ArgsType v, Interpreter& e) {
+Value value_less(ArgsType v, Interpreter& e) {
 	auto lhs = value_of(v[0]);
 	auto rhs = value_of(v[1]);
 
@@ -245,48 +243,48 @@ Handle value_less(ArgsType v, Interpreter& e) {
 	}
 }
 
-Handle value_greater_or_equal(ArgsType v, Interpreter& e) {
+Value value_greater_or_equal(ArgsType v, Interpreter& e) {
 	bool b = value_less(v, e).as_boolean;
 	return {bool(!b)};
 }
 
-Handle value_greater(ArgsType v, Interpreter& e) {
-	Handle args[2] = {v[1], v[0]}; // arguments are swapped
-	return value_less(Span<Handle> {args, 2}, e);
+Value value_greater(ArgsType v, Interpreter& e) {
+	Value args[2] = {v[1], v[0]}; // arguments are swapped
+	return value_less(Span<Value> {args, 2}, e);
 }
 
-Handle value_less_or_equal(ArgsType v, Interpreter& e) {
+Value value_less_or_equal(ArgsType v, Interpreter& e) {
 	bool b = value_greater(v, e).as_boolean;
 	return bool(!b);
 }
 
-Handle value_assign(ArgsType v, Interpreter& e) {
+Value value_assign(ArgsType v, Interpreter& e) {
 	e.assign(v[0], v[1]);
 	return e.null();
 }
 
-Handle read_integer(ArgsType v, Interpreter& e) {
+Value read_integer(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	int result;
 	std::cin >> result;
 	return {result};
 }
 
-Handle read_number(ArgsType v, Interpreter& e) {
+Value read_number(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	float result;
 	std::cin >> result;
 	return {result};
 }
 
-Handle read_line(ArgsType v, Interpreter& e) {
+Value read_line(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	std::string result;
 	std::getline(std::cin, result);
 	return {e.m_gc->new_string_raw(std::move(result))};
 }
 
-Handle read_string(ArgsType v, Interpreter& e) {
+Value read_string(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	std::string result;
 	std::cin >> result;

--- a/src/interpreter/stack.cpp
+++ b/src/interpreter/stack.cpp
@@ -37,29 +37,29 @@ void Stack::end_stack_region() {
 	m_stack.resize(m_stack_ptr);
 }
 
-void Stack::push(Handle ref){
+void Stack::push(Value ref){
 	m_stack.push_back(ref);
 	m_stack_ptr += 1;
 }
 
-Handle Stack::pop_unsafe() {
-	Handle result = m_stack.back();
+Value Stack::pop_unsafe() {
+	Value result = m_stack.back();
 	m_stack.pop_back();
 	m_stack_ptr -= 1;
 	return result;
 }
 
-Handle& Stack::access(int offset) {
+Value& Stack::access(int offset) {
 	return m_stack[m_stack.size() - 1 - offset];
 }
 
-Handle& Stack::frame_at(int offset) {
+Value& Stack::frame_at(int offset) {
 	assert(m_frame_ptr + offset >= 0);
 	assert(m_frame_ptr + offset < m_stack.size());
 	return m_stack[m_frame_ptr + offset];
 }
 
-Span<Handle> Stack::frame_range(int offset, int length) {
+Span<Value> Stack::frame_range(int offset, int length) {
 	if (length > 0) {
 		assert(m_frame_ptr + offset >= 0);
 		assert(m_frame_ptr + offset + length <= m_stack.size());

--- a/src/interpreter/stack.hpp
+++ b/src/interpreter/stack.hpp
@@ -10,7 +10,7 @@ namespace Interpreter {
 struct Stack {
 	int m_frame_ptr {0};
 	int m_stack_ptr {0};
-	std::vector<Handle> m_stack;
+	std::vector<Value> m_stack;
 	std::vector<int> m_fp_stack;
 	std::vector<int> m_sp_stack;
 
@@ -21,13 +21,13 @@ struct Stack {
 	void start_stack_region();
 	void end_stack_region();
 
-	void push(Handle ref);
+	void push(Value ref);
 
-	Handle pop_unsafe();
+	Value pop_unsafe();
 
-	Handle& access(int offset);
-	Handle& frame_at(int offset);
-	Span<Handle> frame_range(int offset, int length);
+	Value& access(int offset);
+	Value& frame_at(int offset);
+	Span<Value> frame_range(int offset, int length);
 };
 
 } // namespace Interpreter

--- a/src/interpreter/utils.cpp
+++ b/src/interpreter/utils.cpp
@@ -4,7 +4,7 @@
 
 namespace Interpreter {
 
-Handle value_of(Handle h) {
+Value value_of(Value h) {
 	if (!is_heap_type(h.type()))
 		return h;
 

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -6,10 +6,10 @@
 
 namespace Interpreter {
 
-Handle value_of(Handle value);
+Value value_of(Value value);
 
 template<typename T>
-T* value_as(Handle h) {
+T* value_as(Value h) {
 	static_assert(std::is_base_of<GcCell, T>::value, "T is not a subclass of GcCell");
 	return value_of(h).get_cast<T>();
 }

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -10,7 +10,7 @@ Handle value_of(Handle value);
 
 template<typename T>
 T* value_as(Handle h) {
-	static_assert(std::is_base_of<Value, T>::value, "T is not a subclass of Value");
+	static_assert(std::is_base_of<GcCell, T>::value, "T is not a subclass of GcCell");
 	return value_of(h).get_cast<T>();
 }
 

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -37,11 +37,11 @@ Record::Record(RecordType o)
     : GcCell(ValueTag::Record)
     , m_value(std::move(o)) {}
 
-void Record::addMember(Identifier const& id, Handle v) {
+void Record::addMember(Identifier const& id, Value v) {
 	m_value[id] = v;
 }
 
-Handle Record::getMember(Identifier const& id) {
+Value Record::getMember(Identifier const& id) {
 	auto it = m_value.find(id);
 	if (it == m_value.end()) {
 		// TODO: return RangeError
@@ -55,7 +55,7 @@ Variant::Variant(InternedString constructor)
     : GcCell(ValueTag::Variant)
     , m_constructor(constructor) {}
 
-Variant::Variant(InternedString constructor, Handle v)
+Variant::Variant(InternedString constructor, Value v)
     : GcCell(ValueTag::Variant)
     , m_constructor(constructor)
     , m_inner_value(v) {}
@@ -69,7 +69,7 @@ NativeFunction::NativeFunction(NativeFunctionType* fptr)
     : GcCell {ValueTag::NativeFunction}
     , m_fptr {fptr} {}
 
-Reference::Reference(Handle value)
+Reference::Reference(Value value)
     : GcCell {ValueTag::Reference}
     , m_value {value} {}
 
@@ -166,7 +166,7 @@ void gc_visit(GcCell* v) {
 	}
 }
 
-void gc_visit(Handle h) {
+void gc_visit(Value h) {
 	if (is_heap_type(h.type()))
 		return gc_visit(h.get());
 }
@@ -283,7 +283,7 @@ void print(GcCell* v, int d) {
 	}
 }
 
-void print(Handle h, int d) {
+void print(Value h, int d) {
 	if (is_heap_type(h.type()))
 		return print(h.get(), d);
 	switch (h.type()) {

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -7,15 +7,15 @@
 namespace Interpreter {
 
 String::String()
-    : Value(ValueTag::String) {}
+    : GcCell(ValueTag::String) {}
 String::String(std::string s)
-    : Value(ValueTag::String)
+    : GcCell(ValueTag::String)
     , m_value(std::move(s)) {}
 
 Array::Array()
-    : Value(ValueTag::Array) {}
+    : GcCell(ValueTag::Array) {}
 Array::Array(ArrayType l)
-    : Value(ValueTag::Array)
+    : GcCell(ValueTag::Array)
     , m_value(std::move(l)) {}
 
 void Array::append(Reference* v) {
@@ -32,9 +32,9 @@ Reference* Array::at(int position) {
 }
 
 Record::Record()
-    : Value(ValueTag::Record) {}
+    : GcCell(ValueTag::Record) {}
 Record::Record(RecordType o)
-    : Value(ValueTag::Record)
+    : GcCell(ValueTag::Record)
     , m_value(std::move(o)) {}
 
 void Record::addMember(Identifier const& id, Handle v) {
@@ -52,33 +52,33 @@ Handle Record::getMember(Identifier const& id) {
 }
 
 Variant::Variant(InternedString constructor)
-    : Value(ValueTag::Variant)
+    : GcCell(ValueTag::Variant)
     , m_constructor(constructor) {}
 
 Variant::Variant(InternedString constructor, Handle v)
-    : Value(ValueTag::Variant)
+    : GcCell(ValueTag::Variant)
     , m_constructor(constructor)
     , m_inner_value(v) {}
 
 Function::Function(FunctionType def, CapturesType captures)
-    : Value(ValueTag::Function)
+    : GcCell(ValueTag::Function)
     , m_def(def)
     , m_captures(std::move(captures)) {}
 
 NativeFunction::NativeFunction(NativeFunctionType* fptr)
-    : Value {ValueTag::NativeFunction}
+    : GcCell {ValueTag::NativeFunction}
     , m_fptr {fptr} {}
 
 Reference::Reference(Handle value)
-    : Value {ValueTag::Reference}
+    : GcCell {ValueTag::Reference}
     , m_value {value} {}
 
 VariantConstructor::VariantConstructor(InternedString constructor)
-    : Value {ValueTag::VariantConstructor}
+    : GcCell {ValueTag::VariantConstructor}
     , m_constructor {constructor} {}
 
 RecordConstructor::RecordConstructor(std::vector<InternedString> keys)
-    : Value {ValueTag::RecordConstructor}
+    : GcCell {ValueTag::RecordConstructor}
     , m_keys {std::move(keys)} {}
 
 void gc_visit(String* v) {
@@ -141,7 +141,7 @@ void gc_visit(Reference* r) {
 	gc_visit(r->m_value);
 }
 
-void gc_visit(Value* v) {
+void gc_visit(GcCell* v) {
 	switch (v->type()) {
 	case ValueTag::String:
 		return gc_visit(static_cast<String*>(v));
@@ -257,7 +257,7 @@ void print(VariantConstructor* l, int d) {
 	std::cout << "VariantConstructor\n";
 }
 
-void print(Value* v, int d) {
+void print(GcCell* v, int d) {
 
 	switch (v->type()) {
 	case ValueTag::String:

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -81,23 +81,23 @@ RecordConstructor::RecordConstructor(std::vector<InternedString> keys)
     : GcCell {ValueTag::RecordConstructor}
     , m_keys {std::move(keys)} {}
 
-void gc_visit(String* v) {
+static void gc_visit(String* v) {
 	v->m_visited = true;
 }
-void gc_visit(Error* v) {
+static void gc_visit(Error* v) {
 	v->m_visited = true;
 }
-void gc_visit(NativeFunction* v) {
+static void gc_visit(NativeFunction* v) {
 	v->m_visited = true;
 }
-void gc_visit(VariantConstructor* v) {
+static void gc_visit(VariantConstructor* v) {
 	v->m_visited = true;
 }
-void gc_visit(RecordConstructor* v) {
+static void gc_visit(RecordConstructor* v) {
 	v->m_visited = true;
 }
 
-void gc_visit(Array* l) {
+static void gc_visit(Array* l) {
 	if (l->m_visited)
 		return;
 
@@ -107,7 +107,7 @@ void gc_visit(Array* l) {
 	}
 }
 
-void gc_visit(Record* o) {
+static void gc_visit(Record* o) {
 	if (o->m_visited)
 		return;
 
@@ -116,7 +116,7 @@ void gc_visit(Record* o) {
 		gc_visit(child.second);
 }
 
-void gc_visit(Variant* u) {
+static void gc_visit(Variant* u) {
 	if (u->m_visited)
 		return;
 
@@ -124,7 +124,7 @@ void gc_visit(Variant* u) {
 	gc_visit(u->m_inner_value);
 }
 
-void gc_visit(Function* f) {
+static void gc_visit(Function* f) {
 	if (f->m_visited)
 		return;
 
@@ -133,7 +133,7 @@ void gc_visit(Function* f) {
 		gc_visit(capture);
 }
 
-void gc_visit(Reference* r) {
+static void gc_visit(Reference* r) {
 	if (r->m_visited)
 		return;
 
@@ -141,7 +141,7 @@ void gc_visit(Reference* r) {
 	gc_visit(r->m_value);
 }
 
-void gc_visit(GcCell* v) {
+static void gc_visit(GcCell* v) {
 	switch (v->type()) {
 	case ValueTag::String:
 		return gc_visit(static_cast<String*>(v));
@@ -163,6 +163,8 @@ void gc_visit(GcCell* v) {
 		return gc_visit(static_cast<VariantConstructor*>(v));
 	case ValueTag::RecordConstructor:
 		return gc_visit(static_cast<RecordConstructor*>(v));
+	default:
+		assert(0);
 	}
 }
 
@@ -178,34 +180,34 @@ void print_spaces(int n) {
 		std::cout << ' ';
 }
 
-void print(int v, int d) {
+static void print(int v, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(ValueTag::Integer)] << ' ' << v << '\n';
 }
 
-void print(float v, int d) {
+static void print(float v, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(ValueTag::Float)] << ' ' << v << '\n';
 }
 
-void print(String* v, int d) {
+static void print(String* v, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(v->type())] << ' ' << '"' << v->m_value
 	          << '"' << '\n';
 }
 
-void print(bool b, int d) {
+static void print(bool b, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(ValueTag::Boolean)] << ' ' << b << '\n';
 }
 
-void print(Error* v, int d) {
+static void print(Error* v, int d) {
 	// TODO
 	print_spaces(d);
 	std::cout << value_string[int(v->type())] << '\n';
 }
 
-void print(Record* o, int d) {
+static void print(Record* o, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(o->type())] << '\n';
 	for (auto& kv : o->m_value){
@@ -215,25 +217,25 @@ void print(Record* o, int d) {
 	}
 }
 
-void print(Variant* m, int d) {
+static void print(Variant* m, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(m->type())] << " " << m->m_constructor << '\n';
 	print(m->m_inner_value, d);
 }
 
-void print(Function* f, int d) {
+static void print(Function* f, int d) {
 	// TODO
 	print_spaces(d);
 	std::cout << value_string[int(f->type())] << '\n';
 }
 
-void print(NativeFunction* f, int d) {
+static void print(NativeFunction* f, int d) {
 	// TODO
 	print_spaces(d);
 	std::cout << value_string[int(f->type())] << '\n';
 }
 
-void print(Array* l, int d) {
+static void print(Array* l, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(l->type())] << '\n';
 	for (auto* child : l->m_value) {
@@ -241,23 +243,23 @@ void print(Array* l, int d) {
 	}
 }
 
-void print(Reference* l, int d) {
+static void print(Reference* l, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(l->type())] << '\n';
 	print(l->m_value, d + 1);
 }
 
-void print(RecordConstructor* l, int d) {
+static void print(RecordConstructor* l, int d) {
 	print_spaces(d);
 	std::cout << "RecordConstructor\n";
 }
 
-void print(VariantConstructor* l, int d) {
+static void print(VariantConstructor* l, int d) {
 	print_spaces(d);
 	std::cout << "VariantConstructor\n";
 }
 
-void print(GcCell* v, int d) {
+static void print(GcCell* v, int d) {
 
 	switch (v->type()) {
 	case ValueTag::String:
@@ -280,6 +282,8 @@ void print(GcCell* v, int d) {
 		return print(static_cast<VariantConstructor*>(v), d);
 	case ValueTag::RecordConstructor:
 		return print(static_cast<RecordConstructor*>(v), d);
+	default:
+		assert(0);
 	}
 }
 
@@ -296,6 +300,8 @@ void print(Value h, int d) {
 	case ValueTag::Null:
 		print_spaces(d);
 		return void(std::cout << "(null)\n");
+	default:
+		assert(0);
 	}
 }
 

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -45,7 +45,7 @@ Value Record::getMember(Identifier const& id) {
 	auto it = m_value.find(id);
 	if (it == m_value.end()) {
 		// TODO: return RangeError
-		return {nullptr};
+		return Value {nullptr};
 	} else {
 		return it->second;
 	}
@@ -81,97 +81,6 @@ RecordConstructor::RecordConstructor(std::vector<InternedString> keys)
     : GcCell {ValueTag::RecordConstructor}
     , m_keys {std::move(keys)} {}
 
-static void gc_visit(String* v) {
-	v->m_visited = true;
-}
-static void gc_visit(Error* v) {
-	v->m_visited = true;
-}
-static void gc_visit(NativeFunction* v) {
-	v->m_visited = true;
-}
-static void gc_visit(VariantConstructor* v) {
-	v->m_visited = true;
-}
-static void gc_visit(RecordConstructor* v) {
-	v->m_visited = true;
-}
-
-static void gc_visit(Array* l) {
-	if (l->m_visited)
-		return;
-
-	l->m_visited = true;
-	for (auto* child : l->m_value) {
-		gc_visit(child);
-	}
-}
-
-static void gc_visit(Record* o) {
-	if (o->m_visited)
-		return;
-
-	o->m_visited = true;
-	for (auto child : o->m_value)
-		gc_visit(child.second);
-}
-
-static void gc_visit(Variant* u) {
-	if (u->m_visited)
-		return;
-
-	u->m_visited = true;
-	gc_visit(u->m_inner_value);
-}
-
-static void gc_visit(Function* f) {
-	if (f->m_visited)
-		return;
-
-	f->m_visited = true;
-	for (auto& capture : f->m_captures)
-		gc_visit(capture);
-}
-
-static void gc_visit(Reference* r) {
-	if (r->m_visited)
-		return;
-
-	r->m_visited = true;
-	gc_visit(r->m_value);
-}
-
-static void gc_visit(GcCell* v) {
-	switch (v->type()) {
-	case ValueTag::String:
-		return gc_visit(static_cast<String*>(v));
-	case ValueTag::Error:
-		return gc_visit(static_cast<Error*>(v));
-	case ValueTag::Array:
-		return gc_visit(static_cast<Array*>(v));
-	case ValueTag::Record:
-		return gc_visit(static_cast<Record*>(v));
-	case ValueTag::Variant:
-		return gc_visit(static_cast<Variant*>(v));
-	case ValueTag::Function:
-		return gc_visit(static_cast<Function*>(v));
-	case ValueTag::NativeFunction:
-		return gc_visit(static_cast<NativeFunction*>(v));
-	case ValueTag::Reference:
-		return gc_visit(static_cast<Reference*>(v));
-	case ValueTag::VariantConstructor:
-		return gc_visit(static_cast<VariantConstructor*>(v));
-	case ValueTag::RecordConstructor:
-		return gc_visit(static_cast<RecordConstructor*>(v));
-	default:
-		assert(0);
-	}
-}
-
-void gc_visit(Value h) {
-	if (is_heap_type(h.type()))
-		return gc_visit(h.get());
-}
 
 // = === === print === === = //
 

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -65,10 +65,6 @@ Function::Function(FunctionType def, CapturesType captures)
     , m_def(def)
     , m_captures(std::move(captures)) {}
 
-NativeFunction::NativeFunction(NativeFunctionType* fptr)
-    : GcCell {ValueTag::NativeFunction}
-    , m_fptr {fptr} {}
-
 Reference::Reference(Value value)
     : GcCell {ValueTag::Reference}
     , m_value {value} {}
@@ -141,7 +137,7 @@ static void print(Function* f, int d) {
 static void print(NativeFunction* f, int d) {
 	// TODO
 	print_spaces(d);
-	std::cout << value_string[int(f->type())] << '\n';
+	std::cout << value_string[int(ValueTag::NativeFunction)] << '\n';
 }
 
 static void print(Array* l, int d) {
@@ -183,8 +179,6 @@ static void print(GcCell* v, int d) {
 		return print(static_cast<Variant*>(v), d);
 	case ValueTag::Function:
 		return print(static_cast<Function*>(v), d);
-	case ValueTag::NativeFunction:
-		return print(static_cast<NativeFunction*>(v), d);
 	case ValueTag::Reference:
 		return print(static_cast<Reference*>(v), d);
 	case ValueTag::VariantConstructor:
@@ -206,6 +200,8 @@ void print(Value h, int d) {
 		return print(h.as_integer, d);
 	case ValueTag::Float:
 		return print(h.as_float, d);
+	case ValueTag::NativeFunction:
+		return print(h.as_native_func, d);
 	case ValueTag::Null:
 		print_spaces(d);
 		return void(std::cout << "(null)\n");

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -32,15 +32,15 @@ inline bool is_heap_type(ValueTag tag) {
 }
 
 struct Value {
-	Value(GcCell* ptr)
+	explicit Value(GcCell* ptr)
 	    : tag {ptr ? ptr->type() : ValueTag::Null}
 	    , ptr {ptr} {}
 
-	Value(std::nullptr_t)
+	explicit Value(std::nullptr_t)
 	    : tag {ValueTag::Null}
 	    , ptr {nullptr} {}
 
-	Value(bool boolean)
+	explicit Value(bool boolean)
 	    : tag {ValueTag::Boolean}
 	    , as_boolean {boolean} {}
 
@@ -101,7 +101,6 @@ struct Value {
 	};
 };
 
-void gc_visit(Value);
 void print(Value v, int d = 0);
 
 struct String : GcCell {

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -44,11 +44,11 @@ struct Value {
 	    : tag {ValueTag::Boolean}
 	    , as_boolean {boolean} {}
 
-	Value(int integer)
+	explicit Value(int integer)
 	    : tag {ValueTag::Integer}
 	    , as_integer {integer} {}
 
-	Value(float number)
+	explicit Value(float number)
 	    : tag {ValueTag::Float}
 	    , as_float {number} {}
 

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -7,6 +7,7 @@
 #include "../utils/interned_string.hpp"
 #include "../utils/span.hpp"
 #include "value_tag.hpp"
+#include "gc_cell.hpp"
 
 namespace AST {
 struct FunctionLiteral;
@@ -14,7 +15,6 @@ struct FunctionLiteral;
 
 namespace Interpreter {
 
-struct GcCell;
 struct Interpreter;
 struct Reference;
 struct Value;
@@ -26,26 +26,6 @@ using ArrayType = std::vector<Reference*>;
 using FunctionType = AST::FunctionLiteral*;
 using NativeFunctionType = auto(Span<Value>, Interpreter&) -> Value;
 using CapturesType = std::vector<Reference*>;
-
-void print(GcCell* v, int d = 0);
-void gc_visit(GcCell*);
-
-struct GcCell {
-  protected:
-	ValueTag m_type;
-
-  public:
-	bool m_visited = false;
-	int m_cpp_refcount = 0;
-
-	GcCell(ValueTag type)
-	    : m_type(type) {}
-	ValueTag type() const {
-		return m_type;
-	}
-
-	virtual ~GcCell() = default;
-};
 
 inline bool is_heap_type(ValueTag tag) {
 	return tag != ValueTag::Null && tag != ValueTag::Boolean && tag != ValueTag::Integer && tag != ValueTag::Float;

--- a/src/interpreter/value_fwd.hpp
+++ b/src/interpreter/value_fwd.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-namespace Interpreter {
-
-struct Value;
-
-}

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -8,11 +8,11 @@
 
 namespace Assert {
 
-using Interpreter::Handle;
+using Interpreter::Value;
 
 namespace detail {
 
-ExitStatus of_type(Interpreter::Handle h, ValueTag tag) {
+ExitStatus of_type(Interpreter::Value h, ValueTag tag) {
 	if (h.type() != tag)
 		return ExitStatus::TypeError;
 
@@ -20,7 +20,7 @@ ExitStatus of_type(Interpreter::Handle h, ValueTag tag) {
 }
 
 template <typename RuntimeValue, typename NativeValue>
-ExitStatus scalar_equals(Handle rv, const ValueTag v_type, const NativeValue& expected) {
+ExitStatus scalar_equals(Value rv, const ValueTag v_type, const NativeValue& expected) {
 	ExitStatus fail = of_type(rv, v_type);
 
 	if (ExitStatus::Ok != fail)
@@ -35,7 +35,7 @@ ExitStatus scalar_equals(Handle rv, const ValueTag v_type, const NativeValue& ex
 
 template <typename NativeValue, typename Getter>
 ExitStatus scalar_equals_fn(
-    Handle rv,
+    Value rv,
     const ValueTag v_type,
     const NativeValue& expected,
     Getter getter
@@ -51,45 +51,45 @@ ExitStatus scalar_equals_fn(
 	return ExitStatus::Ok;
 }
 
-ExitStatus bool_equals(Handle rv, bool expected) {
+ExitStatus bool_equals(Value rv, bool expected) {
 	return scalar_equals_fn(
-	    rv, ValueTag::Boolean, expected, [](Handle h) { return h.as_boolean; });
+	    rv, ValueTag::Boolean, expected, [](Value h) { return h.as_boolean; });
 }
 
 } // namespace detail
 
-ExitStatus equals(Handle rv, std::string const& expected) {
+ExitStatus equals(Value rv, std::string const& expected) {
 	return detail::scalar_equals<Interpreter::String, std::string>(rv, ValueTag::String, expected);
 }
 
-ExitStatus equals(Handle rv, int expected) {
+ExitStatus equals(Value rv, int expected) {
 	return detail::scalar_equals_fn(
-	    rv, ValueTag::Integer, expected, [](Handle h) { return h.as_integer; });
+	    rv, ValueTag::Integer, expected, [](Value h) { return h.as_integer; });
 }
 
-ExitStatus equals(Handle rv, float expected) {
+ExitStatus equals(Value rv, float expected) {
 	return detail::scalar_equals_fn(
-	    rv, ValueTag::Float, expected, [](Handle h) { return h.as_float; });
+	    rv, ValueTag::Float, expected, [](Value h) { return h.as_float; });
 }
 
 // NOTE: allows literals to be used (e.g. 3.5), may need to change in the future?
-ExitStatus equals(Handle rv, double expected) {
+ExitStatus equals(Value rv, double expected) {
 	return equals(rv, float(expected));
 }
 
-ExitStatus is_true(Handle rv) {
+ExitStatus is_true(Value rv) {
 	return detail::bool_equals(rv, true);
 }
 
-ExitStatus is_false(Handle rv) {
+ExitStatus is_false(Value rv) {
 	return detail::bool_equals(rv, false);
 }
 
-ExitStatus is_null(Handle rv) {
+ExitStatus is_null(Value rv) {
 	return detail::of_type(rv, ValueTag::Null);
 }
 
-ExitStatus array_of_size(Handle rv, unsigned int size) {
+ExitStatus array_of_size(Value rv, unsigned int size) {
 	return ExitStatus::Ok;
 	ExitStatus fail = detail::of_type(rv, ValueTag::Array);
 


### PR DESCRIPTION
So, after doing some big changes in the last few PRs, I left some low hanging fruit on the table, for both code quality and speed. This PRs addresses some of that.

bullet points:

- Rename `Value` -> `GcCell`, and move to its own file
- make `gc_visit` a member function of `GcCell` (renamed `visit`)
- Rename `Handle` -> `Value`, and make many of its ctors explicit
- Don't heap allocate native function pointers