### PR TITLE
Typecheck simplification

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -149,7 +149,6 @@ struct FunctionLiteral : public Expr {
 		int inner_frame_offset{INT_MIN};
 	};
 
-	MonoId m_return_type;
 	Expr* m_body;
 	std::vector<Declaration> m_args;
 	std::unordered_map<InternedString, CaptureData> m_captures;

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -157,7 +157,7 @@ void typecheck(AST::NullLiteral* ast, TypecheckHelper& tc) {
 }
 
 void typecheck(AST::ArrayLiteral* ast, TypecheckHelper& tc) {
-	auto element_type = tc.new_var();
+	auto element_type = tc.new_hidden_var();
 	for (auto& element : ast->m_elements) {
 		typecheck(element, tc);
 		tc.unify(element_type, element->m_value_type);
@@ -167,16 +167,16 @@ void typecheck(AST::ArrayLiteral* ast, TypecheckHelper& tc) {
 	    tc.new_term(BuiltinType::Array, {element_type}, "Array Literal");
 }
 
+// Implements [Var] rule
 void typecheck(AST::Identifier* ast, TypecheckHelper& tc) {
 	AST::Declaration* declaration = ast->m_declaration;
 	assert(declaration);
 
 	assert(tc.is_term(declaration->m_meta_type));
 
-	// here we implement the [var] rule
 	ast->m_value_type = declaration->m_is_polymorphic
-	                        ? tc.inst_fresh(declaration->m_decl_type)
-	                        : declaration->m_value_type;
+		? tc.inst_fresh(declaration->m_decl_type)
+		: declaration->m_value_type;
 }
 
 // Implements [App] rule, extended for functions with multiple arguments
@@ -222,7 +222,7 @@ void typecheck(AST::IndexExpression* ast, TypecheckHelper& tc) {
 	typecheck(ast->m_callee, tc);
 	typecheck(ast->m_index, tc);
 
-	auto var = tc.new_var();
+	auto var = tc.new_hidden_var();
 	auto arr = tc.new_term(BuiltinType::Array, {var});
 	tc.unify(arr, ast->m_callee->m_value_type);
 
@@ -378,7 +378,7 @@ void process_contents(AST::Declaration* ast, TypecheckHelper& tc) {
 }
 
 static void typecheck(AST::SequenceExpression* ast, TypecheckHelper& tc) {
-	ast->m_value_type = tc.new_var();
+	ast->m_value_type = tc.new_hidden_var();
 	typecheck_stmt(ast->m_body, tc);
 }
 

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -429,10 +429,6 @@ static void typecheck_stmt(AST::AST* ast, TypecheckHelper& tc) {
 	case ASTTag::type:                                                    \
 		return typecheck_stmt(static_cast<AST::type*>(ast), tc);
 
-#define IGNORE(type)                                                           \
-	case ASTTag::type:                                                    \
-		return;
-
 	// TODO: Compound literals
 	switch (ast->type()) {
 		DISPATCH(Declaration);
@@ -449,7 +445,6 @@ static void typecheck_stmt(AST::AST* ast, TypecheckHelper& tc) {
 	             << ast_string[(int)ast->type()];
 
 #undef DISPATCH
-#undef IGNORE
 }
 
 void typecheck(AST::AST* ast, TypecheckHelper& tc) {
@@ -490,7 +485,6 @@ void typecheck(AST::AST* ast, TypecheckHelper& tc) {
 #undef DISPATCH
 #undef IGNORE
 }
-
 
 void typecheck_program(AST::AST* ast, TypecheckHelper& tc) {
 	// NOTE: we don't actually do anything with `ast`: what we really care about


### PR DESCRIPTION
I cleaned up some historical artifacts:

- `rule_app` came to be from the idea that each type system rule should be implemented by a single function. While I'm not against it in principle, this ended up not being the case in practice.
- `typecheck(FunctionLiteral)` was originally written when function bodies were statement-based, which forced it to do things in a weird order. (also, we didn't know what we were doing at the time)
- In general, we didn't use to recognize that expressions and statements were different things. The mental model I have now is that statements are just some special nodes that appear inside `SequenceExpressions`, so they get treated differently.
- We didn't use to understand what things should go into the environment and what things shouldn't. Really, most type vars should not get added into the environment. (This was left incomplete as it takes a surprisingly high amount of brain power to reason through each one in order to be able to change it)