### PR TITLE
Don't create useless `AST::*Handle` nodes

### DIFF
--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -262,9 +262,19 @@ static MonoId compute_mono(
 		assert(arg);
 		assert(arg->type() == ASTTag::Identifier || arg->type() == ASTTag::TypeTerm);
 		if (arg->type() == ASTTag::Identifier) {
-			auto arg_handle = ct_eval(arg, tc, alloc);
-			assert(arg_handle->type() == ASTTag::MonoTypeHandle);
-			MonoId mono = static_cast<AST::MonoTypeHandle*>(arg_handle)->m_value;
+
+			auto identifier = static_cast<AST::Identifier*>(arg);
+
+			assert(identifier->m_declaration);
+
+			auto& uf = tc.core().m_meta_core;
+			MetaTypeId meta_type = uf.eval(identifier->m_meta_type);
+			assert(uf.is(meta_type, Tag::Mono));
+
+			auto decl = identifier->m_declaration;
+			assert(decl->m_value->type() == ASTTag::MonoTypeHandle);
+			AST::MonoTypeHandle* arg_handle = static_cast<AST::MonoTypeHandle*>(decl->m_value);
+			MonoId mono = arg_handle->m_value;
 			args.push_back(mono);
 		} else {
 			auto type_term = static_cast<AST::TypeTerm*>(arg);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -31,12 +31,10 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocat
 
 	if (ast->type() == ASTTag::UnionExpression) {
 		auto union_expression = static_cast<AST::UnionExpression*>(ast);
-		TypeFunctionId result = compute_type_func(union_expression, tc, alloc);
-		return result;
+		return compute_type_func(union_expression, tc, alloc);
 	} else if (ast->type() == ASTTag::StructExpression) {
 		auto struct_expression = static_cast<AST::StructExpression*>(ast);
-		TypeFunctionId result = compute_type_func(struct_expression, tc, alloc);
-		return result;
+		return compute_type_func(struct_expression, tc, alloc);
 	} else {
 		auto identifier = static_cast<AST::Identifier*>(ast);
 		auto handle = ct_eval(identifier, tc, alloc);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -37,9 +37,18 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocat
 		return compute_type_func(struct_expression, tc, alloc);
 	} else {
 		auto identifier = static_cast<AST::Identifier*>(ast);
-		auto handle = ct_eval(identifier, tc, alloc);
-		assert(handle->type() == ASTTag::TypeFunctionHandle);
-		return static_cast<AST::TypeFunctionHandle*>(handle)->m_value;
+
+		assert(identifier);
+		assert(identifier->m_declaration);
+
+		auto& uf = tc.core().m_meta_core;
+		MetaTypeId meta_type = uf.eval(identifier->m_meta_type);
+		assert(uf.is(meta_type, Tag::Func));
+
+		auto decl = identifier->m_declaration;
+		assert(decl->m_value->type() == ASTTag::TypeFunctionHandle);
+
+		return static_cast<AST::TypeFunctionHandle*>(decl->m_value)->m_value;
 	}
 }
 

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -12,6 +12,7 @@
 
 namespace TypeChecker {
 
+static TypeFunctionId frobble(AST::StructExpression*, TypeChecker&, AST::Allocator&);
 static AST::Expr* ct_eval(AST::AST* ast, TypeChecker& tc, AST::Allocator& alloc);
 static void ct_visit(AST::AST*& ast, TypeChecker& tc, AST::Allocator& alloc);
 static void ct_visit(AST::Block* ast, TypeChecker& tc, AST::Allocator& alloc);
@@ -34,9 +35,8 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocat
 		return result;
 	} else if (ast->type() == ASTTag::StructExpression) {
 		auto struct_expression = static_cast<AST::StructExpression*>(ast);
-		auto handle = ct_eval(struct_expression, tc, alloc);
-		assert(handle->type() == ASTTag::TypeFunctionHandle);
-		return static_cast<AST::TypeFunctionHandle*>(handle)->m_value;
+		TypeFunctionId result = frobble(struct_expression, tc, alloc);
+		return result;
 	} else {
 		auto identifier = static_cast<AST::Identifier*>(ast);
 		auto handle = ct_eval(identifier, tc, alloc);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -278,9 +278,7 @@ static MonoId compute_mono(
 
 	std::vector<MonoId> args;
 	for (auto& arg : ast->m_args) {
-		MonoId mono;
-		mono = compute_mono(arg, tc, alloc);
-		args.push_back(mono);
+		args.push_back(compute_mono(arg, tc, alloc));
 	}
 
 	MonoId result = tc.core().new_term(type_function, std::move(args), "from ast");

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -253,6 +253,8 @@ static AST::Constructor* constructor_from_ast(
 	return constructor;
 }
 
+static MonoId compute_mono(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc);
+	
 static MonoId compute_mono(
     AST::Identifier* ast, TypeChecker& tc) {
 
@@ -276,22 +278,25 @@ static MonoId compute_mono(
 
 	std::vector<MonoId> args;
 	for (auto& arg : ast->m_args) {
-		assert(arg);
-		assert(arg->type() == ASTTag::Identifier || arg->type() == ASTTag::TypeTerm);
 		MonoId mono;
-		if (arg->type() == ASTTag::Identifier) {
-			auto identifier = static_cast<AST::Identifier*>(arg);
-			mono = compute_mono(identifier, tc);
-		} else {
-			auto type_term = static_cast<AST::TypeTerm*>(arg);
-			MonoId result = compute_mono(type_term, tc, alloc);
-			mono = result;
-		}
+		mono = compute_mono(arg, tc, alloc);
 		args.push_back(mono);
 	}
 
 	MonoId result = tc.core().new_term(type_function, std::move(args), "from ast");
 	return result;
+}
+
+static MonoId compute_mono(AST::Expr* arg, TypeChecker& tc, AST::Allocator& alloc) {
+	assert(arg);
+	assert(arg->type() == ASTTag::Identifier || arg->type() == ASTTag::TypeTerm);
+	if (arg->type() == ASTTag::Identifier) {
+		auto identifier = static_cast<AST::Identifier*>(arg);
+		return compute_mono(identifier, tc);
+	} else {
+		auto type_term = static_cast<AST::TypeTerm*>(arg);
+		return compute_mono(type_term, tc, alloc);
+	}
 }
 
 static AST::MonoTypeHandle* ct_eval(

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -210,14 +210,21 @@ static AST::TypeFunctionHandle* ct_eval(
 	return node;
 }
 
-static AST::TypeFunctionHandle* ct_eval(
-    AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
-
+static TypeFunctionId fribble(
+	AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	std::unordered_map<InternedString, MonoId> structure =
 		build_map(ast->m_constructors, ast->m_types, tc, alloc);
 
 	TypeFunctionId result = tc.core().new_type_function(
 		TypeFunctionTag::Variant, {}, std::move(structure));
+
+	return result;
+}
+
+static AST::TypeFunctionHandle* ct_eval(
+    AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+
+	TypeFunctionId result = fribble(ast, tc, alloc);
 
 	auto node = alloc.make<AST::TypeFunctionHandle>();
 	node->m_value = result;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -12,7 +12,6 @@
 
 namespace TypeChecker {
 
-static TypeFunctionId frobble(AST::StructExpression*, TypeChecker&, AST::Allocator&);
 static AST::Expr* ct_eval(AST::AST* ast, TypeChecker& tc, AST::Allocator& alloc);
 static void ct_visit(AST::AST*& ast, TypeChecker& tc, AST::Allocator& alloc);
 static void ct_visit(AST::Block* ast, TypeChecker& tc, AST::Allocator& alloc);
@@ -21,6 +20,7 @@ static AST::Constructor* constructor_from_ast(AST::Expr* ast, TypeChecker& tc, A
 
 static MonoId compute_mono(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc);
 
+static TypeFunctionId compute_type_func(AST::StructExpression*, TypeChecker&, AST::Allocator&);
 static TypeFunctionId compute_type_func(AST::UnionExpression*, TypeChecker&, AST::Allocator&);
 
 static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc) {
@@ -35,7 +35,7 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocat
 		return result;
 	} else if (ast->type() == ASTTag::StructExpression) {
 		auto struct_expression = static_cast<AST::StructExpression*>(ast);
-		TypeFunctionId result = frobble(struct_expression, tc, alloc);
+		TypeFunctionId result = compute_type_func(struct_expression, tc, alloc);
 		return result;
 	} else {
 		auto identifier = static_cast<AST::Identifier*>(ast);
@@ -199,7 +199,7 @@ build_map(
 	return structure;
 }
 
-static TypeFunctionId frobble(
+static TypeFunctionId compute_type_func(
     AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 
 	std::vector<InternedString> fields = ast->m_fields;
@@ -215,7 +215,7 @@ static TypeFunctionId frobble(
 static AST::TypeFunctionHandle* ct_eval(
     AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 
-	TypeFunctionId result = frobble(ast, tc, alloc);
+	TypeFunctionId result = compute_type_func(ast, tc, alloc);
 
 	auto node = alloc.make<AST::TypeFunctionHandle>();
 	node->m_value = result;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -278,20 +278,16 @@ static MonoId compute_mono(
 	for (auto& arg : ast->m_args) {
 		assert(arg);
 		assert(arg->type() == ASTTag::Identifier || arg->type() == ASTTag::TypeTerm);
+		MonoId mono;
 		if (arg->type() == ASTTag::Identifier) {
-
 			auto identifier = static_cast<AST::Identifier*>(arg);
-			MonoId mono = compute_mono(identifier, tc);
-			args.push_back(mono);
+			mono = compute_mono(identifier, tc);
 		} else {
 			auto type_term = static_cast<AST::TypeTerm*>(arg);
-
 			MonoId result = compute_mono(type_term, tc, alloc);
-
-			MonoId mono = result;
-			args.push_back(mono);
-
+			mono = result;
 		}
+		args.push_back(mono);
 	}
 
 	MonoId result = tc.core().new_term(type_function, std::move(args), "from ast");

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -416,25 +416,17 @@ static TypeFunctionId compute_type_func(AST::Identifier* ast, TypeChecker& tc) {
 }
 
 static TypeFunctionId compute_type_func(AST::StructExpression* ast, TypeChecker& tc) {
-
-	std::vector<InternedString> fields = ast->m_fields;
-
-	std::unordered_map<InternedString, MonoId> structure =
-	    build_map(ast->m_fields, ast->m_types, tc);
-
-	TypeFunctionId result = tc.core().new_type_function(
-		TypeFunctionTag::Record, std::move(fields), std::move(structure));
-	return result;
+	return tc.core().new_type_function(
+	    TypeFunctionTag::Record,
+	    ast->m_fields,
+	    build_map(ast->m_fields, ast->m_types, tc));
 }
 
 static TypeFunctionId compute_type_func(AST::UnionExpression* ast, TypeChecker& tc) {
-	std::unordered_map<InternedString, MonoId> structure =
-		build_map(ast->m_constructors, ast->m_types, tc);
-
-	TypeFunctionId result = tc.core().new_type_function(
-		TypeFunctionTag::Variant, {}, std::move(structure));
-
-	return result;
+	return tc.core().new_type_function(
+	    TypeFunctionTag::Variant,
+	    {},
+	    build_map(ast->m_constructors, ast->m_types, tc));
 }
 
 static TypeFunctionId compute_type_func(AST::Expr* ast, TypeChecker& tc) {
@@ -473,8 +465,7 @@ static MonoId compute_mono(AST::TypeTerm* ast, TypeChecker& tc) {
 		args.push_back(compute_mono(arg, tc));
 	}
 
-	MonoId result = tc.core().new_term(type_function, std::move(args), "from ast");
-	return result;
+	return tc.core().new_term(type_function, std::move(args), "from ast");
 }
 
 static MonoId compute_mono(AST::Expr* ast, TypeChecker& tc) {

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -26,9 +26,22 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocat
 	    ast->type() == ASTTag::UnionExpression ||
 	    ast->type() == ASTTag::StructExpression);
 
-	auto handle = ct_eval(ast, tc, alloc);
-	assert(handle->type() == ASTTag::TypeFunctionHandle);
-	return static_cast<AST::TypeFunctionHandle*>(handle)->m_value;
+	if (ast->type() == ASTTag::UnionExpression) {
+		auto union_expression = static_cast<AST::UnionExpression*>(ast);
+		auto handle = ct_eval(union_expression, tc, alloc);
+		assert(handle->type() == ASTTag::TypeFunctionHandle);
+		return static_cast<AST::TypeFunctionHandle*>(handle)->m_value;
+	} else if (ast->type() == ASTTag::StructExpression) {
+		auto struct_expression = static_cast<AST::StructExpression*>(ast);
+		auto handle = ct_eval(struct_expression, tc, alloc);
+		assert(handle->type() == ASTTag::TypeFunctionHandle);
+		return static_cast<AST::TypeFunctionHandle*>(handle)->m_value;
+	} else {
+		auto identifier = static_cast<AST::Identifier*>(ast);
+		auto handle = ct_eval(identifier, tc, alloc);
+		assert(handle->type() == ASTTag::TypeFunctionHandle);
+		return static_cast<AST::TypeFunctionHandle*>(handle)->m_value;
+	}
 }
 
 // literals

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -18,7 +18,7 @@ static void ct_visit(AST::Block* ast, TypeChecker& tc, AST::Allocator& alloc);
 
 static AST::Constructor* constructor_from_ast(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc);
 
-static MonoId compute_mono(AST::Expr* ast, TypeChecker& tc);
+static MonoId compute_mono(AST::Expr*, TypeChecker&);
 
 static TypeFunctionId compute_type_func(AST::StructExpression*, TypeChecker&);
 static TypeFunctionId compute_type_func(AST::UnionExpression*, TypeChecker&);
@@ -30,11 +30,9 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc) {
 	    ast->type() == ASTTag::StructExpression);
 
 	if (ast->type() == ASTTag::UnionExpression) {
-		auto union_expression = static_cast<AST::UnionExpression*>(ast);
-		return compute_type_func(union_expression, tc);
+		return compute_type_func(static_cast<AST::UnionExpression*>(ast), tc);
 	} else if (ast->type() == ASTTag::StructExpression) {
-		auto struct_expression = static_cast<AST::StructExpression*>(ast);
-		return compute_type_func(struct_expression, tc);
+		return compute_type_func(static_cast<AST::StructExpression*>(ast), tc);
 	} else {
 		auto identifier = static_cast<AST::Identifier*>(ast);
 
@@ -286,8 +284,7 @@ static AST::Constructor* constructor_from_ast(
 	return constructor;
 }
 
-static MonoId compute_mono(
-    AST::Identifier* ast, TypeChecker& tc) {
+static MonoId compute_mono(AST::Identifier* ast, TypeChecker& tc) {
 
 	assert(ast->m_declaration);
 
@@ -303,8 +300,7 @@ static MonoId compute_mono(
 	return mono;
 }
 
-static MonoId compute_mono(
-    AST::TypeTerm* ast, TypeChecker& tc) {
+static MonoId compute_mono(AST::TypeTerm* ast, TypeChecker& tc) {
 	TypeFunctionId type_function = eval_then_get_type_func(ast->m_callee, tc);
 
 	std::vector<MonoId> args;
@@ -316,15 +312,13 @@ static MonoId compute_mono(
 	return result;
 }
 
-static MonoId compute_mono(AST::Expr* arg, TypeChecker& tc) {
-	assert(arg);
-	assert(arg->type() == ASTTag::Identifier || arg->type() == ASTTag::TypeTerm);
-	if (arg->type() == ASTTag::Identifier) {
-		auto identifier = static_cast<AST::Identifier*>(arg);
-		return compute_mono(identifier, tc);
+static MonoId compute_mono(AST::Expr* ast, TypeChecker& tc) {
+	assert(ast);
+	assert(ast->type() == ASTTag::Identifier || ast->type() == ASTTag::TypeTerm);
+	if (ast->type() == ASTTag::Identifier) {
+		return compute_mono(static_cast<AST::Identifier*>(ast), tc);
 	} else {
-		auto type_term = static_cast<AST::TypeTerm*>(arg);
-		return compute_mono(type_term, tc);
+		return compute_mono(static_cast<AST::TypeTerm*>(ast), tc);
 	}
 }
 

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -254,6 +254,23 @@ static AST::Constructor* constructor_from_ast(
 }
 
 static MonoId compute_mono(
+    AST::Identifier* ast, TypeChecker& tc) {
+
+	assert(ast->m_declaration);
+
+	auto& uf = tc.core().m_meta_core;
+	MetaTypeId meta_type = uf.eval(ast->m_meta_type);
+	assert(uf.is(meta_type, Tag::Mono));
+
+	auto decl = ast->m_declaration;
+	assert(decl->m_value->type() == ASTTag::MonoTypeHandle);
+
+	AST::MonoTypeHandle* handle = static_cast<AST::MonoTypeHandle*>(decl->m_value);
+	MonoId mono = handle->m_value;
+	return mono;
+}
+
+static MonoId compute_mono(
     AST::TypeTerm* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	TypeFunctionId type_function = eval_then_get_type_func(ast->m_callee, tc, alloc);
 
@@ -264,17 +281,7 @@ static MonoId compute_mono(
 		if (arg->type() == ASTTag::Identifier) {
 
 			auto identifier = static_cast<AST::Identifier*>(arg);
-
-			assert(identifier->m_declaration);
-
-			auto& uf = tc.core().m_meta_core;
-			MetaTypeId meta_type = uf.eval(identifier->m_meta_type);
-			assert(uf.is(meta_type, Tag::Mono));
-
-			auto decl = identifier->m_declaration;
-			assert(decl->m_value->type() == ASTTag::MonoTypeHandle);
-			AST::MonoTypeHandle* arg_handle = static_cast<AST::MonoTypeHandle*>(decl->m_value);
-			MonoId mono = arg_handle->m_value;
+			MonoId mono = compute_mono(identifier, tc);
 			args.push_back(mono);
 		} else {
 			auto type_term = static_cast<AST::TypeTerm*>(arg);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -20,6 +20,8 @@ static AST::Constructor* constructor_from_ast(AST::Expr* ast, TypeChecker& tc, A
 
 static MonoId compute_mono(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc);
 
+static TypeFunctionId fribble(AST::UnionExpression*, TypeChecker&, AST::Allocator&);
+
 static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	assert(
 	    ast->type() == ASTTag::Identifier ||
@@ -28,9 +30,8 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocat
 
 	if (ast->type() == ASTTag::UnionExpression) {
 		auto union_expression = static_cast<AST::UnionExpression*>(ast);
-		auto handle = ct_eval(union_expression, tc, alloc);
-		assert(handle->type() == ASTTag::TypeFunctionHandle);
-		return static_cast<AST::TypeFunctionHandle*>(handle)->m_value;
+		TypeFunctionId result = fribble(union_expression, tc, alloc);
+		return result;
 	} else if (ast->type() == ASTTag::StructExpression) {
 		auto struct_expression = static_cast<AST::StructExpression*>(ast);
 		auto handle = ct_eval(struct_expression, tc, alloc);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -253,9 +253,8 @@ static AST::Constructor* constructor_from_ast(
 	return constructor;
 }
 
-static AST::MonoTypeHandle* ct_eval(
+static MonoId compute_mono(
     AST::TypeTerm* ast, TypeChecker& tc, AST::Allocator& alloc) {
-
 	TypeFunctionId type_function = eval_then_get_type_func(ast->m_callee, tc, alloc);
 
 	std::vector<MonoId> args;
@@ -266,6 +265,13 @@ static AST::MonoTypeHandle* ct_eval(
 	}
 
 	MonoId result = tc.core().new_term(type_function, std::move(args), "from ast");
+	return result;
+}
+
+static AST::MonoTypeHandle* ct_eval(
+    AST::TypeTerm* ast, TypeChecker& tc, AST::Allocator& alloc) {
+
+	MonoId result = compute_mono(ast, tc, alloc);
 
 	auto handle = alloc.make<AST::MonoTypeHandle>();
 	handle->m_value = result;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -35,11 +35,9 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc) {
 	} else if (ast->type() == ASTTag::StructExpression) {
 		return compute_type_func(static_cast<AST::StructExpression*>(ast), tc);
 	} else {
-		auto identifier = static_cast<AST::Identifier*>(ast);
-		return compute_type_func(identifier, tc);
+		return compute_type_func(static_cast<AST::Identifier*>(ast), tc);
 	}
 }
-
 
 static TypeFunctionId compute_type_func(AST::Identifier* identifier, TypeChecker& tc) {
 	assert(identifier);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -185,7 +185,7 @@ build_map(
 	return structure;
 }
 
-static AST::TypeFunctionHandle* ct_eval(
+static TypeFunctionId frobble(
     AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 
 	std::vector<InternedString> fields = ast->m_fields;
@@ -195,6 +195,13 @@ static AST::TypeFunctionHandle* ct_eval(
 
 	TypeFunctionId result = tc.core().new_type_function(
 		TypeFunctionTag::Record, std::move(fields), std::move(structure));
+	return result;
+}
+
+static AST::TypeFunctionHandle* ct_eval(
+    AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+
+	TypeFunctionId result = frobble(ast, tc, alloc);
 
 	auto node = alloc.make<AST::TypeFunctionHandle>();
 	node->m_value = result;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -20,7 +20,7 @@ static AST::Constructor* constructor_from_ast(AST::Expr* ast, TypeChecker& tc, A
 
 static MonoId compute_mono(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc);
 
-static TypeFunctionId fribble(AST::UnionExpression*, TypeChecker&, AST::Allocator&);
+static TypeFunctionId compute_type_func(AST::UnionExpression*, TypeChecker&, AST::Allocator&);
 
 static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	assert(
@@ -30,7 +30,7 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocat
 
 	if (ast->type() == ASTTag::UnionExpression) {
 		auto union_expression = static_cast<AST::UnionExpression*>(ast);
-		TypeFunctionId result = fribble(union_expression, tc, alloc);
+		TypeFunctionId result = compute_type_func(union_expression, tc, alloc);
 		return result;
 	} else if (ast->type() == ASTTag::StructExpression) {
 		auto struct_expression = static_cast<AST::StructExpression*>(ast);
@@ -224,7 +224,7 @@ static AST::TypeFunctionHandle* ct_eval(
 	return node;
 }
 
-static TypeFunctionId fribble(
+static TypeFunctionId compute_type_func(
 	AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	std::unordered_map<InternedString, MonoId> structure =
 		build_map(ast->m_constructors, ast->m_types, tc, alloc);
@@ -238,7 +238,7 @@ static TypeFunctionId fribble(
 static AST::TypeFunctionHandle* ct_eval(
     AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 
-	TypeFunctionId result = fribble(ast, tc, alloc);
+	TypeFunctionId result = compute_type_func(ast, tc, alloc);
 
 	auto node = alloc.make<AST::TypeFunctionHandle>();
 	node->m_value = result;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -259,6 +259,8 @@ static MonoId compute_mono(
 
 	std::vector<MonoId> args;
 	for (auto& arg : ast->m_args) {
+		assert(arg);
+		assert(arg->type() == ASTTag::Identifier || arg->type() == ASTTag::TypeTerm);
 		auto arg_handle = ct_eval(arg, tc, alloc);
 		assert(arg_handle->type() == ASTTag::MonoTypeHandle);
 		MonoId mono = static_cast<AST::MonoTypeHandle*>(arg_handle)->m_value;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -21,6 +21,11 @@ static AST::Constructor* constructor_from_ast(AST::Expr* ast, TypeChecker& tc, A
 static MonoId compute_mono(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc);
 
 static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc) {
+	assert(
+	    ast->type() == ASTTag::Identifier ||
+	    ast->type() == ASTTag::UnionExpression ||
+	    ast->type() == ASTTag::StructExpression);
+
 	auto handle = ct_eval(ast, tc, alloc);
 	assert(handle->type() == ASTTag::TypeFunctionHandle);
 	return static_cast<AST::TypeFunctionHandle*>(handle)->m_value;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -158,29 +158,26 @@ static AST::Expr* ct_eval(
 }
 // types
 
-
-static AST::TypeFunctionHandle* ct_eval(
-    AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
-
-	TypeFunctionId result = compute_type_func(ast, tc);
+static AST::TypeFunctionHandle* wrap_in_type_func_handle(
+    AST::Expr* ast, TypeFunctionId value, AST::Allocator& alloc) {
 
 	auto node = alloc.make<AST::TypeFunctionHandle>();
-	node->m_value = result;
+	node->m_value = value;
 	node->m_syntax = ast;
 
 	return node;
 }
 
 static AST::TypeFunctionHandle* ct_eval(
+    AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+
+	return wrap_in_type_func_handle(ast, compute_type_func(ast, tc), alloc);
+}
+
+static AST::TypeFunctionHandle* ct_eval(
     AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 
-	TypeFunctionId result = compute_type_func(ast, tc);
-
-	auto node = alloc.make<AST::TypeFunctionHandle>();
-	node->m_value = result;
-	node->m_syntax = ast;
-
-	return node;
+	return wrap_in_type_func_handle(ast, compute_type_func(ast, tc), alloc);
 }
 
 static AST::Constructor* constructor_from_ast(

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -261,7 +261,8 @@ static MonoId compute_mono(
 	for (auto& arg : ast->m_args) {
 		auto arg_handle = ct_eval(arg, tc, alloc);
 		assert(arg_handle->type() == ASTTag::MonoTypeHandle);
-		args.push_back(static_cast<AST::MonoTypeHandle*>(arg_handle)->m_value);
+		MonoId mono = static_cast<AST::MonoTypeHandle*>(arg_handle)->m_value;
+		args.push_back(mono);
 	}
 
 	MonoId result = tc.core().new_term(type_function, std::move(args), "from ast");

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -285,10 +285,12 @@ static MonoId compute_mono(
 			args.push_back(mono);
 		} else {
 			auto type_term = static_cast<AST::TypeTerm*>(arg);
-			auto arg_handle = ct_eval(type_term, tc, alloc);
-			assert(arg_handle->type() == ASTTag::MonoTypeHandle);
-			MonoId mono = static_cast<AST::MonoTypeHandle*>(arg_handle)->m_value;
+
+			MonoId result = compute_mono(type_term, tc, alloc);
+
+			MonoId mono = result;
 			args.push_back(mono);
+
 		}
 	}
 

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -405,15 +405,14 @@ static AST::Expr* ct_eval(AST::AST* ast, TypeChecker& tc, AST::Allocator& alloc)
 static std::unordered_map<InternedString, MonoId> build_map(
     std::vector<InternedString> const&, std::vector<AST::Expr*> const&, TypeChecker&);
 
-static TypeFunctionId compute_type_func(AST::Identifier* identifier, TypeChecker& tc) {
-	assert(identifier);
-	assert(identifier->m_declaration);
+static TypeFunctionId compute_type_func(AST::Identifier* ast, TypeChecker& tc) {
+	assert(ast->m_declaration);
 
 	auto& uf = tc.core().m_meta_core;
-	MetaTypeId meta_type = uf.eval(identifier->m_meta_type);
+	MetaTypeId meta_type = uf.eval(ast->m_meta_type);
 	assert(uf.is(meta_type, Tag::Func));
 
-	auto decl = identifier->m_declaration;
+	auto decl = ast->m_declaration;
 	assert(decl->m_value->type() == ASTTag::TypeFunctionHandle);
 
 	return static_cast<AST::TypeFunctionHandle*>(decl->m_value)->m_value;
@@ -457,7 +456,6 @@ static TypeFunctionId compute_type_func(AST::Expr* ast, TypeChecker& tc) {
 }
 
 static MonoId compute_mono(AST::Identifier* ast, TypeChecker& tc) {
-
 	assert(ast->m_declaration);
 
 	auto& uf = tc.core().m_meta_core;
@@ -467,9 +465,7 @@ static MonoId compute_mono(AST::Identifier* ast, TypeChecker& tc) {
 	auto decl = ast->m_declaration;
 	assert(decl->m_value->type() == ASTTag::MonoTypeHandle);
 
-	AST::MonoTypeHandle* handle = static_cast<AST::MonoTypeHandle*>(decl->m_value);
-	MonoId mono = handle->m_value;
-	return mono;
+	return static_cast<AST::MonoTypeHandle*>(decl->m_value)->m_value;
 }
 
 static MonoId compute_mono(AST::TypeTerm* ast, TypeChecker& tc) {

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -255,7 +255,6 @@ static AST::Constructor* constructor_from_ast(
 
 static AST::MonoTypeHandle* ct_eval(
     AST::TypeTerm* ast, TypeChecker& tc, AST::Allocator& alloc) {
-	auto handle = alloc.make<AST::MonoTypeHandle>();
 
 	TypeFunctionId type_function = eval_then_get_type_func(ast->m_callee, tc, alloc);
 
@@ -267,6 +266,8 @@ static AST::MonoTypeHandle* ct_eval(
 	}
 
 	MonoId result = tc.core().new_term(type_function, std::move(args), "from ast");
+
+	auto handle = alloc.make<AST::MonoTypeHandle>();
 	handle->m_value = result;
 	handle->m_syntax = ast;
 	return handle;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -24,7 +24,7 @@ static TypeFunctionId compute_type_func(AST::StructExpression*, TypeChecker&);
 static TypeFunctionId compute_type_func(AST::UnionExpression*, TypeChecker&);
 static TypeFunctionId compute_type_func(AST::Identifier*, TypeChecker&);
 
-static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc) {
+static int compute_type_func(AST::Expr* ast, TypeChecker& tc) {
 	assert(
 	    ast->type() == ASTTag::Identifier ||
 	    ast->type() == ASTTag::UnionExpression ||
@@ -304,7 +304,7 @@ static MonoId compute_mono(AST::Identifier* ast, TypeChecker& tc) {
 }
 
 static MonoId compute_mono(AST::TypeTerm* ast, TypeChecker& tc) {
-	TypeFunctionId type_function = eval_then_get_type_func(ast->m_callee, tc);
+	TypeFunctionId type_function = compute_type_func(ast->m_callee, tc);
 
 	std::vector<MonoId> args;
 	for (auto& arg : ast->m_args) {
@@ -415,7 +415,7 @@ static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) 
 					Log::fatal() << "type hint not allowed in typefunc declaration";
 
 				auto handle = static_cast<AST::TypeFunctionHandle*>(decl->m_value);
-				TypeFunctionId tf = eval_then_get_type_func(handle->m_syntax, tc);
+				TypeFunctionId tf = compute_type_func(handle->m_syntax, tc);
 				tc.core().unify_type_function(tf, handle->m_value);
 			} else if (uf.is(meta_type, Tag::Mono)) {
 				if (decl->m_type_hint)

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -261,10 +261,18 @@ static MonoId compute_mono(
 	for (auto& arg : ast->m_args) {
 		assert(arg);
 		assert(arg->type() == ASTTag::Identifier || arg->type() == ASTTag::TypeTerm);
-		auto arg_handle = ct_eval(arg, tc, alloc);
-		assert(arg_handle->type() == ASTTag::MonoTypeHandle);
-		MonoId mono = static_cast<AST::MonoTypeHandle*>(arg_handle)->m_value;
-		args.push_back(mono);
+		if (arg->type() == ASTTag::Identifier) {
+			auto arg_handle = ct_eval(arg, tc, alloc);
+			assert(arg_handle->type() == ASTTag::MonoTypeHandle);
+			MonoId mono = static_cast<AST::MonoTypeHandle*>(arg_handle)->m_value;
+			args.push_back(mono);
+		} else {
+			auto type_term = static_cast<AST::TypeTerm*>(arg);
+			auto arg_handle = ct_eval(type_term, tc, alloc);
+			assert(arg_handle->type() == ASTTag::MonoTypeHandle);
+			MonoId mono = static_cast<AST::MonoTypeHandle*>(arg_handle)->m_value;
+			args.push_back(mono);
+		}
 	}
 
 	MonoId result = tc.core().new_term(type_function, std::move(args), "from ast");

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -22,6 +22,7 @@ static MonoId compute_mono(AST::Expr*, TypeChecker&);
 
 static TypeFunctionId compute_type_func(AST::StructExpression*, TypeChecker&);
 static TypeFunctionId compute_type_func(AST::UnionExpression*, TypeChecker&);
+static TypeFunctionId compute_type_func(AST::Identifier*, TypeChecker&);
 
 static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc) {
 	assert(
@@ -35,19 +36,23 @@ static int eval_then_get_type_func(AST::Expr* ast, TypeChecker& tc) {
 		return compute_type_func(static_cast<AST::StructExpression*>(ast), tc);
 	} else {
 		auto identifier = static_cast<AST::Identifier*>(ast);
-
-		assert(identifier);
-		assert(identifier->m_declaration);
-
-		auto& uf = tc.core().m_meta_core;
-		MetaTypeId meta_type = uf.eval(identifier->m_meta_type);
-		assert(uf.is(meta_type, Tag::Func));
-
-		auto decl = identifier->m_declaration;
-		assert(decl->m_value->type() == ASTTag::TypeFunctionHandle);
-
-		return static_cast<AST::TypeFunctionHandle*>(decl->m_value)->m_value;
+		return compute_type_func(identifier, tc);
 	}
+}
+
+
+static TypeFunctionId compute_type_func(AST::Identifier* identifier, TypeChecker& tc) {
+	assert(identifier);
+	assert(identifier->m_declaration);
+
+	auto& uf = tc.core().m_meta_core;
+	MetaTypeId meta_type = uf.eval(identifier->m_meta_type);
+	assert(uf.is(meta_type, Tag::Func));
+
+	auto decl = identifier->m_declaration;
+	assert(decl->m_value->type() == ASTTag::TypeFunctionHandle);
+
+	return static_cast<AST::TypeFunctionHandle*>(decl->m_value)->m_value;
 }
 
 // literals


### PR DESCRIPTION
When encountering a type func or a mono type, `ct_eval` essentially encodes the same data in a format that is suitable for the type checker. As it's doing that, though, it also wraps each type in a new AST node.

However, most of those nodes are discarded as soon as they are created (see `eval_then_get_mono` in the current master branch). For example, a declaration like `pt := struct { x: int<::>; y: int<::>; }<::>;` causes three nodes to be created and promptly discarded. I think this is just silly.

Furthermore, all the wrapping and unwrapping makes the code slower and harder to read.

For these reasons, I tried to split the code that translates ASTs into typechecker data from the code that wraps the result.

> This was originally over 60 commits that I squashed down to 29. It's still a lot, but it's hard to crunch down further without diluting each commit.