### PR TITLE
eliminate tuples from the codebase

### DIFF
--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -337,13 +337,6 @@ struct UnionExpression : public CST {
 	    : CST {CSTTag::UnionExpression} {}
 };
 
-struct TupleExpression : public CST {
-	std::vector<CST*> m_types;
-
-	TupleExpression()
-	    : CST {CSTTag::TupleExpression} {}
-};
-
 struct StructExpression : public CST {
 	// TODO: better storage?
 	std::vector<Identifier> m_fields;

--- a/src/cst_tag.hpp
+++ b/src/cst_tag.hpp
@@ -33,7 +33,6 @@
 	X(TypeTerm)                                                                \
 	X(TypeVar)                                                                 \
 	X(UnionExpression)                                                         \
-	X(TupleExpression)                                                         \
 	X(StructExpression)
 
 #define X(name) #name,

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -255,7 +255,6 @@ namespace EndStates {
 	X(Array, KEYWORD_ARRAY, "array")                                           \
 	X(Null, KEYWORD_NULL, "null")                                              \
 	X(Seq, KEYWORD_SEQ, "seq")                                                 \
-	X(Tuple, KEYWORD_TUPLE, "tuple")                                           \
 	X(Struct, KEYWORD_STRUCT, "struct")                                        \
 	X(Union, KEYWORD_UNION, "union")
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1161,14 +1161,6 @@ Writer<CST::CST*> Parser::parse_type_function() {
 		u->m_types = std::move(tl.m_result.second);
 
 		return make_writer<CST::CST*>(u);
-	} else if (consume(TokenTag::KEYWORD_TUPLE)) {
-		auto tl = parse_type_list(false);
-		CHECK_AND_RETURN(result, tl);
-
-		auto t = m_cst_allocator.make<CST::TupleExpression>();
-		t->m_types = std::move(tl.m_result.second);
-
-		return make_writer<CST::CST*>(t);
 	} else if (consume(TokenTag::KEYWORD_STRUCT)) {
 		auto tl = parse_type_list(true);
 		CHECK_AND_RETURN(result, tl);

--- a/src/token_tag.hpp
+++ b/src/token_tag.hpp
@@ -64,7 +64,6 @@
 	X(KEYWORD_MATCH, "KEYWORD_MATCH")                                          \
 	X(KEYWORD_SEQ, "KEYWORD_SEQ")                                              \
 	X(KEYWORD_UNION, "KEYWORD_UNION")                                          \
-	X(KEYWORD_TUPLE, "KEYWORD_TUPLE")                                          \
 	X(KEYWORD_STRUCT, "KEYWORD_STRUCT")                                        \
 	X(END, "(end of file)")
 

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -9,9 +9,9 @@
 #include "typechecker_types.hpp"
 #include "utils/interned_string.hpp"
 
-enum class TypeFunctionTag { Builtin, Variant, Tuple, Record };
+enum class TypeFunctionTag { Builtin, Variant, Record };
 // Concrete type function. If it's a built-in, we use argument_count
-// to tell how many arguments it takes. Else, for variant, tuple and record,
+// to tell how many arguments it takes. Else, for variant, and record,
 // we store their structure as a hash from names to monotypes.
 //
 // Dummy type functions are for unification purposes only, but do not count


### PR DESCRIPTION
Realistically, tuples will never be implemented in jasper, so might as well get rid of all the related code, since it's just dead weight.