### PR TITLE
add barebones negative testing

### DIFF
--- a/run_negative_tests.sh
+++ b/run_negative_tests.sh
@@ -1,0 +1,9 @@
+
+for t in tests/should_fail/*.jp
+do
+	./bin/jasperi $t 2> /dev/null > /dev/null
+	if [ $? -eq 0 ]
+	then
+		echo $(printf "\\u001b[31mFAIL: $t exited with a 'success' code\\u001b[0m");
+	fi
+done

--- a/tests/should_fail/265a.jp
+++ b/tests/should_fail/265a.jp
@@ -1,0 +1,20 @@
+fn __invoke() {
+  // infer f : forall a. () -> array<:a:>
+  f := fn() => array{};
+
+  // instanciate f, then generalize, infer arr : forall b. array<:b:>... wth???
+  arr := f();
+
+  // instanciate arr with b=int<::>, infer a1 : array<:int<::>:>
+  a1 : array<:int<::>:> = arr;
+
+   // instanciate arr with b=string<::>, infer a2 : array<:string<::>:>
+  a2 : array<:string<::>:> = arr;
+
+  array_append(a1, 10); // ok, a1 is array of int
+  array_append(a2, ""); // ok, a2 is array of string
+
+  // arr := array { 10; ""; };
+
+  return 0;
+};

--- a/tests/should_fail/265b.jp
+++ b/tests/should_fail/265b.jp
@@ -1,0 +1,14 @@
+fn __invoke() {
+  f := fn() => array{};
+  a := f(); // has type array<:a:> (note lack of forall, due to new logic)
+
+  // seems like it would generalize and have type forall b. array<:b:>, due to it being an identifier
+  b := a;
+  a1 : array<:int<::>:> = b;
+  a2 : array<:string<::>:> = b;
+
+  array_append(a1, 10);
+  array_append(a2, "");
+
+  return 0;
+};

--- a/tests/should_fail/293.jp
+++ b/tests/should_fail/293.jp
@@ -1,0 +1,7 @@
+fn __invoke() {
+  x := array{};
+  g := fn () => x[0][0];
+  array_append(array{3});
+  z := array{ "z"; g(); };
+  return 0;
+};


### PR DESCRIPTION
I added some tests that exercise failure cases and a script that checks that the interpreter indeed fails in those cases. This plugs a very significant hole in our testing story.

The tests were taken from #293, #265, and #266.

It's worth noting that this is the bare minimum I could get away with. I would like someone that better understands shell scripting to step in and upgrade this thing.

PS: this is not UNIX-compatible, as it uses `$(...)`, which is a Bash-ism