### PR TITLE
Extract incidental union find typefunc unification logic

### DIFF
--- a/src/algorithms/union_find.hpp
+++ b/src/algorithms/union_find.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+
+struct UnionFind {
+	int new_var() {
+		int result = repr.size();
+		repr.push_back(result);
+		return result;
+	}
+
+	int find(int i) {
+		if (repr[i] == i)
+			return i;
+		return repr[i] = find(repr[i]);
+	}
+
+	void join_left_to_right(int i, int j) {
+		repr[find(i)] = find(j);
+	}
+
+	bool is_single(int i) {
+		return i == repr[i];
+	}
+
+  private:
+	std::vector<int> repr;
+};

--- a/src/algorithms/union_find.hpp
+++ b/src/algorithms/union_find.hpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 struct UnionFind {
-	int new_var() {
+	int new_node() {
 		int result = repr.size();
 		repr.push_back(result);
 		return result;

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -322,7 +322,7 @@ static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) 
 		// put a dummy var where required.
 		if (uf.is(meta_type, Tag::Func)) {
 			auto handle = alloc.make<AST::TypeFunctionHandle>();
-			handle->m_value = tc.m_core.new_tf_var();
+			handle->m_value = tc.m_core.new_type_function_var();
 			handle->m_syntax = decl.m_value;
 			decl.m_value = handle;
 		} else if (uf.is(meta_type, Tag::Mono)) {
@@ -352,7 +352,7 @@ static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) 
 
 				auto handle = static_cast<AST::TypeFunctionHandle*>(decl->m_value);
 				TypeFunctionId tf = eval_then_get_type_func(handle->m_syntax, tc, alloc);
-				tc.m_core.unify_tf(tf, handle->m_value);
+				tc.m_core.unify_type_function(tf, handle->m_value);
 			} else if (uf.is(meta_type, Tag::Mono)) {
 				if (decl->m_type_hint)
 					Log::fatal() << "type hint not allowed in type declaration";

--- a/src/ct_eval.cpp
+++ b/src/ct_eval.cpp
@@ -322,7 +322,7 @@ static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) 
 		// put a dummy var where required.
 		if (uf.is(meta_type, Tag::Func)) {
 			auto handle = alloc.make<AST::TypeFunctionHandle>();
-			handle->m_value = tc.m_core.m_tf_core.new_var();
+			handle->m_value = tc.m_core.new_tf_var();
 			handle->m_syntax = decl.m_value;
 			decl.m_value = handle;
 		} else if (uf.is(meta_type, Tag::Mono)) {
@@ -352,7 +352,7 @@ static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) 
 
 				auto handle = static_cast<AST::TypeFunctionHandle*>(decl->m_value);
 				TypeFunctionId tf = eval_then_get_type_func(handle->m_syntax, tc, alloc);
-				tc.m_core.m_tf_core.unify(tf, handle->m_value);
+				tc.m_core.unify_tf(tf, handle->m_value);
 			} else if (uf.is(meta_type, Tag::Mono)) {
 				if (decl->m_type_hint)
 					Log::fatal() << "type hint not allowed in type declaration";

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -355,17 +355,12 @@ void eval(AST::TypeFunctionHandle* ast, Interpreter& e) {
 }
 
 void eval(AST::MonoTypeHandle* ast, Interpreter& e) {
-	TypeFunctionId type_function_header =
-	    e.m_tc->m_core.m_mono_core.find_function(ast->m_value);
-	int type_function = e.m_tc->m_core.m_tf_core.find_function(type_function_header);
-	auto& type_function_data = e.m_tc->m_core.m_type_functions[type_function];
+	auto& type_function_data = e.m_tc->m_core.type_function_data_of(ast->m_value);
 	e.push_record_constructor(type_function_data.fields);
 }
 
 void eval(AST::Constructor* ast, Interpreter& e) {
-	TypeFunctionId tf_header = e.m_tc->m_core.m_mono_core.find_function(ast->m_mono);
-	int tf = e.m_tc->m_core.m_tf_core.find_function(tf_header);
-	auto& tf_data = e.m_tc->m_core.m_type_functions[tf];
+	auto& tf_data = e.m_tc->m_core.type_function_data_of(ast->m_mono);
 
 	if (tf_data.tag == TypeFunctionTag::Record) {
 		e.push_record_constructor(tf_data.fields);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -238,9 +238,7 @@ void typecheck(AST::ConstructorExpression* ast, TypeChecker& tc) {
 	auto constructor = static_cast<AST::Constructor*>(ast->m_constructor);
 	assert(constructor->type() == ASTTag::Constructor);
 
-	TypeFunctionId tf = tc.m_core.m_mono_core.find_function(constructor->m_mono);
-	int tf_data_idx = tc.m_core.m_tf_core.find_function(tf);
-	TypeFunctionData& tf_data = tc.m_core.m_type_functions[tf_data_idx];
+	TypeFunctionData& tf_data = tc.m_core.type_function_data_of(constructor->m_mono);
 
 	// match value arguments
 	if (tf_data.tag == TypeFunctionTag::Record) {

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -180,19 +180,20 @@ void TypeSystemCore::unify_tf_data(TypeFunctionData& a_data, TypeFunctionData& b
 
 	b_data.argument_count = new_argument_count;
 
+	bool can_add_fields_to_b = b_data.is_dummy;
 	for (auto& kv_a : a_data.structure) {
-		auto kv_b = b_data.structure.find(kv_a.first);
+		auto const& field_name = kv_a.first;
+		auto const kv_b = b_data.structure.find(field_name);
 
-		if (kv_b == b_data.structure.end())
-			// if b doesn't have a field of a, act accordingly
-			if (b_data.is_dummy)
-				b_data.structure.insert(kv_a);
-			else
-				Log::fatal() << "Accessing non-existing field '" << kv_a.first << "' of a record";
-		else
-			// else the fields must have equivalent types
+		bool const b_has_field = kv_b != b_data.structure.end();
+		if (b_has_field)
 			m_mono_core.unify(kv_a.second, kv_b->second);
+		else if (can_add_fields_to_b)
+			b_data.structure.insert(kv_a);
+		else
+			Log::fatal() << "Accessing non-existing field '" << field_name << "' of a record";
 	}
+
 }
 
 TypeFunctionData& TypeSystemCore::get_tf_data(TypeFunctionId tf) {

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -123,7 +123,7 @@ TypeFunctionId TypeSystemCore::create_tf(
     std::vector<InternedString> fields,
     std::unordered_map<InternedString, MonoId> structure,
     bool is_dummy) {
-	TypeFunctionId result = m_tf_uf.new_var();
+	TypeFunctionId result = m_tf_uf.new_node();
 	m_type_functions.push_back(
 	    {tag, arity, std::move(fields), std::move(structure), is_dummy});
 	return result;
@@ -175,10 +175,9 @@ int TypeSystemCore::compute_new_argument_count(
 }
 
 void TypeSystemCore::unify_tf_data(TypeFunctionData& a_data, TypeFunctionData& b_data) {
+	assert(a_data.is_dummy);
 
-	int const new_argument_count = compute_new_argument_count(a_data, b_data);
-
-	b_data.argument_count = new_argument_count;
+	b_data.argument_count = compute_new_argument_count(a_data, b_data);
 
 	bool can_add_fields_to_b = b_data.is_dummy;
 	for (auto& kv_a : a_data.structure) {

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -191,3 +191,20 @@ void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<MonoId>& f
 			gather_free_vars(arg, free_vars);
 	}
 }
+
+
+
+
+TypeFunctionData& TypeSystemCore::type_function_data_of(MonoId mono){
+	TypeFunctionId tf_header = m_mono_core.find_function(mono);
+	int tf = m_tf_core.find_function(tf_header);
+	return m_type_functions[tf];
+}
+
+TypeFunctionId TypeSystemCore::new_tf_var() {
+	return m_tf_core.new_var();
+}
+
+void TypeSystemCore::unify_tf(TypeFunctionId i, TypeFunctionId j) {
+	m_tf_core.unify(i, j);
+}

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -29,24 +29,7 @@ TypeSystemCore::TypeSystemCore() {
 			// Also, we do it before unifying their data to prevent infinite
 			// recursion
 			point_tf_at_another(a, b);
-
-			int const new_argument_count = compute_new_argument_count(a_data, b_data);
-
-			b_data.argument_count = new_argument_count;
-
-			for (auto& kv_a : a_data.structure) {
-				auto kv_b = b_data.structure.find(kv_a.first);
-
-				if (kv_b == b_data.structure.end())
-					// if b doesn't have a field of a, act accordingly
-					if (b_data.is_dummy)
-						b_data.structure.insert(kv_a);
-					else
-						Log::fatal() << "Accessing non-existing field '" << kv_a.first << "' of a record";
-				else
-					// else the fields must have equivalent types
-					m_mono_core.unify(kv_a.second, kv_b->second);
-			}
+			unify_tf_data(a_data, b_data);
 
 		} else {
 			Log::fatal()
@@ -215,4 +198,23 @@ int TypeSystemCore::compute_new_argument_count(
 	}
 }
 
-// void TypeSystemCore::technobabble(TypeFunctionData& a_data, TypeFunctionData& b_data) { }
+void TypeSystemCore::unify_tf_data(TypeFunctionData& a_data, TypeFunctionData& b_data) {
+
+	int const new_argument_count = compute_new_argument_count(a_data, b_data);
+
+	b_data.argument_count = new_argument_count;
+
+	for (auto& kv_a : a_data.structure) {
+		auto kv_b = b_data.structure.find(kv_a.first);
+
+		if (kv_b == b_data.structure.end())
+			// if b doesn't have a field of a, act accordingly
+			if (b_data.is_dummy)
+				b_data.structure.insert(kv_a);
+			else
+				Log::fatal() << "Accessing non-existing field '" << kv_a.first << "' of a record";
+		else
+			// else the fields must have equivalent types
+			m_mono_core.unify(kv_a.second, kv_b->second);
+	}
+}

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -55,7 +55,7 @@ TypeSystemCore::TypeSystemCore() {
 
 MonoId TypeSystemCore::new_term(
     TypeFunctionId tf, std::vector<int> args, char const* tag) {
-	tf = m_tf_core.find(tf);
+	tf = find_tf(tf);
 
 	{
 		// TODO: add a TypeFunctionTag::Unknown tag, to express
@@ -65,10 +65,9 @@ MonoId TypeSystemCore::new_term(
 		TypeFunctionId dummy_tf =
 		    new_type_function(TypeFunctionTag::Builtin, {}, {}, true);
 
-		int dummy_tf_data_id = m_tf_core.find_function(dummy_tf);
-		m_type_functions[dummy_tf_data_id].argument_count = args.size();
+		get_tf_data(dummy_tf).argument_count = args.size();
 
-		m_tf_core.unify(tf, dummy_tf);
+		unify_tf(tf, dummy_tf);
 	}
 
 	return m_mono_core.new_term(tf, std::move(args), tag);
@@ -160,9 +159,8 @@ void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<MonoId>& f
 
 
 TypeFunctionData& TypeSystemCore::type_function_data_of(MonoId mono){
-	TypeFunctionId tf_header = m_mono_core.find_function(mono);
-	int tf = m_tf_core.find_function(tf_header);
-	return m_type_functions[tf];
+	TypeFunctionId tf = m_mono_core.find_function(mono);
+	return get_tf_data(tf);
 }
 
 TypeFunctionId TypeSystemCore::new_tf_var() {
@@ -217,4 +215,13 @@ void TypeSystemCore::unify_tf_data(TypeFunctionData& a_data, TypeFunctionData& b
 			// else the fields must have equivalent types
 			m_mono_core.unify(kv_a.second, kv_b->second);
 	}
+}
+
+TypeFunctionData& TypeSystemCore::get_tf_data(TypeFunctionId tf) {
+	int data_idx = m_tf_core.find_function(tf);
+	return m_type_functions[data_idx];
+}
+
+TypeFunctionId TypeSystemCore::find_tf(TypeFunctionId tf) {
+	return m_tf_core.find(tf);
 }

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -145,8 +145,13 @@ void TypeSystemCore::unify_type_function(TypeFunctionId i, TypeFunctionId j) {
 		std::swap(i, j);
 
 	if (get_type_function_data(i).is_dummy) {
+		// We get the data before calling point_type_function_at_another
+		// because doing it after the call would give us the same reference
+		// for both indices
+		auto& i_data = get_type_function_data(i);
+		auto& j_data = get_type_function_data(j);
 		point_type_function_at_another(i, j);
-		unify_type_function_data(get_type_function_data(i), get_type_function_data(j));
+		unify_type_function_data(i_data, j_data);
 	} else {
 		Log::fatal() << "unified different typefuncs";
 	}

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -45,31 +45,6 @@ PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
 	return poly;
 }
 
-
-TypeFunctionId TypeSystemCore::new_builtin_type_function(int arity) {
-	return create_tf(TypeFunctionTag::Builtin, arity, {}, {}, false);
-}
-
-TypeFunctionId TypeSystemCore::new_type_function(
-    TypeFunctionTag type,
-    std::vector<InternedString> fields,
-    std::unordered_map<InternedString, MonoId> structure,
-    bool dummy) {
-	return create_tf(type, 0, std::move(fields), std::move(structure), dummy);
-}
-
-TypeFunctionId TypeSystemCore::create_tf(
-    TypeFunctionTag tag,
-    int arity,
-    std::vector<InternedString> fields,
-    std::unordered_map<InternedString, MonoId> structure,
-    bool is_dummy) {
-	TypeFunctionId result = m_tf_uf.new_var();
-	m_type_functions.push_back(
-	    {tag, arity, std::move(fields), std::move(structure), is_dummy});
-	return result;
-}
-
 MonoId TypeSystemCore::inst_impl(
     MonoId mono, std::unordered_map<MonoId, MonoId> const& mapping) {
 
@@ -126,14 +101,37 @@ void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<MonoId>& f
 
 
 
+TypeFunctionId TypeSystemCore::new_builtin_type_function(int arity) {
+	return create_tf(TypeFunctionTag::Builtin, arity, {}, {}, false);
+}
 
-TypeFunctionData& TypeSystemCore::type_function_data_of(MonoId mono){
-	TypeFunctionId tf = m_mono_core.find_function(mono);
-	return get_tf_data(tf);
+TypeFunctionId TypeSystemCore::new_type_function(
+    TypeFunctionTag type,
+    std::vector<InternedString> fields,
+    std::unordered_map<InternedString, MonoId> structure,
+    bool dummy) {
+	return create_tf(type, 0, std::move(fields), std::move(structure), dummy);
 }
 
 TypeFunctionId TypeSystemCore::new_tf_var() {
 	return create_tf(TypeFunctionTag::Builtin, -1, {}, {}, true);
+}
+
+TypeFunctionId TypeSystemCore::create_tf(
+    TypeFunctionTag tag,
+    int arity,
+    std::vector<InternedString> fields,
+    std::unordered_map<InternedString, MonoId> structure,
+    bool is_dummy) {
+	TypeFunctionId result = m_tf_uf.new_var();
+	m_type_functions.push_back(
+	    {tag, arity, std::move(fields), std::move(structure), is_dummy});
+	return result;
+}
+
+TypeFunctionData& TypeSystemCore::type_function_data_of(MonoId mono){
+	TypeFunctionId tf = m_mono_core.find_function(mono);
+	return get_tf_data(tf);
 }
 
 void TypeSystemCore::unify_tf(TypeFunctionId i, TypeFunctionId j) {

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -178,25 +178,6 @@ void TypeSystemCore::point_type_function_at_another(TypeFunctionId a, TypeFuncti
 	m_type_function_uf.join_left_to_right(a, b);
 }
 
-int TypeSystemCore::compute_new_argument_count(
-    TypeFunctionData const& a_data, TypeFunctionData const& b_data) const {
-
-	if (a_data.argument_count == b_data.argument_count) {
-		return a_data.argument_count;
-	} else if (b_data.strength == TypeFunctionStrength::Half || b_data.argument_count == -1) {
-		return -1;
-	} else {
-		auto present_argument_count = [](int x) -> std::string {
-			return x == -1 ? "variadic" : std::to_string(x);
-		};
-		std::string argc_a = present_argument_count(a_data.argument_count);
-		std::string argc_b = present_argument_count(b_data.argument_count);
-		Log::fatal() << "Deduced type functions with incompatible argument "
-		                "counts to be equal (with "
-		             << argc_a << " and " << argc_b << " arguments)";
-	}
-}
-
 void TypeSystemCore::unify_type_function_data(TypeFunctionData& a_data, TypeFunctionData& b_data) {
 	assert(a_data.strength == TypeFunctionStrength::Half);
 
@@ -216,6 +197,25 @@ void TypeSystemCore::unify_type_function_data(TypeFunctionData& a_data, TypeFunc
 			Log::fatal() << "Accessing non-existing field '" << field_name << "' of a record";
 	}
 
+}
+
+int TypeSystemCore::compute_new_argument_count(
+    TypeFunctionData const& a_data, TypeFunctionData const& b_data) const {
+
+	if (a_data.argument_count == b_data.argument_count)
+		return a_data.argument_count;
+
+	if (b_data.strength == TypeFunctionStrength::Half || b_data.argument_count == -1)
+		return -1;
+
+	auto present_argument_count = [](int x) -> std::string {
+		return x == -1 ? "variadic" : std::to_string(x);
+	};
+	std::string argc_a = present_argument_count(a_data.argument_count);
+	std::string argc_b = present_argument_count(b_data.argument_count);
+	Log::fatal() << "Deduced type functions with incompatible argument "
+	                "counts to be equal (with "
+	             << argc_a << " and " << argc_b << " arguments)";
 }
 
 TypeFunctionData& TypeSystemCore::get_type_function_data(TypeFunctionId tf) {

--- a/src/typesystem.cpp
+++ b/src/typesystem.cpp
@@ -163,16 +163,14 @@ int TypeSystemCore::compute_new_argument_count(
 	} else if (b_data.is_dummy || b_data.argument_count == -1) {
 		return -1;
 	} else {
-		std::string argc_a = a_data.argument_count == -1
-			? std::string("variadic")
-			: std::to_string(a_data.argument_count);
-		std::string argc_b = b_data.argument_count == -1
-			? std::string("variadic")
-			: std::to_string(b_data.argument_count);
-		Log::fatal()
-			<< "Deduced type functions with incompatible argument "
-			"counts to be equal (with "
-			<< argc_a << " and " << argc_b << " arguments)";
+		auto present_argument_count = [](int x) -> std::string {
+			return x == -1 ? "variadic" : std::to_string(x);
+		};
+		std::string argc_a = present_argument_count(a_data.argument_count);
+		std::string argc_b = present_argument_count(b_data.argument_count);
+		Log::fatal() << "Deduced type functions with incompatible argument "
+		                "counts to be equal (with "
+		             << argc_a << " and " << argc_b << " arguments)";
 	}
 }
 

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -72,4 +72,9 @@ struct TypeSystemCore {
 	void unify_tf(TypeFunctionId, TypeFunctionId);
 private:
 	Unification::Core m_tf_core;
+
+	int compute_new_argument_count(
+	    TypeFunctionData const& a_data, TypeFunctionData const& b_data) const;
+
+	void point_tf_at_another(TypeFunctionId a, TypeFunctionId b);
 };

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -10,6 +10,16 @@
 #include "typechecker_types.hpp"
 #include "utils/interned_string.hpp"
 
+// Type function strength is an ad-hoc concept, specific to our implementation
+// of unification.
+// If a typefunc has 'None' strength, its data is not even considered for
+// unification.
+// If it has 'Half' strength, its data is considered to be incomplete, so we
+// allow adding to it, but not removing.
+// If it has 'Full' strength, we only accept exact matches during unification.
+// We don't allow unifying two different full-strength type functions
+enum class TypeFunctionStrength { None, Half, Full };
+
 enum class TypeFunctionTag { Builtin, Variant, Record };
 // Concrete type function. If it's a built-in, we use argument_count
 // to tell how many arguments it takes. Else, for variant, and record,
@@ -26,7 +36,7 @@ struct TypeFunctionData {
 	std::vector<InternedString> fields;
 	std::unordered_map<InternedString, MonoId> structure;
 
-	bool is_dummy {false};
+	TypeFunctionStrength strength;
 };
 
 // A polytype is a type where some amount of type variables can take
@@ -79,7 +89,7 @@ private:
 	    int arity,
 	    std::vector<InternedString> fields,
 	    std::unordered_map<InternedString, MonoId> structure,
-	    bool is_dummy);
+	    TypeFunctionStrength);
 
 	std::vector<TypeFunctionData> m_type_functions;
 	std::vector<PolyData> poly_data;

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -64,17 +64,17 @@ struct TypeSystemCore {
 	MonoId inst_fresh(PolyId poly);
 
 	TypeFunctionData& type_function_data_of(MonoId);
-	TypeFunctionId new_tf_var();
-	void unify_tf(TypeFunctionId, TypeFunctionId);
+	TypeFunctionId new_type_function_var();
+	void unify_type_function(TypeFunctionId, TypeFunctionId);
 private:
 	int compute_new_argument_count(
 	    TypeFunctionData const& a_data, TypeFunctionData const& b_data) const;
 
-	void point_tf_at_another(TypeFunctionId a, TypeFunctionId b);
-	void unify_tf_data(TypeFunctionData& a_data, TypeFunctionData& b_data);
-	TypeFunctionData& get_tf_data(TypeFunctionId tf);
-	TypeFunctionId find_tf(TypeFunctionId tf);
-	TypeFunctionId create_tf(
+	void point_type_function_at_another(TypeFunctionId a, TypeFunctionId b);
+	void unify_type_function_data(TypeFunctionData& a_data, TypeFunctionData& b_data);
+	TypeFunctionData& get_type_function_data(TypeFunctionId);
+	TypeFunctionId find_type_function(TypeFunctionId);
+	TypeFunctionId create_type_function(
 	    TypeFunctionTag tag,
 	    int arity,
 	    std::vector<InternedString> fields,
@@ -83,5 +83,5 @@ private:
 
 	std::vector<TypeFunctionData> m_type_functions;
 	std::vector<PolyData> poly_data;
-	UnionFind m_tf_uf;
+	UnionFind m_type_function_uf;
 };

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -38,11 +38,6 @@ struct PolyData {
 
 struct TypeSystemCore {
 	Unification::Core m_mono_core;
-
-	std::vector<TypeFunctionData> m_type_functions;
-
-	std::vector<PolyData> poly_data;
-
 	MetaUnifier m_meta_core;
 
 	TypeSystemCore();
@@ -72,8 +67,6 @@ struct TypeSystemCore {
 	TypeFunctionId new_tf_var();
 	void unify_tf(TypeFunctionId, TypeFunctionId);
 private:
-	UnionFind m_tf_uf;
-
 	int compute_new_argument_count(
 	    TypeFunctionData const& a_data, TypeFunctionData const& b_data) const;
 
@@ -87,4 +80,8 @@ private:
 	    std::vector<InternedString> fields,
 	    std::unordered_map<InternedString, MonoId> structure,
 	    bool is_dummy);
+
+	std::vector<TypeFunctionData> m_type_functions;
+	std::vector<PolyData> poly_data;
+	UnionFind m_tf_uf;
 };

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "algorithms/unification.hpp"
+#include "algorithms/union_find.hpp"
 #include "meta_unifier.hpp"
 #include "typechecker_types.hpp"
 #include "utils/interned_string.hpp"
@@ -71,6 +72,7 @@ struct TypeSystemCore {
 	TypeFunctionId new_tf_var();
 	void unify_tf(TypeFunctionId, TypeFunctionId);
 private:
+	UnionFind m_tf_uf;
 	Unification::Core m_tf_core;
 
 	int compute_new_argument_count(

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -73,7 +73,6 @@ struct TypeSystemCore {
 	void unify_tf(TypeFunctionId, TypeFunctionId);
 private:
 	UnionFind m_tf_uf;
-	Unification::Core m_tf_core;
 
 	int compute_new_argument_count(
 	    TypeFunctionData const& a_data, TypeFunctionData const& b_data) const;

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -38,7 +38,6 @@ struct PolyData {
 struct TypeSystemCore {
 	Unification::Core m_mono_core;
 
-	Unification::Core m_tf_core;
 	std::vector<TypeFunctionData> m_type_functions;
 
 	std::vector<PolyData> poly_data;
@@ -67,4 +66,10 @@ struct TypeSystemCore {
 	MonoId inst_impl(MonoId mono, std::unordered_map<MonoId, MonoId> const& mapping);
 	MonoId inst_with(PolyId poly, std::vector<MonoId> const& vals);
 	MonoId inst_fresh(PolyId poly);
+
+	TypeFunctionData& type_function_data_of(MonoId);
+	TypeFunctionId new_tf_var();
+	void unify_tf(TypeFunctionId, TypeFunctionId);
+private:
+	Unification::Core m_tf_core;
 };

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -66,14 +66,14 @@ struct TypeSystemCore {
 	TypeFunctionData& type_function_data_of(MonoId);
 	TypeFunctionId new_type_function_var();
 	void unify_type_function(TypeFunctionId, TypeFunctionId);
-private:
-	int compute_new_argument_count(
-	    TypeFunctionData const& a_data, TypeFunctionData const& b_data) const;
 
-	void point_type_function_at_another(TypeFunctionId a, TypeFunctionId b);
-	void unify_type_function_data(TypeFunctionData& a_data, TypeFunctionData& b_data);
+private:
+	void point_type_function_at_another(TypeFunctionId, TypeFunctionId);
+	void unify_type_function_data(TypeFunctionData&, TypeFunctionData&);
+	int compute_new_argument_count(TypeFunctionData const&, TypeFunctionData const&) const;
 	TypeFunctionData& get_type_function_data(TypeFunctionId);
 	TypeFunctionId find_type_function(TypeFunctionId);
+
 	TypeFunctionId create_type_function(
 	    TypeFunctionTag tag,
 	    int arity,

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -81,4 +81,10 @@ private:
 	void unify_tf_data(TypeFunctionData& a_data, TypeFunctionData& b_data);
 	TypeFunctionData& get_tf_data(TypeFunctionId tf);
 	TypeFunctionId find_tf(TypeFunctionId tf);
+	TypeFunctionId create_tf(
+	    TypeFunctionTag tag,
+	    int arity,
+	    std::vector<InternedString> fields,
+	    std::unordered_map<InternedString, MonoId> structure,
+	    bool is_dummy);
 };

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -78,4 +78,6 @@ private:
 
 	void point_tf_at_another(TypeFunctionId a, TypeFunctionId b);
 	void unify_tf_data(TypeFunctionData& a_data, TypeFunctionData& b_data);
+	TypeFunctionData& get_tf_data(TypeFunctionId tf);
+	TypeFunctionId find_tf(TypeFunctionId tf);
 };

--- a/src/typesystem.hpp
+++ b/src/typesystem.hpp
@@ -77,4 +77,5 @@ private:
 	    TypeFunctionData const& a_data, TypeFunctionData const& b_data) const;
 
 	void point_tf_at_another(TypeFunctionId a, TypeFunctionId b);
+	void unify_tf_data(TypeFunctionData& a_data, TypeFunctionData& b_data);
 };


### PR DESCRIPTION
This patch simplifies typefunc unification logic by making it no longer rely on the cumbersome `Unification::Core` class.

There is a deeper observation to be made about `Unification::Core` in general, which might be why it is so cumbersome to use and work on: It hides a union-find data structure inside of it. Part of this patch is making the data structure explicit, which simplifies reasoning.

It would be nice to do a similar thing for the other usage of `Unification::Core`, but that one may prove more difficult, as it does depend on all of the bells and whistles that the class includes.

Notice: This is a draft, but I'd still like a review. The core change is done, but the code was left in a less than ideal state due to a series of refactorings mean to facilitate this change. Any help in improving code quality is appreciated.

Notice: The commits are fairly self contained and cohesive, though some of the code was overwritten in the later ones.