### PR TITLE
Bugfix typevar in environment

### DIFF
--- a/src/typechecker/compile_time_environment.cpp
+++ b/src/typechecker/compile_time_environment.cpp
@@ -62,7 +62,11 @@ bool CompileTimeEnvironment::has_type_var(MonoId var, TypeSystemCore& core) {
 
 void CompileTimeEnvironment::bind_var_if_not_present(MonoId var, TypeSystemCore& core) {
 	if (!has_type_var(var, core))
-		current_scope().m_type_vars.insert(var);
+		bind_to_current_scope(var);
+}
+
+void CompileTimeEnvironment::bind_to_current_scope(MonoId var) {
+	current_scope().m_type_vars.insert(var);
 }
 
 } // namespace Frontend

--- a/src/typechecker/compile_time_environment.cpp
+++ b/src/typechecker/compile_time_environment.cpp
@@ -10,6 +10,7 @@
 namespace Frontend {
 
 CompileTimeEnvironment::CompileTimeEnvironment() {
+	m_scopes.push_back({false});
 }
 
 CompileTimeEnvironment::Scope& CompileTimeEnvironment::current_scope() {
@@ -25,6 +26,7 @@ void CompileTimeEnvironment::new_nested_scope() {
 }
 
 void CompileTimeEnvironment::end_scope() {
+	assert(m_scopes.size() > 1);
 	m_scopes.pop_back();
 }
 
@@ -36,7 +38,7 @@ bool CompileTimeEnvironment::has_type_var(MonoId var, TypeSystemCore& core) {
 	};
 
 	// scan nested scopes from the inside out
-	for (int i = m_scopes.size(); i--;) {
+	for (int i = m_scopes.size(); i-- > 1;) {
 		auto found = scan_scope(m_scopes[i], var);
 		if (found)
 			return true;
@@ -72,7 +74,7 @@ void CompileTimeEnvironment::bind_to_current_scope(MonoId var) {
 
 
 CompileTimeEnvironment::Scope& CompileTimeEnvironment::global_scope() {
-	return m_global_scope;
+	return m_scopes[0];
 }
 
 } // namespace Frontend

--- a/src/typechecker/compile_time_environment.cpp
+++ b/src/typechecker/compile_time_environment.cpp
@@ -33,16 +33,16 @@ void CompileTimeEnvironment::end_scope() {
 bool CompileTimeEnvironment::has_type_var(MonoId var, TypeSystemCore& core) {
 	// TODO: check that the given mono is actually a var
 
-	auto scan_scope = [](Scope& scope, MonoId var) -> bool {
+	auto scan_scope = [](Scope const& scope, MonoId var) -> bool {
 		return scope.m_type_vars.count(var) != 0;
 	};
 
 	// scan nested scopes from the inside out
-	for (int i = m_scopes.size(); i-- > 1;) {
-		auto found = scan_scope(m_scopes[i], var);
+	for (int i = scopes().size(); i-- > 1;) {
+		auto found = scan_scope(scopes()[i], var);
 		if (found)
 			return true;
-		if (!m_scopes[i].m_nested)
+		if (!scopes()[i].m_nested)
 			break;
 	}
 
@@ -51,7 +51,7 @@ bool CompileTimeEnvironment::has_type_var(MonoId var, TypeSystemCore& core) {
 	if (found)
 		return true;
 
-	for (auto& scope : m_scopes) {
+	for (auto& scope : scopes()) {
 		for (auto stored_var : scope.m_type_vars) {
 			std::unordered_set<MonoId> free_vars;
 			core.gather_free_vars(stored_var, free_vars);
@@ -75,6 +75,10 @@ void CompileTimeEnvironment::bind_to_current_scope(MonoId var) {
 
 CompileTimeEnvironment::Scope& CompileTimeEnvironment::global_scope() {
 	return m_scopes[0];
+}
+
+std::vector<CompileTimeEnvironment::Scope> const& CompileTimeEnvironment::scopes() {
+	return m_scopes;
 }
 
 } // namespace Frontend

--- a/src/typechecker/compile_time_environment.cpp
+++ b/src/typechecker/compile_time_environment.cpp
@@ -10,7 +10,7 @@
 namespace Frontend {
 
 CompileTimeEnvironment::CompileTimeEnvironment() {
-	m_scopes.push_back({false});
+	m_scopes.push_back({});
 }
 
 CompileTimeEnvironment::Scope& CompileTimeEnvironment::current_scope() {
@@ -18,11 +18,11 @@ CompileTimeEnvironment::Scope& CompileTimeEnvironment::current_scope() {
 }
 
 void CompileTimeEnvironment::new_scope() {
-	m_scopes.push_back({false});
+	m_scopes.push_back({});
 }
 
 void CompileTimeEnvironment::new_nested_scope() {
-	m_scopes.push_back({true});
+	m_scopes.push_back({});
 }
 
 void CompileTimeEnvironment::end_scope() {
@@ -33,7 +33,6 @@ void CompileTimeEnvironment::end_scope() {
 void CompileTimeEnvironment::bind_to_current_scope(MonoId var) {
 	current_scope().m_type_vars.insert(var);
 }
-
 
 CompileTimeEnvironment::Scope& CompileTimeEnvironment::global_scope() {
 	return m_scopes[0];

--- a/src/typechecker/compile_time_environment.cpp
+++ b/src/typechecker/compile_time_environment.cpp
@@ -9,10 +9,11 @@
 
 namespace Frontend {
 
-CompileTimeEnvironment::CompileTimeEnvironment() {}
+CompileTimeEnvironment::CompileTimeEnvironment() {
+}
 
 CompileTimeEnvironment::Scope& CompileTimeEnvironment::current_scope() {
-	return m_scopes.empty() ? m_global_scope : m_scopes.back();
+	return m_scopes.empty() ? global_scope() : m_scopes.back();
 }
 
 void CompileTimeEnvironment::new_scope() {
@@ -44,7 +45,7 @@ bool CompileTimeEnvironment::has_type_var(MonoId var, TypeSystemCore& core) {
 	}
 
 	// fall back to global scope lookup
-	auto found = scan_scope(m_global_scope, var);
+	auto found = scan_scope(global_scope(), var);
 	if (found)
 		return true;
 
@@ -67,6 +68,11 @@ void CompileTimeEnvironment::bind_var_if_not_present(MonoId var, TypeSystemCore&
 
 void CompileTimeEnvironment::bind_to_current_scope(MonoId var) {
 	current_scope().m_type_vars.insert(var);
+}
+
+
+CompileTimeEnvironment::Scope& CompileTimeEnvironment::global_scope() {
+	return m_global_scope;
 }
 
 } // namespace Frontend

--- a/src/typechecker/compile_time_environment.cpp
+++ b/src/typechecker/compile_time_environment.cpp
@@ -30,44 +30,6 @@ void CompileTimeEnvironment::end_scope() {
 	m_scopes.pop_back();
 }
 
-bool CompileTimeEnvironment::has_type_var(MonoId var, TypeSystemCore& core) {
-	// TODO: check that the given mono is actually a var
-
-	auto scan_scope = [](Scope const& scope, MonoId var) -> bool {
-		return scope.m_type_vars.count(var) != 0;
-	};
-
-	// scan nested scopes from the inside out
-	for (int i = scopes().size(); i-- > 1;) {
-		auto found = scan_scope(scopes()[i], var);
-		if (found)
-			return true;
-		if (!scopes()[i].m_nested)
-			break;
-	}
-
-	// fall back to global scope lookup
-	auto found = scan_scope(global_scope(), var);
-	if (found)
-		return true;
-
-	for (auto& scope : scopes()) {
-		for (auto stored_var : scope.m_type_vars) {
-			std::unordered_set<MonoId> free_vars;
-			core.gather_free_vars(stored_var, free_vars);
-			if (free_vars.count(var))
-				return true;
-		}
-	}
-
-	return false;
-}
-
-void CompileTimeEnvironment::bind_var_if_not_present(MonoId var, TypeSystemCore& core) {
-	if (!has_type_var(var, core))
-		bind_to_current_scope(var);
-}
-
 void CompileTimeEnvironment::bind_to_current_scope(MonoId var) {
 	current_scope().m_type_vars.insert(var);
 }

--- a/src/typechecker/compile_time_environment.hpp
+++ b/src/typechecker/compile_time_environment.hpp
@@ -36,8 +36,6 @@ struct CompileTimeEnvironment {
 	void new_nested_scope();
 	void end_scope();
 
-	bool has_type_var(MonoId, TypeSystemCore&);
-	void bind_var_if_not_present(MonoId, TypeSystemCore&);
 	void bind_to_current_scope(MonoId);
 
 	void compute_declaration_order(AST::Program* ast);

--- a/src/typechecker/compile_time_environment.hpp
+++ b/src/typechecker/compile_time_environment.hpp
@@ -22,7 +22,6 @@ namespace Frontend {
 
 struct CompileTimeEnvironment {
 	struct Scope {
-		bool m_nested {false};
 		std::unordered_set<MonoId> m_type_vars;
 	};
 

--- a/src/typechecker/compile_time_environment.hpp
+++ b/src/typechecker/compile_time_environment.hpp
@@ -26,7 +26,6 @@ struct CompileTimeEnvironment {
 		std::unordered_set<MonoId> m_type_vars;
 	};
 
-	Scope m_global_scope;
 	std::vector<Scope> m_scopes;
 	std::vector<AST::FunctionLiteral*> m_function_stack;
 	std::vector<AST::SequenceExpression*> m_seq_expr_stack;
@@ -44,6 +43,11 @@ struct CompileTimeEnvironment {
 	void bind_to_current_scope(MonoId);
 
 	void compute_declaration_order(AST::Program* ast);
+
+	Scope& global_scope();
+
+private:
+	Scope m_global_scope;
 };
 
 } // namespace Frontend

--- a/src/typechecker/compile_time_environment.hpp
+++ b/src/typechecker/compile_time_environment.hpp
@@ -43,6 +43,7 @@ struct CompileTimeEnvironment {
 	void compute_declaration_order(AST::Program* ast);
 
 	Scope& global_scope();
+	std::vector<Scope> const& scopes();
 };
 
 } // namespace Frontend

--- a/src/typechecker/compile_time_environment.hpp
+++ b/src/typechecker/compile_time_environment.hpp
@@ -41,6 +41,7 @@ struct CompileTimeEnvironment {
 
 	bool has_type_var(MonoId, TypeSystemCore&);
 	void bind_var_if_not_present(MonoId, TypeSystemCore&);
+	void bind_to_current_scope(MonoId);
 
 	void compute_declaration_order(AST::Program* ast);
 };

--- a/src/typechecker/compile_time_environment.hpp
+++ b/src/typechecker/compile_time_environment.hpp
@@ -16,6 +16,8 @@ struct SequenceExpression;
 
 } // namespace AST
 
+struct TypeSystemCore;
+
 namespace Frontend {
 
 struct CompileTimeEnvironment {
@@ -37,8 +39,8 @@ struct CompileTimeEnvironment {
 	void new_nested_scope();
 	void end_scope();
 
-	bool has_type_var(MonoId);
-	void bind_var_if_not_present(MonoId);
+	bool has_type_var(MonoId, TypeSystemCore&);
+	void bind_var_if_not_present(MonoId, TypeSystemCore&);
 
 	void compute_declaration_order(AST::Program* ast);
 };

--- a/src/typechecker/compile_time_environment.hpp
+++ b/src/typechecker/compile_time_environment.hpp
@@ -27,9 +27,7 @@ struct CompileTimeEnvironment {
 	};
 
 	std::vector<Scope> m_scopes;
-	std::vector<AST::FunctionLiteral*> m_function_stack;
-	std::vector<AST::SequenceExpression*> m_seq_expr_stack;
-	AST::Declaration* m_current_decl {nullptr};
+
 
 	CompileTimeEnvironment();
 

--- a/src/typechecker/compile_time_environment.hpp
+++ b/src/typechecker/compile_time_environment.hpp
@@ -45,9 +45,6 @@ struct CompileTimeEnvironment {
 	void compute_declaration_order(AST::Program* ast);
 
 	Scope& global_scope();
-
-private:
-	Scope m_global_scope;
 };
 
 } // namespace Frontend

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -75,19 +75,13 @@ private:
 			return scope.m_type_vars.count(var) != 0;
 		};
 
-		// scan nested scopes from the inside out
-		for (int i = scopes().size(); i-- > 1;) {
+		// scan nested scopes from the inside out, including
+		// the global scope, at index 0
+		for (int i = scopes().size(); i-- ;) {
 			auto found = scan_scope(scopes()[i], var);
 			if (found)
 				return true;
-			if (!scopes()[i].m_nested)
-				break;
 		}
-
-		// fall back to global scope lookup
-		auto found = scan_scope(global_scope(), var);
-		if (found)
-			return true;
 
 		for (auto& scope : scopes()) {
 			for (auto stored_var : scope.m_type_vars) {

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -85,8 +85,7 @@ private:
 
 		for (auto& scope : scopes()) {
 			for (auto stored_var : scope.m_type_vars) {
-				std::unordered_set<MonoId> free_vars;
-				core().gather_free_vars(stored_var, free_vars);
+				std::unordered_set<MonoId> free_vars = free_vars_of(stored_var);
 				if (free_vars.count(var))
 					return true;
 			}
@@ -99,12 +98,17 @@ private:
 		if (!has_type_var(var))
 			env().bind_to_current_scope(var);
 	}
+
+	std::unordered_set<MonoId> free_vars_of(MonoId mono) {
+		std::unordered_set<MonoId> free_vars;
+		core().gather_free_vars(mono, free_vars);
+		return free_vars;
+	}
 };
 
 
 void TypecheckHelper::bind_free_vars(MonoId mono) {
-	std::unordered_set<MonoId> free_vars;
-	core().gather_free_vars(mono, free_vars);
+	std::unordered_set<MonoId> free_vars = free_vars_of(mono);
 	for (MonoId var : free_vars) {
 		bind_var_if_not_present(var);
 	}
@@ -112,8 +116,7 @@ void TypecheckHelper::bind_free_vars(MonoId mono) {
 
 // qualifies all free variables in the given monotype
 PolyId TypecheckHelper::generalize(MonoId mono) {
-	std::unordered_set<MonoId> free_vars;
-	core().gather_free_vars(mono, free_vars);
+	std::unordered_set<MonoId> free_vars = free_vars_of(mono);
 
 	std::vector<MonoId> new_vars;
 	std::unordered_map<MonoId, MonoId> mapping;

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -101,7 +101,7 @@ private:
 		return false;
 	}
 
-	void bind_var_if_not_present(MonoId var, TypeSystemCore& core) {
+	void bind_var_if_not_present(MonoId var) {
 		if (!has_type_var(var))
 			env().bind_to_current_scope(var);
 	}
@@ -112,7 +112,7 @@ void TypecheckHelper::bind_free_vars(MonoId mono) {
 	std::unordered_set<MonoId> free_vars;
 	core().gather_free_vars(mono, free_vars);
 	for (MonoId var : free_vars) {
-		bind_var_if_not_present(var, core());
+		bind_var_if_not_present(var);
 	}
 }
 

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -68,7 +68,7 @@ void TypecheckHelper::bind_free_vars(MonoId mono) {
 	std::unordered_set<MonoId> free_vars;
 	core().gather_free_vars(mono, free_vars);
 	for (MonoId var : free_vars) {
-		env().bind_var_if_not_present(var);
+		env().bind_var_if_not_present(var, core());
 	}
 }
 
@@ -80,7 +80,7 @@ PolyId TypecheckHelper::generalize(MonoId mono) {
 	std::vector<MonoId> new_vars;
 	std::unordered_map<MonoId, MonoId> mapping;
 	for (MonoId var : free_vars) {
-		if (!env().has_type_var(var)) {
+		if (!env().has_type_var(var, core())) {
 			auto fresh_var = new_hidden_var();
 			new_vars.push_back(fresh_var);
 			mapping[var] = fresh_var;

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -70,7 +70,7 @@ private:
 		return env().scopes();
 	}
 
-	bool has_type_var(MonoId var, TypeSystemCore& core) {
+	bool has_type_var(MonoId var) {
 		auto scan_scope = [](Frontend::CompileTimeEnvironment::Scope const& scope, MonoId var) -> bool {
 			return scope.m_type_vars.count(var) != 0;
 		};
@@ -92,7 +92,7 @@ private:
 		for (auto& scope : scopes()) {
 			for (auto stored_var : scope.m_type_vars) {
 				std::unordered_set<MonoId> free_vars;
-				core.gather_free_vars(stored_var, free_vars);
+				core().gather_free_vars(stored_var, free_vars);
 				if (free_vars.count(var))
 					return true;
 			}
@@ -102,7 +102,7 @@ private:
 	}
 
 	void bind_var_if_not_present(MonoId var, TypeSystemCore& core) {
-		if (!has_type_var(var, core))
+		if (!has_type_var(var))
 			env().bind_to_current_scope(var);
 	}
 };
@@ -124,7 +124,7 @@ PolyId TypecheckHelper::generalize(MonoId mono) {
 	std::vector<MonoId> new_vars;
 	std::unordered_map<MonoId, MonoId> mapping;
 	for (MonoId var : free_vars) {
-		if (!has_type_var(var, core())) {
+		if (!has_type_var(var)) {
 			auto fresh_var = new_hidden_var();
 			new_vars.push_back(fresh_var);
 			mapping[var] = fresh_var;


### PR DESCRIPTION
We used to only check if a variable was directly bound to the environment, but we actually need to recurse down all types that are bound to it, in case the variable shows up inside them

In terms of the Hindley-Milner system, (our implementation of) `\Bar{\Gamma}(\tau)` was correct, but `free(\Gamma)` was wrong.

The definition of `free(\Gamma)` can be seen in the figure in https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system#Syntax

The definition of `\Bar{\Gamma}(\tau)` can be seen in the figure in https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system#Syntax-directed_rule_system