### PR TITLE
split SymbolTable more nicely

### DIFF
--- a/src/match_identifiers.cpp
+++ b/src/match_identifiers.cpp
@@ -15,9 +15,77 @@
 
 namespace Frontend {
 
+struct SymbolResolutionHelper {
+
+	SymbolResolutionHelper(SymbolTable& symbol_table)
+	    : m_symbol_table {symbol_table} {}
+
+	void declare(AST::Declaration* decl) {
+		m_symbol_table.declare(decl);
+	}
+
+	AST::Declaration* access(InternedString const& name) {
+		return m_symbol_table.access(name);
+	}
+
+	void new_nested_scope() {
+		m_symbol_table.new_nested_scope();
+	}
+
+	void end_scope() {
+		m_symbol_table.end_scope();
+	}
+
+
+	AST::SequenceExpression* current_seq_expr() {
+		return m_seq_expr_stack.empty() ? nullptr : m_seq_expr_stack.back();
+	}
+
+	void enter_seq_expr(AST::SequenceExpression* seq_expr) {
+		m_seq_expr_stack.push_back(seq_expr);
+	}
+
+	void exit_seq_expr() {
+		m_seq_expr_stack.pop_back();
+	}
+
+
+	AST::FunctionLiteral* current_function() {
+		return m_function_stack.empty() ? nullptr : m_function_stack.back();
+	}
+
+	void enter_function(AST::FunctionLiteral* func) {
+		m_function_stack.push_back(func);
+	}
+
+	void exit_function() {
+		m_function_stack.pop_back();
+	}
+
+
+	AST::Declaration* current_top_level_declaration() {
+		return m_current_decl;
+	}
+
+	void enter_top_level_decl(AST::Declaration* decl) {
+		assert(!m_current_decl);
+		m_current_decl = decl;
+	}
+
+	void exit_top_level_decl() {
+		assert(m_current_decl);
+		m_current_decl = nullptr;
+	}
+
+	SymbolTable& m_symbol_table;
+	std::vector<AST::FunctionLiteral*> m_function_stack;
+	std::vector<AST::SequenceExpression*> m_seq_expr_stack;
+	AST::Declaration* m_current_decl {nullptr};
+};
+
 #define CHECK_AND_RETURN(expr)                                                 \
 	{                                                                          \
-		auto err = expr;                                                       \
+		auto err = (expr);                                                     \
 		if (!err.ok()) {                                                       \
 			return err;                                                        \
 		}                                                                      \
@@ -31,9 +99,9 @@ namespace Frontend {
 		}                                                                      \
 	}
 
-[[nodiscard]] ErrorReport match_identifiers(AST::AST* ast, SymbolTable& env);
+[[nodiscard]] ErrorReport match_identifiers(AST::AST* ast, SymbolResolutionHelper& env);
 
-[[nodiscard]] ErrorReport match_identifiers(AST::Declaration* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::Declaration* ast, SymbolResolutionHelper& env) {
 
 	ast->m_surrounding_function = env.current_function();
 	ast->m_surrounding_seq_expr = env.current_seq_expr();
@@ -51,7 +119,7 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::Identifier* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::Identifier* ast, SymbolResolutionHelper& env) {
 
 	AST::Declaration* declaration = env.access(ast->text());
 
@@ -91,7 +159,7 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::Block* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::Block* ast, SymbolResolutionHelper& env) {
 	env.new_nested_scope();
 	for (auto& child : ast->m_body)
 		CHECK_AND_RETURN(match_identifiers(child, env));
@@ -99,7 +167,7 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::IfElseStatement* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::IfElseStatement* ast, SymbolResolutionHelper& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_condition, env));
 	CHECK_AND_RETURN(match_identifiers(ast->m_body, env));
 
@@ -108,14 +176,14 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::CallExpression* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::CallExpression* ast, SymbolResolutionHelper& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_callee, env));
 	for (auto& arg : ast->m_args)
 		CHECK_AND_RETURN(match_identifiers(arg, env));
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::FunctionLiteral* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::FunctionLiteral* ast, SymbolResolutionHelper& env) {
 
 	ast->m_surrounding_function = env.current_function();
 
@@ -137,14 +205,14 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::ArrayLiteral* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::ArrayLiteral* ast, SymbolResolutionHelper& env) {
 	for (auto& element : ast->m_elements)
 		CHECK_AND_RETURN(match_identifiers(element, env));
 
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::WhileStatement* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::WhileStatement* ast, SymbolResolutionHelper& env) {
 	env.new_nested_scope();
 
 	CHECK_AND_RETURN(match_identifiers(ast->m_condition, env));
@@ -154,29 +222,29 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::ReturnStatement* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::ReturnStatement* ast, SymbolResolutionHelper& env) {
 	ast->m_surrounding_seq_expr = env.current_seq_expr();
 	return match_identifiers(ast->m_value, env);
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::IndexExpression* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::IndexExpression* ast, SymbolResolutionHelper& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_callee, env));
 	CHECK_AND_RETURN(match_identifiers(ast->m_index, env));
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::TernaryExpression* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::TernaryExpression* ast, SymbolResolutionHelper& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_condition, env));
 	CHECK_AND_RETURN(match_identifiers(ast->m_then_expr, env));
 	CHECK_AND_RETURN(match_identifiers(ast->m_else_expr, env));
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::AccessExpression* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::AccessExpression* ast, SymbolResolutionHelper& env) {
 	return match_identifiers(ast->m_target, env);
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::MatchExpression* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::MatchExpression* ast, SymbolResolutionHelper& env) {
 
 	CHECK_AND_RETURN(match_identifiers(&ast->m_target, env));
 
@@ -197,7 +265,7 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::ConstructorExpression* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::ConstructorExpression* ast, SymbolResolutionHelper& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_constructor, env));
 
 	for (auto& arg : ast->m_args)
