### PR TITLE
File context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ COMMON_TARGETS := \
 	ast \
 	compute_offsets \
 	cst \
+	frontend_context \
 	lexer \
 	parser \
 	symbol_resolution \

--- a/src/frontend_context.cpp
+++ b/src/frontend_context.cpp
@@ -1,0 +1,23 @@
+#include "frontend_context.hpp"
+
+namespace Frontend {
+
+SourceLocation Context::char_offset_to_location(int offset) const {
+
+	int code_idx = 0;
+	int line = 0;
+	int col = 0;
+
+	for (; code_idx < offset; ++code_idx) {
+		if (source[code_idx] == '\n') {
+			line += 1;
+			col = 0;
+		} else {
+			col += 1;
+		}
+	}
+
+	return {line, col};
+}
+
+} // namespace Frontend

--- a/src/frontend_context.hpp
+++ b/src/frontend_context.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+#include "./utils/source_location.hpp"
+
+namespace Frontend {
+
+struct Context {
+	std::string source;
+
+	SourceLocation char_offset_to_location(int offset) const;
+};
+
+} // namespace Frontend

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -4,6 +4,7 @@
 #include "../ast_allocator.hpp"
 #include "../compute_offsets.hpp"
 #include "../cst_allocator.hpp"
+#include "../frontend_context.hpp"
 #include "../lexer.hpp"
 #include "../parser.hpp"
 #include "../symbol_resolution.hpp"
