### PR TITLE
Remove mono handles

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -295,6 +295,7 @@ struct StructExpression : public Expr {
 struct TypeTerm : public Expr {
 	Expr* m_callee;
 	std::vector<Expr*> m_args; // should these be TypeTerms?
+	MonoId m_value {-1};
 
 	TypeTerm()
 	    : Expr {ASTTag::TypeTerm} {}
@@ -307,15 +308,6 @@ struct BuiltinTypeFunction : public Expr {
 
 	BuiltinTypeFunction()
 	    : Expr {ASTTag::BuiltinTypeFunction} {}
-};
-
-struct MonoTypeHandle : public Expr {
-	MonoId m_value;
-	// points to the ast node this one was made from
-	Expr* m_syntax;
-
-	MonoTypeHandle()
-	    : Expr {ASTTag::MonoTypeHandle} {}
 };
 
 struct Constructor : public Expr {

--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -22,7 +22,6 @@
 	X(StructExpression)                                                        \
 	X(TypeTerm)                                                                \
 	X(BuiltinTypeFunction)                                                      \
-	X(MonoTypeHandle)                                                          \
 	X(Constructor)                                                             \
 	/* All before this point are expressions */                                \
 	X(Block)                                                                   \

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -195,7 +195,6 @@ void compute_offsets(AST::AST* ast, int frame_offset) {
 		DISPATCH(TypeTerm);
 
 		DO_NOTHING(BuiltinTypeFunction);
-		DO_NOTHING(MonoTypeHandle);
 		DO_NOTHING(Constructor);
 	}
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -354,10 +354,6 @@ void eval(AST::BuiltinTypeFunction* ast, Interpreter& e) {
 	return eval(ast->m_syntax, e);
 }
 
-void eval(AST::MonoTypeHandle* ast, Interpreter& e) {
-	return eval(ast->m_syntax, e);
-}
-
 void eval(AST::Constructor* ast, Interpreter& e) {
 	return eval(ast->m_syntax, e);
 }
@@ -406,7 +402,6 @@ void eval(AST::AST* ast, Interpreter& e) {
 		DISPATCH(StructExpression);
 		DISPATCH(UnionExpression);
 		DISPATCH(BuiltinTypeFunction);
-		DISPATCH(MonoTypeHandle);
 		DISPATCH(Constructor);
 	}
 

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -306,7 +306,7 @@ static void stub_monotype_id(AST::Expr* ast, TypeChecker& tc) {
 	}
 }
 
-MonoId get_monotype_id(AST::Expr* ast) {
+static MonoId get_monotype_id(AST::Expr* ast) {
 	switch (ast->type()) {
 	case ASTTag::TypeTerm:
 		return static_cast<AST::TypeTerm*>(ast)->m_value;
@@ -498,8 +498,7 @@ static MonoId compute_mono(AST::Identifier* ast, TypeChecker& tc) {
 	MetaTypeId meta_type = uf.eval(ast->m_meta_type);
 	assert(uf.is(meta_type, Tag::Mono));
 
-	auto decl = ast->m_declaration;
-	return get_monotype_id(decl->m_value);
+	return get_monotype_id(ast->m_declaration->m_value);
 }
 
 static MonoId compute_mono(AST::TypeTerm* ast, TypeChecker& tc) {

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -133,6 +133,13 @@ void typecheck(AST::AST* ast, TypeChecker& tc) {
 
 static void process_type_hint(AST::Declaration* ast, TypecheckHelper& tc);
 
+static MonoId get_monotype_id(AST::Expr* ast) {
+	switch(ast->type()) {
+	case ASTTag::TypeTerm:
+		return static_cast<AST::TypeTerm*>(ast)->m_value;
+	default: assert(0);
+	}
+}
 
 // Literals
 void typecheck(AST::NumberLiteral* ast, TypecheckHelper& tc) {
@@ -301,9 +308,7 @@ void typecheck(AST::AccessExpression* ast, TypecheckHelper& tc) {
 void typecheck(AST::MatchExpression* ast, TypecheckHelper& tc) {
 	typecheck(&ast->m_target, tc);
 	if (ast->m_type_hint) {
-		assert(ast->m_type_hint->type() == ASTTag::MonoTypeHandle);
-		auto handle = static_cast<AST::MonoTypeHandle*>(ast->m_type_hint);
-		tc.unify(ast->m_target.m_value_type, handle->m_value);
+		tc.unify(ast->m_target.m_value_type, get_monotype_id(ast->m_type_hint));
 	}
 
 	ast->m_value_type = tc.new_var();
@@ -406,9 +411,7 @@ static void process_type_hint(AST::Declaration* ast, TypecheckHelper& tc) {
 	if (!ast->m_type_hint)
 		return;
 
-	assert(ast->m_type_hint->type() == ASTTag::MonoTypeHandle);
-	auto handle = static_cast<AST::MonoTypeHandle*>(ast->m_type_hint);
-	tc.unify(ast->m_value_type, handle->m_value);
+	tc.unify(ast->m_value_type, get_monotype_id(ast->m_type_hint));
 }
 
 // typecheck the value and make the type of the decl equal
@@ -510,7 +513,6 @@ void typecheck(AST::AST* ast, TypecheckHelper& tc) {
 		DISPATCH(ReturnStatement);
 
 		IGNORE(BuiltinTypeFunction);
-		IGNORE(MonoTypeHandle);
 		IGNORE(Constructor);
 	}
 


### PR DESCRIPTION
Following the trend from #298, this PR removes creation of `MonoTypeHandle`s in ct_eval.

Turns out, we're not creating them anywhere else, so I removed them from the codebase.

~As a side note, I don't think we rewrite AST nodes in `ct_eval` anymore, so we could change its return type to void.~ We still rewrite some nodes into `AST::Constructor`s