### PR TITLE
Remove handles

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -300,13 +300,13 @@ struct TypeTerm : public Expr {
 	    : Expr {ASTTag::TypeTerm} {}
 };
 
-struct TypeFunctionHandle : public Expr {
+struct BuiltinTypeFunction : public Expr {
 	TypeFunctionId m_value;
 	// points to the ast node this one was made from
 	Expr* m_syntax;
 
-	TypeFunctionHandle()
-	    : Expr {ASTTag::TypeFunctionHandle} {}
+	BuiltinTypeFunction()
+	    : Expr {ASTTag::BuiltinTypeFunction} {}
 };
 
 struct MonoTypeHandle : public Expr {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -277,6 +277,7 @@ struct WhileStatement : public AST {
 struct UnionExpression : public Expr {
 	std::vector<InternedString> m_constructors;
 	std::vector<Expr*> m_types;
+	TypeFunctionId m_value;
 
 	UnionExpression()
 	    : Expr {ASTTag::UnionExpression} {}
@@ -285,6 +286,7 @@ struct UnionExpression : public Expr {
 struct StructExpression : public Expr {
 	std::vector<InternedString> m_fields;
 	std::vector<Expr*> m_types;
+	TypeFunctionId m_value;
 
 	StructExpression()
 	    : Expr {ASTTag::StructExpression} {}

--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -21,7 +21,7 @@
 	X(UnionExpression)                                                         \
 	X(StructExpression)                                                        \
 	X(TypeTerm)                                                                \
-	X(TypeFunctionHandle)                                                      \
+	X(BuiltinTypeFunction)                                                      \
 	X(MonoTypeHandle)                                                          \
 	X(Constructor)                                                             \
 	/* All before this point are expressions */                                \

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -194,7 +194,7 @@ void compute_offsets(AST::AST* ast, int frame_offset) {
 		DISPATCH(UnionExpression);
 		DISPATCH(TypeTerm);
 
-		DO_NOTHING(TypeFunctionHandle);
+		DO_NOTHING(BuiltinTypeFunction);
 		DO_NOTHING(MonoTypeHandle);
 		DO_NOTHING(Constructor);
 	}

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -350,7 +350,7 @@ void eval(AST::UnionExpression* ast, Interpreter& e) {
 	e.m_stack.push(result.as_value());
 }
 
-void eval(AST::TypeFunctionHandle* ast, Interpreter& e) {
+void eval(AST::BuiltinTypeFunction* ast, Interpreter& e) {
 	return eval(ast->m_syntax, e);
 }
 
@@ -405,7 +405,7 @@ void eval(AST::AST* ast, Interpreter& e) {
 		DISPATCH(TypeTerm);
 		DISPATCH(StructExpression);
 		DISPATCH(UnionExpression);
-		DISPATCH(TypeFunctionHandle);
+		DISPATCH(BuiltinTypeFunction);
 		DISPATCH(MonoTypeHandle);
 		DISPATCH(Constructor);
 	}

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -69,8 +69,7 @@ static AST::Expr* ct_eval(
 		auto decl = ast->m_declaration;
 		return static_cast<AST::MonoTypeHandle*>(decl->m_value);
 	} else if (uf.is(meta_type, Tag::Func)) {
-		auto decl = ast->m_declaration;
-		return static_cast<AST::TypeFunctionHandle*>(decl->m_value);
+		return ast->m_declaration->m_value;
 	}
 
 	assert(0 && "UNREACHABLE");
@@ -158,26 +157,16 @@ static AST::Expr* ct_eval(
 }
 // types
 
-static AST::TypeFunctionHandle* wrap_in_type_func_handle(
-    AST::Expr* ast, TypeFunctionId value, AST::Allocator& alloc) {
-
-	auto node = alloc.make<AST::TypeFunctionHandle>();
-	node->m_value = value;
-	node->m_syntax = ast;
-
-	return node;
-}
-
 static AST::StructExpression* ct_eval(
     AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
-	    ast->m_value = compute_type_func(ast, tc);
-	    return ast;
+	ast->m_value = compute_type_func(ast, tc);
+	return ast;
 }
 
-static AST::TypeFunctionHandle* ct_eval(
+static AST::UnionExpression* ct_eval(
     AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
-
-	return wrap_in_type_func_handle(ast, compute_type_func(ast, tc), alloc);
+	ast->m_value = compute_type_func(ast, tc);
+	return ast;
 }
 
 static AST::Constructor* constructor_from_ast(
@@ -278,8 +267,8 @@ static TypeFunctionId get_foo(AST::Expr* ast) {
 		break;
 	}
 	
-	case ASTTag::TypeFunctionHandle: {
-		auto handle = static_cast<AST::TypeFunctionHandle*>(ast);
+	case ASTTag::BuiltinTypeFunction: {
+		auto handle = static_cast<AST::BuiltinTypeFunction*>(ast);
 		return handle->m_value;
 	}
 	
@@ -441,7 +430,7 @@ static AST::Expr* ct_eval(AST::AST* ast, TypeChecker& tc, AST::Allocator& alloc)
 		DISPATCH(TypeTerm);
 		DISPATCH(StructExpression);
 		DISPATCH(UnionExpression);
-		REJECT(TypeFunctionHandle);
+		REJECT(BuiltinTypeFunction);
 		REJECT(MonoTypeHandle);
 		REJECT(Constructor);
 	}

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -247,7 +247,7 @@ static void ct_visit(AST::Declaration* ast, TypeChecker& tc, AST::Allocator& all
 	ast->m_value = ct_eval(ast->m_value, tc, alloc);
 }
 
-static TypeFunctionId get_foo(AST::Expr* ast) {
+static TypeFunctionId get_type_function_id(AST::Expr* ast) {
 	switch (ast->type()) {
 
 	case ASTTag::StructExpression: {
@@ -258,13 +258,11 @@ static TypeFunctionId get_foo(AST::Expr* ast) {
 	case ASTTag::UnionExpression: {
 		auto union_expression = static_cast<AST::UnionExpression*>(ast);
 		return union_expression->m_value;
-		break;
 	}
 
 	case ASTTag::Identifier: {
 		auto identifier = static_cast<AST::Identifier*>(ast);
-		return get_foo(identifier->m_declaration->m_value);
-		break;
+		return get_type_function_id(identifier->m_declaration->m_value);
 	}
 	
 	case ASTTag::BuiltinTypeFunction: {
@@ -278,7 +276,7 @@ static TypeFunctionId get_foo(AST::Expr* ast) {
 	}
 }
 
-static void foo(AST::Expr* ast, TypeChecker& tc) {
+static void stub_type_function_id(AST::Expr* ast, TypeChecker& tc) {
 	switch (ast->type()) {
 
 	case ASTTag::StructExpression: {
@@ -295,7 +293,7 @@ static void foo(AST::Expr* ast, TypeChecker& tc) {
 
 	case ASTTag::Identifier: {
 		auto identifier = static_cast<AST::Identifier*>(ast);
-		foo(identifier->m_declaration->m_value, tc);
+		stub_type_function_id(identifier->m_declaration->m_value, tc);
 		break;
 	}
 	
@@ -322,7 +320,7 @@ static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) 
 
 		// put a dummy var where required.
 		if (uf.is(meta_type, Tag::Func)) {
-			foo(decl.m_value, tc);
+			stub_type_function_id(decl.m_value, tc);
 		} else if (uf.is(meta_type, Tag::Mono)) {
 			auto handle = alloc.make<AST::MonoTypeHandle>();
 			handle->m_value = tc.new_var(); // should it be hidden?
@@ -349,7 +347,7 @@ static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) 
 					Log::fatal() << "type hint not allowed in typefunc declaration";
 
 				TypeFunctionId tf = compute_type_func(decl->m_value, tc);
-				tc.core().unify_type_function(tf, get_foo(decl->m_value));
+				tc.core().unify_type_function(tf, get_type_function_id(decl->m_value));
 			} else if (uf.is(meta_type, Tag::Mono)) {
 				if (decl->m_type_hint)
 					Log::fatal() << "type hint not allowed in type declaration";
@@ -453,7 +451,7 @@ static TypeFunctionId compute_type_func(AST::Identifier* ast, TypeChecker& tc) {
 	assert(uf.is(meta_type, Tag::Func));
 
 	auto decl = ast->m_declaration;
-	return get_foo(decl->m_value);
+	return get_type_function_id(decl->m_value);
 }
 
 static TypeFunctionId compute_type_func(AST::StructExpression* ast, TypeChecker& tc) {

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -168,10 +168,10 @@ static AST::TypeFunctionHandle* wrap_in_type_func_handle(
 	return node;
 }
 
-static AST::TypeFunctionHandle* ct_eval(
+static AST::StructExpression* ct_eval(
     AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
-
-	return wrap_in_type_func_handle(ast, compute_type_func(ast, tc), alloc);
+	    ast->m_value = compute_type_func(ast, tc);
+	    return ast;
 }
 
 static AST::TypeFunctionHandle* ct_eval(
@@ -258,6 +258,64 @@ static void ct_visit(AST::Declaration* ast, TypeChecker& tc, AST::Allocator& all
 	ast->m_value = ct_eval(ast->m_value, tc, alloc);
 }
 
+static TypeFunctionId get_foo(AST::Expr* ast) {
+	switch (ast->type()) {
+
+	case ASTTag::StructExpression: {
+		auto struct_expression = static_cast<AST::StructExpression*>(ast);
+		return struct_expression->m_value;
+	}
+
+	case ASTTag::UnionExpression: {
+		auto union_expression = static_cast<AST::UnionExpression*>(ast);
+		return union_expression->m_value;
+		break;
+	}
+
+	case ASTTag::Identifier: {
+		auto identifier = static_cast<AST::Identifier*>(ast);
+		return get_foo(identifier->m_declaration->m_value);
+		break;
+	}
+	
+	case ASTTag::TypeFunctionHandle: {
+		auto handle = static_cast<AST::TypeFunctionHandle*>(ast);
+		return handle->m_value;
+	}
+	
+	default:
+		assert(0);
+		break;
+	}
+}
+
+static void foo(AST::Expr* ast, TypeChecker& tc) {
+	switch (ast->type()) {
+
+	case ASTTag::StructExpression: {
+		auto struct_expression = static_cast<AST::StructExpression*>(ast);
+		struct_expression->m_value = tc.core().new_type_function_var();
+		break;
+	}
+
+	case ASTTag::UnionExpression: {
+		auto union_expression = static_cast<AST::UnionExpression*>(ast);
+		union_expression->m_value = tc.core().new_type_function_var();
+		break;
+	}
+
+	case ASTTag::Identifier: {
+		auto identifier = static_cast<AST::Identifier*>(ast);
+		foo(identifier->m_declaration->m_value, tc);
+		break;
+	}
+	
+	default:
+		assert(0);
+		break;
+	}
+}
+
 static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) {
 
 	auto& uf = tc.core().m_meta_core;
@@ -275,10 +333,7 @@ static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) 
 
 		// put a dummy var where required.
 		if (uf.is(meta_type, Tag::Func)) {
-			auto handle = alloc.make<AST::TypeFunctionHandle>();
-			handle->m_value = tc.core().new_type_function_var();
-			handle->m_syntax = decl.m_value;
-			decl.m_value = handle;
+			foo(decl.m_value, tc);
 		} else if (uf.is(meta_type, Tag::Mono)) {
 			auto handle = alloc.make<AST::MonoTypeHandle>();
 			handle->m_value = tc.new_var(); // should it be hidden?
@@ -304,9 +359,8 @@ static void ct_visit(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) 
 				if (decl->m_type_hint)
 					Log::fatal() << "type hint not allowed in typefunc declaration";
 
-				auto handle = static_cast<AST::TypeFunctionHandle*>(decl->m_value);
-				TypeFunctionId tf = compute_type_func(handle->m_syntax, tc);
-				tc.core().unify_type_function(tf, handle->m_value);
+				TypeFunctionId tf = compute_type_func(decl->m_value, tc);
+				tc.core().unify_type_function(tf, get_foo(decl->m_value));
 			} else if (uf.is(meta_type, Tag::Mono)) {
 				if (decl->m_type_hint)
 					Log::fatal() << "type hint not allowed in type declaration";
@@ -410,9 +464,7 @@ static TypeFunctionId compute_type_func(AST::Identifier* ast, TypeChecker& tc) {
 	assert(uf.is(meta_type, Tag::Func));
 
 	auto decl = ast->m_declaration;
-	assert(decl->m_value->type() == ASTTag::TypeFunctionHandle);
-
-	return static_cast<AST::TypeFunctionHandle*>(decl->m_value)->m_value;
+	return get_foo(decl->m_value);
 }
 
 static TypeFunctionId compute_type_func(AST::StructExpression* ast, TypeChecker& tc) {

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -509,7 +509,7 @@ void typecheck(AST::AST* ast, TypecheckHelper& tc) {
 		DISPATCH(IfElseStatement);
 		DISPATCH(ReturnStatement);
 
-		IGNORE(TypeFunctionHandle);
+		IGNORE(BuiltinTypeFunction);
 		IGNORE(MonoTypeHandle);
 		IGNORE(Constructor);
 	}

--- a/src/typechecker/typechecker.cpp
+++ b/src/typechecker/typechecker.cpp
@@ -190,7 +190,7 @@ void TypeChecker::declare_builtin_typefunc(
     InternedString const& name, TypeFunctionId typefunc) {
 	auto decl = new_builtin_declaration(name);
 
-	auto handle = m_ast_allocator->make<AST::TypeFunctionHandle>();
+	auto handle = m_ast_allocator->make<AST::BuiltinTypeFunction>();
 	handle->m_value = typefunc;
 	decl->m_value = handle;
 	decl->m_meta_type = core().m_meta_core.make_const_node(Tag::Func);


### PR DESCRIPTION
Removes type function handles from the codebase, repurposes handles only for builtins.