### PR TITLE
Metacheck improvement

### DIFF
--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -112,7 +112,7 @@ static AST::Expr* ct_eval(
 	MetaTypeId meta_type = uf.eval(ast->m_meta_type);
 
 	// TODO: support vars
-	if (uf.is(meta_type, Tag::Ctor))
+	if (uf.is_ctor(meta_type))
 		return constructor_from_ast(ast, tc, alloc);
 
 	ast->m_target = ct_eval(ast->m_target, tc, alloc);
@@ -227,7 +227,7 @@ static AST::Constructor* constructor_from_ast(
 
 	if (uf.is(meta, Tag::Mono)) {
 		constructor->m_mono = eval_then_get_mono(ast, tc, alloc);
-	} else if (uf.is(meta, Tag::Ctor)) {
+	} else if (uf.is_ctor(meta)) {
 		assert(ast->type() == ASTTag::AccessExpression);
 
 		auto access = static_cast<AST::AccessExpression*>(ast);

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -69,6 +69,7 @@ ExitStatus execute(
 	if (settings.typecheck) {
 		tc.m_core.m_meta_core.comp = &tc.m_env.declaration_components;
 		TypeChecker::metacheck(tc.m_core.m_meta_core, ast);
+		tc.m_core.m_meta_core.solve();
 		TypeChecker::reify_types(ast, tc, ast_allocator);
 		TypeChecker::typecheck(ast, tc);
 	}

--- a/src/meta_unifier.cpp
+++ b/src/meta_unifier.cpp
@@ -10,16 +10,12 @@ Tag MetaUnifier::tag(int idx) const {
 	return nodes[idx].tag;
 }
 
-bool MetaUnifier::is_dot_target(int idx) const {
-	return nodes[idx].is_dot_target;
-}
-
 bool MetaUnifier::is(int idx, Tag t) const {
 	return tag(idx) == t;
 }
 
-bool MetaUnifier::is_ctor(int idx) const {
-	return tag(idx) == Tag::Ctor;
+bool MetaUnifier::is_ctor(int idx) {
+	return is(idx, Tag::Ctor);
 }
 
 bool MetaUnifier::is_constant(Tag t) const {
@@ -43,10 +39,6 @@ bool MetaUnifier::occurs(int v, int i){
 	if (i == v)
 		return true;
 
-	if (is(i, Tag::DotResult))
-		if (occurs(v, nodes[i].target))
-			return true;
-
 	return false;
 }
 
@@ -58,62 +50,35 @@ int MetaUnifier::find(int idx) {
 	return nodes[idx].target = find(nodes[idx].target);
 }
 
-void MetaUnifier::register_dot_target(int idx) {
-	idx = find(idx);
-
-	if (is(idx, Tag::Ctor) || is(idx, Tag::Func))
-		Log::fatal() << "used dot operator on a constructor or typefunc";
-
-	nodes[idx].is_dot_target = true;
-}
-
 void MetaUnifier::turn_into_var(int idx, int target) {
 	// make idx be a var that points to target (unsafe)
 	assert(find(target) == target);
 	nodes[idx].tag = Tag::Var;
 	nodes[idx].target = target;
-	if (nodes[idx].is_dot_target)
-		register_dot_target(target);
 }
 
-void MetaUnifier::turn_dot_result_into(int idx, Tag tag) {
-	assert(is(idx, Tag::DotResult));
-
-	// maybe this assert is actually a legitimate error state?
-	assert(tag == Tag::Term || tag == Tag::Ctor);
-
-	nodes[idx].tag = tag;
-
-	if (tag == Tag::Term)
-		return turn_into(nodes[idx].target, Tag::Term);
-
-	if (tag == Tag::Ctor)
-		return turn_into(nodes[idx].target, Tag::Mono);
-}
-
-void MetaUnifier::turn_into(int idx, Tag tag) {
-	assert(tag != Tag::DotResult);
+bool MetaUnifier::turn_into(int idx, Tag tag) {
 	assert(tag != Tag::Var);
 
 	idx = find(idx);
 	if (is(idx, Tag::Var)) {
 		nodes[idx].tag = tag;
-		return;
+		return true;
 	}
 
-	if (is(idx, Tag::DotResult)) {
-		return turn_dot_result_into(idx, tag);
+	if (this->tag(idx) != tag) {
+		char const* str[5] = { "Var", "Term", "Mono", "Ctor", "Func" };
+
+		Log::fatal() << "bad turn_into: turning a " << str[int(this->tag(idx))] << " into a " << str[int(tag)];
 	}
 
-	if (this->tag(idx) != tag)
-		Log::fatal() << "bad turn_into";
+	return false;
 }
 
 void MetaUnifier::unify(int idx1, int idx2) {
 	// FIXME: This code was written when I was very sleepy. Please, check
 	//        very carefully, and point out the suspicious bits.
 
-	// TODO: propagate is_dot_target
 	// TODO: occurs check
 
 	idx1 = find(idx1);
@@ -128,11 +93,6 @@ void MetaUnifier::unify(int idx1, int idx2) {
 	}
 
 	if (tag1 == Tag::Var) {
-		if (tag2 == Tag::DotResult) {
-			if (occurs(idx1, idx2))
-				Log::fatal() << "recursive unification";
-		}
-
 		turn_into_var(idx1, idx2);
 		return;
 	}
@@ -149,38 +109,12 @@ void MetaUnifier::unify(int idx1, int idx2) {
 		std::swap(tag1, tag2);
 	}
 
-	if (is_constant(tag1) && tag2 == Tag::DotResult) {
-		turn_dot_result_into(idx2, tag1);
-		turn_into_var(idx1, idx2);
-		return;
-	}
-
-	if (tag1 == Tag::DotResult && tag2 == Tag::DotResult) {
-		int target1 = nodes[idx1].target;
-		int target2 = nodes[idx2].target;
-
-		unify(target1, target2);
-		turn_into_var(idx1, idx2);
-		return;
-	}
-
 	assert(0 && "NOT REACHABLE");
 }
 
 
 int MetaUnifier::eval(int idx) {
 	idx = find(idx);
-
-	if (!is(idx, Tag::DotResult))
-		return idx;
-
-	int target = eval(nodes[idx].target);
-
-	if (is(target, Tag::Term) || is(target, Tag::DotResult) || is_dot_target(idx))
-		turn_dot_result_into(idx, Tag::Term);
-
-	if (is(target, Tag::Mono))
-		turn_dot_result_into(idx, Tag::Ctor);
 
 	return idx;
 }
@@ -193,19 +127,12 @@ void MetaUnifier::make_access_fact(int result, int target) {
 int MetaUnifier::make_const_node(Tag tag) {
 	assert(is_constant(tag));
 	int result = nodes.size();
-	nodes.push_back({tag, -1, false});
+	nodes.push_back({tag, -1});
 	return result;
 }
 
 int MetaUnifier::make_var_node() {
 	int result = nodes.size();
-	nodes.push_back({Tag::Var, result, false});
-	return result;
-}
-
-int MetaUnifier::make_dot_node(int target) {
-	int result = nodes.size();
-	nodes.push_back({Tag::DotResult, target, false});
-	register_dot_target(target);
+	nodes.push_back({Tag::Var, result});
 	return result;
 }

--- a/src/meta_unifier.cpp
+++ b/src/meta_unifier.cpp
@@ -186,6 +186,10 @@ int MetaUnifier::eval(int idx) {
 }
 
 
+void MetaUnifier::make_access_fact(int result, int target) {
+	access_facts.push_back({result, target});
+}
+
 int MetaUnifier::make_const_node(Tag tag) {
 	assert(is_constant(tag));
 	int result = nodes.size();

--- a/src/meta_unifier.cpp
+++ b/src/meta_unifier.cpp
@@ -121,7 +121,13 @@ int MetaUnifier::eval(int idx) {
 
 
 void MetaUnifier::make_access_fact(int result, int target) {
+	Log::info() << "make_access_fact " << result << " " << target << "\n";
 	access_facts.push_back({result, target});
+}
+
+void MetaUnifier::make_ctor_fact(int target) {
+	Log::info() << "make_ctor_fact " << target << "\n";
+	ctor_facts.push_back({target});
 }
 
 int MetaUnifier::make_const_node(Tag tag) {

--- a/src/meta_unifier.cpp
+++ b/src/meta_unifier.cpp
@@ -2,8 +2,6 @@
 
 #include "log/log.hpp"
 
-#include <iostream>
-
 #include <cassert>
 
 static char const* tag_str[5] = { "Var", "Term", "Mono", "Ctor", "Func" };
@@ -122,7 +120,7 @@ int MetaUnifier::make_var_node() {
 void MetaUnifier::solve() {
 
 	bool advanced = true;
-	while (advanced) {
+	do {
 		advanced = false;
 
 		for (auto fact : access_facts) {
@@ -130,13 +128,19 @@ void MetaUnifier::solve() {
 			int result = fact.result;
 
 			// accessing a mono gives you a ctor
-			if (is(target, Tag::Mono)) advanced |= turn_into(result, Tag::Ctor);
-			if (is(result, Tag::Ctor)) advanced |= turn_into(target, Tag::Mono);
+			if (is(target, Tag::Mono))
+				advanced |= turn_into(result, Tag::Ctor);
+
+			if (is(result, Tag::Ctor))
+				advanced |= turn_into(target, Tag::Mono);
 
 
 			// accessing a term gives you another term
-			if (is(target, Tag::Term)) advanced |= turn_into(result, Tag::Term);
-			if (is(result, Tag::Term)) advanced |= turn_into(target, Tag::Term);
+			if (is(target, Tag::Term))
+				advanced |= turn_into(result, Tag::Term);
+
+			if (is(result, Tag::Term))
+				advanced |= turn_into(target, Tag::Term);
 
 
 			// this language only has access chains between terms
@@ -157,6 +161,6 @@ void MetaUnifier::solve() {
 				}
 			}
 		}
-	}
+	} while(advanced);
 
 }

--- a/src/meta_unifier.cpp
+++ b/src/meta_unifier.cpp
@@ -18,6 +18,10 @@ bool MetaUnifier::is(int idx, Tag t) const {
 	return tag(idx) == t;
 }
 
+bool MetaUnifier::is_ctor(int idx) const {
+	return tag(idx) == Tag::Ctor;
+}
+
 bool MetaUnifier::is_constant(Tag t) const {
 	return t == Tag::Term || t == Tag::Mono || t == Tag::Ctor || t == Tag::Func;
 }

--- a/src/meta_unifier.hpp
+++ b/src/meta_unifier.hpp
@@ -7,8 +7,7 @@ struct Declaration;
 }
 
 enum class Tag {
-	Var,       // computed
-	DotResult, // computed
+	Var,  // computed
 	Term, // constant
 	Mono, // constant
 	Ctor, // constant
@@ -18,7 +17,6 @@ enum class Tag {
 struct Node {
 	Tag tag;
 	int target;
-	bool is_dot_target{false};
 };
 
 struct AccessFact {
@@ -30,27 +28,23 @@ struct MetaUnifier {
 	// TODO: handle dot targets
 
 	Tag tag(int idx) const;
-	bool is_dot_target(int idx) const;
 
 	bool is(int idx, Tag t) const;
-	bool is_ctor(int idx) const;
+	bool is_ctor(int idx);
 	bool is_singleton_var(int idx) const;
 	bool is_constant(Tag tag) const;
 	bool is_constant(int idx) const;
 
-	void turn_into(int idx, Tag tag);
+	bool turn_into(int idx, Tag tag);
 	int eval(int idx);
 	void unify(int idx1, int idx2);
 
 	int make_const_node(Tag tag);
 	int make_var_node();
-	int make_dot_node(int target);
 
 	void make_access_fact(int result, int target);
 
 private:
-	void register_dot_target(int idx);
-	void turn_dot_result_into(int idx, Tag tag);
 	bool occurs(int var, int target);
 	int find(int idx);
 

--- a/src/meta_unifier.hpp
+++ b/src/meta_unifier.hpp
@@ -24,6 +24,10 @@ struct AccessFact {
 	int target;
 };
 
+struct CtorFact {
+	int target;
+};
+
 struct MetaUnifier {
 	// TODO: handle dot targets
 
@@ -43,6 +47,9 @@ struct MetaUnifier {
 	int make_var_node();
 
 	void make_access_fact(int result, int target);
+	void make_ctor_fact(int target);
+
+	void solve();
 
 private:
 	bool occurs(int var, int target);
@@ -52,6 +59,7 @@ private:
 
 	std::vector<Node> nodes;
 	std::vector<AccessFact> access_facts;
+	std::vector<CtorFact> ctor_facts;
 public:
 	std::vector<std::vector<AST::Declaration*>> const* comp {nullptr};
 };

--- a/src/meta_unifier.hpp
+++ b/src/meta_unifier.hpp
@@ -21,6 +21,11 @@ struct Node {
 	bool is_dot_target{false};
 };
 
+struct AccessFact {
+	int result;
+	int target;
+};
+
 struct MetaUnifier {
 	// TODO: handle dot targets
 
@@ -41,6 +46,8 @@ struct MetaUnifier {
 	int make_var_node();
 	int make_dot_node(int target);
 
+	void make_access_fact(int result, int target);
+
 private:
 	void register_dot_target(int idx);
 	void turn_dot_result_into(int idx, Tag tag);
@@ -50,6 +57,7 @@ private:
 	void turn_into_var(int idx, int target);
 
 	std::vector<Node> nodes;
+	std::vector<AccessFact> access_facts;
 public:
 	std::vector<std::vector<AST::Declaration*>> const* comp {nullptr};
 };

--- a/src/meta_unifier.hpp
+++ b/src/meta_unifier.hpp
@@ -28,6 +28,7 @@ struct MetaUnifier {
 	bool is_dot_target(int idx) const;
 
 	bool is(int idx, Tag t) const;
+	bool is_ctor(int idx) const;
 	bool is_singleton_var(int idx) const;
 	bool is_constant(Tag tag) const;
 	bool is_constant(int idx) const;

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -78,6 +78,13 @@ static void metacheck(MetaUnifier& uf, AST::IndexExpression* ast) {
 
 static void metacheck(MetaUnifier& uf, AST::AccessExpression* ast) {
 	metacheck(uf, ast->m_target);
+
+	auto result_node = uf.make_var_node();
+	auto target_node = ast->m_target->m_meta_type;
+
+	uf.make_access_fact(result_node, target_node);
+	ast->m_meta_type = result_node;
+
 	ast->m_meta_type = uf.make_dot_node(ast->m_target->m_meta_type);
 }
 

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -2,6 +2,7 @@
 
 #include "ast.hpp"
 #include "meta_unifier.hpp"
+#include "log/log.hpp"
 
 namespace TypeChecker {
 
@@ -84,8 +85,6 @@ static void metacheck(MetaUnifier& uf, AST::AccessExpression* ast) {
 
 	uf.make_access_fact(result_node, target_node);
 	ast->m_meta_type = result_node;
-
-	ast->m_meta_type = uf.make_dot_node(ast->m_target->m_meta_type);
 }
 
 static void metacheck(MetaUnifier& uf, AST::MatchExpression* ast) {
@@ -130,6 +129,10 @@ static void metacheck(MetaUnifier& uf, AST::ConstructorExpression* ast) {
 	ast->m_meta_type = uf.make_const_node(Tag::Term);
 
 	metacheck(uf, ast->m_constructor);
+	uf.make_ctor_fact(ast->m_constructor->m_meta_type);
+
+	Log::info() << "ctor target meta type: " << ast->m_constructor->m_meta_type;
+	Log::info() << "ctor expression meta type: " << ast->m_meta_type;
 
 	for (auto& arg : ast->m_args) {
 		metacheck(uf, arg);

--- a/src/metacheck.cpp
+++ b/src/metacheck.cpp
@@ -131,9 +131,6 @@ static void metacheck(MetaUnifier& uf, AST::ConstructorExpression* ast) {
 	metacheck(uf, ast->m_constructor);
 	uf.make_ctor_fact(ast->m_constructor->m_meta_type);
 
-	Log::info() << "ctor target meta type: " << ast->m_constructor->m_meta_type;
-	Log::info() << "ctor expression meta type: " << ast->m_meta_type;
-
 	for (auto& arg : ast->m_args) {
 		metacheck(uf, arg);
 		uf.turn_into(arg->m_meta_type, Tag::Term);


### PR DESCRIPTION
This patch will change the paradigm of how meta type inference works behind the scenes.

The main idea is that, instead of trying to do inference by focusing on single variables, we take a more global view and try to solve all the constraints at the same time, in a single go. This makes things a lot simpler in my opinion.

The algorithm I used is very inefficient (it loops over all constraints until no further inferences can be made), but it is simple, maintainable, and easy to verify. It is also relatively easy to optimize: just add some hash tables to cut down on look ups.

PS: The commits are pretty good, so they can be looked at one-by-one