@@ -26,6 +27,8 @@ ExitStatus execute(
 	ExecuteSettings settings,
 	Runner* runner
 ) {
+
+	Frontend::Context file_context = {source};
 	TokenArray const ta = tokenize(source.c_str());
 
 	CST::Allocator cst_allocator;
@@ -57,7 +60,7 @@ ExitStatus execute(
 		for (auto& bucket : tc.m_builtin_declarations.m_buckets)
 			for (auto& decl : bucket)
 				context.declare(&decl);
-		auto err = Frontend::resolve_symbols(ast, context);
+		auto err = Frontend::resolve_symbols(ast, file_context, context);
 		if (!err.ok()) {
 			err.print();
 			return ExitStatus::StaticError;
@@ -92,6 +95,7 @@ Value eval_expression(
 	Interpreter& env,
 	Frontend::SymbolTable& context
 ) {
+	Frontend::Context file_context = {expr};
 	TokenArray const ta = tokenize(expr.c_str());
 
 	CST::Allocator cst_allocator;
@@ -103,7 +107,7 @@ Value eval_expression(
 	auto ast = AST::convert_ast(cst, ast_allocator);
 
 	{
-		auto err = Frontend::resolve_symbols(ast, context);
+		auto err = Frontend::resolve_symbols(ast, file_context, context);
 		if (!err.ok()) {
 			err.print();
 			return env.null();

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -32,7 +32,7 @@ ExitStatus execute(
 	TokenArray const ta = tokenize(source.c_str());
 
 	CST::Allocator cst_allocator;
-	auto parse_result = parse_program(ta, cst_allocator);
+	auto parse_result = parse_program(ta, file_context, cst_allocator);
 
 	if (not parse_result.ok()) {
 		parse_result.m_error.print();
@@ -99,7 +99,7 @@ Value eval_expression(
 	TokenArray const ta = tokenize(expr.c_str());
 
 	CST::Allocator cst_allocator;
-	auto parse_result = parse_expression(ta, cst_allocator);
+	auto parse_result = parse_expression(ta, file_context, cst_allocator);
 	// TODO: handle parse error
 	auto cst = parse_result.m_result;
 

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -6,6 +6,7 @@
 #include "../ast.hpp"
 #include "../ast_allocator.hpp"
 #include "../cst_allocator.hpp"
+#include "../frontend_context.hpp"
 #include "../lexer.hpp"
 #include "../parser.hpp"
 #include "../symbol_table.hpp"
@@ -53,7 +54,7 @@ int main(int argc, char** argv) {
 			    TokenArray const ta = tokenize("__invoke()");
 
 			    CST::Allocator cst_allocator;
-			    auto top_level_call_ast = parse_expression(ta, cst_allocator);
+			    auto top_level_call_ast = parse_expression(ta, {}, cst_allocator);
 
 			    AST::Allocator ast_allocator;
 			    auto top_level_call = AST::convert_ast(top_level_call_ast.m_result, ast_allocator);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -382,7 +382,7 @@ TokenArray tokenize(char const* p) {
 
 		eat_whitespace();
 	}
-	ta.push_back({TokenTag::END, InternedString()});
+	ta.push_back({TokenTag::END, InternedString(), p-code_start});
 
 	return ta;
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -297,7 +297,7 @@ static void print_error(char const* p) {
 	printf("Error -- last two chars are: %c%c\n", *(p-2), *(p-1));
 }
 
-static void push_identifier_or_keyword(Automaton const& a, TokenArray& ta, string_view str) {
+static void push_identifier_or_keyword(Automaton const& a, TokenArray& ta, string_view str, int start_offset) {
 
 	int state = state_count - 1;
 	for (int i = 0; i < str.size(); ++i) {
@@ -310,13 +310,13 @@ static void push_identifier_or_keyword(Automaton const& a, TokenArray& ta, strin
 		ta.push_back({
 			TokenTag::IDENTIFIER,
 			InternedString(str.begin(), str.size()),
-			0, 0, 0, 0
+			0, 0, 0, 0, start_offset
 		});
 	} else {
 		ta.push_back({
 			KeywordLexer::token_tags[state - 1],
 			KeywordLexer::fixed_strings[state - 1],
-			0, 0, 0, 0,
+			0, 0, 0, 0, start_offset
 		});
 	}
 }
@@ -360,23 +360,26 @@ TokenArray tokenize(char const* p) {
 			ta.push_back({
 				MainLexer::token_tags[state - 1],
 				MainLexer::fixed_strings[state - 1],
-				{{p0 - code_start}, {p - code_start}}
+				{{p0 - code_start}, {p - code_start}},
+				p0 - code_start,
 			});
 		} else if(state == MainLexer::EndStates::Identifier) {
-			push_identifier_or_keyword(ka, ta, string_view(p0, p - p0));
+			push_identifier_or_keyword(ka, ta, string_view(p0, p - p0), p0 - code_start);
 		} else if(state == MainLexer::EndStates::Comment) {
 			// do nothing.
 		} else if(state == MainLexer::EndStates::String) {
 			ta.push_back({
 				MainLexer::token_tags[state - 1],
 				InternedString(p0 + 1, p - p0 - 2),
-				{{p0 - code_start}, {p - code_start}}
+				{{p0 - code_start}, {p - code_start}},
+				p0 - code_start,
 			});
 		} else {
 			ta.push_back({
 				MainLexer::token_tags[state - 1],
 				InternedString(p0, p - p0),
-				{{p0 - code_start}, {p - code_start}}
+				{{p0 - code_start}, {p - code_start}},
+				p0 - code_start,
 			});
 		}
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -387,41 +387,5 @@ TokenArray tokenize(char const* p) {
 	}
 	ta.push_back({TokenTag::END, InternedString()});
 
-	// resolve source locations
-	{
-		int const real_token_count = ta.size() - 1;
-		int code_idx = 0;
-		int line = 0;
-		int col = 0;
-
-		auto advance_until = [&] (int end_idx) {
-			for (; code_idx < end_idx; ++code_idx) {
-				if (code_start[code_idx] == '\n') {
-					line += 1;
-					col = 0;
-				} else {
-					col += 1;
-				}
-			}
-		};
-
-		for (int i = 0; i < real_token_count; ++i) {
-			auto& token = ta.at(i);
-
-			int code_idx1 = token.m_source_location.start.line;
-			int code_idx2 = token.m_source_location.end.line;
-
-			advance_until(code_idx1);
-
-			token.m_source_location.start.line = line;
-			token.m_source_location.start.col = col;
-
-			advance_until(code_idx2);
-
-			token.m_source_location.end.line = line;
-			token.m_source_location.end.col = col;
-		}
-	}
-
 	return ta;
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -310,13 +310,13 @@ static void push_identifier_or_keyword(Automaton const& a, TokenArray& ta, strin
 		ta.push_back({
 			TokenTag::IDENTIFIER,
 			InternedString(str.begin(), str.size()),
-			0, 0, 0, 0, start_offset
+			start_offset
 		});
 	} else {
 		ta.push_back({
 			KeywordLexer::token_tags[state - 1],
 			KeywordLexer::fixed_strings[state - 1],
-			0, 0, 0, 0, start_offset
+			start_offset
 		});
 	}
 }
@@ -360,7 +360,6 @@ TokenArray tokenize(char const* p) {
 			ta.push_back({
 				MainLexer::token_tags[state - 1],
 				MainLexer::fixed_strings[state - 1],
-				{{p0 - code_start}, {p - code_start}},
 				p0 - code_start,
 			});
 		} else if(state == MainLexer::EndStates::Identifier) {
@@ -371,14 +370,12 @@ TokenArray tokenize(char const* p) {
 			ta.push_back({
 				MainLexer::token_tags[state - 1],
 				InternedString(p0 + 1, p - p0 - 2),
-				{{p0 - code_start}, {p - code_start}},
 				p0 - code_start,
 			});
 		} else {
 			ta.push_back({
 				MainLexer::token_tags[state - 1],
 				InternedString(p0, p - p0),
-				{{p0 - code_start}, {p - code_start}},
 				p0 - code_start,
 			});
 		}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -65,11 +65,13 @@ ErrorReport make_expected_error(TokenTag tag, Token const* found_token) {
 struct Parser {
 	/* token handler */
 	TokenArray const& m_tokens;
+	Frontend::Context const& m_file_context;
 	CST::Allocator& m_cst_allocator;
 	int m_token_cursor { 0 };
 
-	Parser(TokenArray const& tokens, CST::Allocator& cst_allocator)
+	Parser(TokenArray const& tokens, Frontend::Context const& file_context, CST::Allocator& cst_allocator)
 	    : m_tokens {tokens}
+		, m_file_context {file_context}
 	    , m_cst_allocator {cst_allocator} {}
 
 	Writer<std::vector<CST::CST*>> parse_expression_list(TokenTag, TokenTag, bool);
@@ -1185,12 +1187,12 @@ Writer<CST::CST*> Parser::parse_type_function() {
 #undef CHECK_AND_RETURN
 #undef REQUIRE
 
-Writer<CST::CST*> parse_program(TokenArray const& ta, CST::Allocator& allocator) {
-	Parser p {ta, allocator};
+Writer<CST::CST*> parse_program(TokenArray const& ta, Frontend::Context const& file_context, CST::Allocator& allocator) {
+	Parser p {ta, file_context, allocator};
 	return p.parse_top_level();
 }
 
-Writer<CST::CST*> parse_expression(TokenArray const& ta, CST::Allocator& allocator) {
-	Parser p {ta, allocator};
+Writer<CST::CST*> parse_expression(TokenArray const& ta, Frontend::Context const& file_context, CST::Allocator& allocator) {
+	Parser p {ta, file_context, allocator};
 	return p.parse_expression();
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -10,6 +10,10 @@ struct CST;
 struct Allocator;
 }
 
+namespace Frontend {
+struct Context;
+}
+
 template <typename T>
 struct Writer {
 	ErrorReport m_error {};
@@ -54,5 +58,5 @@ struct Writer {
 	}
 };
 
-Writer<CST::CST*> parse_program(TokenArray const&, CST::Allocator&);
-Writer<CST::CST*> parse_expression(TokenArray const&, CST::Allocator&);
+Writer<CST::CST*> parse_program(TokenArray const&, Frontend::Context const&, CST::Allocator&);
+Writer<CST::CST*> parse_expression(TokenArray const&, Frontend::Context const&, CST::Allocator&);

--- a/src/symbol_resolution.cpp
+++ b/src/symbol_resolution.cpp
@@ -8,6 +8,7 @@
 #include "./utils/error_report.hpp"
 #include "./utils/interned_string.hpp"
 #include "ast.hpp"
+#include "frontend_context.hpp"
 #include "symbol_table.hpp"
 #include "token.hpp"
 
@@ -67,8 +68,9 @@ struct PtrStack {
 	}
 
 struct SymbolResolutionCommand {
-	SymbolResolutionCommand(SymbolTable& symbol_table)
-	    : symbol_table {symbol_table} {}
+	SymbolResolutionCommand(Context const& file_context, SymbolTable& symbol_table)
+		: file_context {file_context}
+		, symbol_table {symbol_table} {}
 
 	ErrorReport handle(AST::AST* ast) {
 		return resolve(ast);
@@ -76,6 +78,7 @@ struct SymbolResolutionCommand {
 
 private:
 
+	Context const& file_context;
 	SymbolTable& symbol_table;
 	TopLevelDeclTracker top_level;
 	PtrStack<AST::FunctionLiteral> functions;
@@ -357,8 +360,8 @@ private:
 
 #undef CHECK_AND_RETURN
 
-[[nodiscard]] ErrorReport resolve_symbols(AST::AST* ast, SymbolTable& env) {
-	auto command = SymbolResolutionCommand {env};
+[[nodiscard]] ErrorReport resolve_symbols(AST::AST* ast, Context const& file_context, SymbolTable& env) {
+	auto command = SymbolResolutionCommand {file_context, env};
 	return command.handle(ast);
 }
 

--- a/src/symbol_resolution.cpp
+++ b/src/symbol_resolution.cpp
@@ -109,9 +109,10 @@ private:
 		if (!declaration) {
 			// TODO: clean up how we build error reports
 			auto token = ast->token();
+			SourceLocation token_location = file_context.char_offset_to_location(token->m_start_offset);
 			return make_located_error(
 				"accessed undeclared identifier '" + ast->text().str() + "'",
-				token->m_source_location.start);
+				token_location);
 		}
 
 		ast->m_declaration = declaration;

--- a/src/symbol_resolution.hpp
+++ b/src/symbol_resolution.hpp
@@ -10,11 +10,12 @@ struct Declaration;
 namespace Frontend {
 
 struct SymbolTable;
+struct Context;
 
 /*
  * Matches every identifier in the given ast with a declaration.
  * This also includes captures in a closure.
  */
-[[nodiscard]] ErrorReport resolve_symbols(AST::AST* ast, SymbolTable&);
+[[nodiscard]] ErrorReport resolve_symbols(AST::AST* ast, Context const& file_context, SymbolTable&);
 
 } // namespace Frontend

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -11,4 +11,5 @@ struct Token {
 	InternedString m_text;
 
 	SourceRange m_source_location;
+	int m_start_offset;
 };

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -10,6 +10,5 @@ struct Token {
 	/* source code representation of token */
 	InternedString m_text;
 
-	SourceRange m_source_location;
 	int m_start_offset;
 };


### PR DESCRIPTION
Closes #301 

This patch avoids computing source locations for tokens until they are needed. We achieve this by passing the source file around, wrapped in a new struct.

I figure we can keep adding stuff to this struct for extra context, like the filename and so on, so it's probably something we wanted anyways.