@@ -206,14 +274,14 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::SequenceExpression* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::SequenceExpression* ast, SymbolResolutionHelper& env) {
 	env.enter_seq_expr(ast);
 	CHECK_AND_RETURN(match_identifiers(ast->m_body, env));
 	env.exit_seq_expr();
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::DeclarationList* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::DeclarationList* ast, SymbolResolutionHelper& env) {
 	for (auto& decl : ast->m_declarations) {
 		env.declare(&decl);
 		decl.m_surrounding_function = env.current_function();
@@ -237,7 +305,7 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::UnionExpression* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::UnionExpression* ast, SymbolResolutionHelper& env) {
 
 	for (auto& type : ast->m_types)
 		CHECK_AND_RETURN(match_identifiers(type, env));
@@ -245,7 +313,7 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::StructExpression* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::StructExpression* ast, SymbolResolutionHelper& env) {
 
 	for (auto& type : ast->m_types)
 		CHECK_AND_RETURN(match_identifiers(type, env));
@@ -253,14 +321,14 @@ namespace Frontend {
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::TypeTerm* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::TypeTerm* ast, SymbolResolutionHelper& env) {
 	CHECK_AND_RETURN(match_identifiers(ast->m_callee, env));
 	for (auto& arg : ast->m_args)
 		CHECK_AND_RETURN(match_identifiers(arg, env));
 	return {};
 }
 
-[[nodiscard]] ErrorReport match_identifiers(AST::AST* ast, SymbolTable& env) {
+[[nodiscard]] ErrorReport match_identifiers(AST::AST* ast, SymbolResolutionHelper& env) {
 #define DISPATCH(type)                                                         \
 	case ASTTag::type:                                                    \
 		return match_identifiers(static_cast<AST::type*>(ast), env);
@@ -306,5 +374,10 @@ namespace Frontend {
 }
 
 #undef CHECK_AND_RETURN
+
+[[nodiscard]] ErrorReport match_identifiers(AST::AST* ast, SymbolTable& env) {
+	auto helper = SymbolResolutionHelper {env};
+	return match_identifiers(ast, helper);
+}
 
 } // namespace Frontend

--- a/src/symbol_table.cpp
+++ b/src/symbol_table.cpp
@@ -53,42 +53,8 @@ void SymbolTable::end_scope() {
 	m_shadowed_scopes.pop_back();
 }
 
-AST::SequenceExpression* SymbolTable::current_seq_expr() {
-	return m_seq_expr_stack.empty() ? nullptr : m_seq_expr_stack.back();
-}
 
-void SymbolTable::enter_seq_expr(AST::SequenceExpression* seq_expr) {
-	m_seq_expr_stack.push_back(seq_expr);
-}
 
-void SymbolTable::exit_seq_expr() {
-	m_seq_expr_stack.pop_back();
-}
 
-AST::FunctionLiteral* SymbolTable::current_function() {
-	return m_function_stack.empty() ? nullptr : m_function_stack.back();
-}
-
-void SymbolTable::enter_function(AST::FunctionLiteral* func) {
-	m_function_stack.push_back(func);
-}
-
-void SymbolTable::exit_function() {
-	m_function_stack.pop_back();
-}
-
-AST::Declaration* SymbolTable::current_top_level_declaration() {
-	return m_current_decl;
-}
-
-void SymbolTable::enter_top_level_decl(AST::Declaration* decl) {
-	assert(!m_current_decl);
-	m_current_decl = decl;
-}
-
-void SymbolTable::exit_top_level_decl() {
-	assert(m_current_decl);
-	m_current_decl = nullptr;
-}
 
 } // namespace Frontend

--- a/src/symbol_table.hpp
+++ b/src/symbol_table.hpp
@@ -6,46 +6,25 @@
 #include "./utils/interned_string.hpp"
 
 namespace AST {
-struct SequenceExpression;
 struct Declaration;
-struct FunctionLiteral;
 }
 
 namespace Frontend {
 
 struct SymbolTable {
-	using SymbolMap = std::unordered_map<InternedString, AST::Declaration*>;
-
 	SymbolTable();
 
-	void declare(AST::Declaration*);
 	AST::Declaration* access(InternedString const&);
-
-	AST::SequenceExpression* current_seq_expr();
-	void enter_seq_expr(AST::SequenceExpression*);
-	void exit_seq_expr();
-
-	AST::FunctionLiteral* current_function();
-	void enter_function(AST::FunctionLiteral*);
-	void exit_function();
-
-	AST::Declaration* current_top_level_declaration();
-	void enter_top_level_decl(AST::Declaration*);
-	void exit_top_level_decl();
+	void declare(AST::Declaration*);
 
 	void new_nested_scope();
 	void end_scope();
+private:
+	using SymbolMap = std::unordered_map<InternedString, AST::Declaration*>;
 
+	SymbolMap& latest_shadowed_scope();
 	SymbolMap m_bindings;
 	std::vector<SymbolMap> m_shadowed_scopes;
-
-	std::vector<AST::FunctionLiteral*> m_function_stack;
-	std::vector<AST::SequenceExpression*> m_seq_expr_stack;
-	AST::Declaration* m_current_decl {nullptr};
-
-private:
-	SymbolMap& latest_shadowed_scope();
-
 };
 
 } // namespace Frontend


### PR DESCRIPTION
Make `SymbolTable` do a single thing. The unrelated functionality was moved to a module-local class named `SymbolResolutionHelper`.