### PR TITLE
`TRY` macro for the parser and other improvements

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -183,7 +183,7 @@ Writer<CST::CST*> Parser::parse_top_level() {
 
 	auto e = m_cst_allocator.make<CST::Program>();
 	e->m_declarations = std::move(declarations);
-	return make_writer<CST::CST*>(e);
+	return make_writer(e);
 }
 
 Writer<std::vector<CST::CST*>> Parser::parse_expression_list(
@@ -518,7 +518,7 @@ Writer<CST::CST*> Parser::parse_expression(CST::CST* lhs, int bp) {
 		lhs = e;
 	}
 
-	return make_writer<CST::CST*>(lhs);
+	return make_writer(lhs);
 }
 
 /* We say a terminal is any expression that is not an infix expression.
@@ -530,21 +530,21 @@ Writer<CST::CST*> Parser::parse_terminal() {
 	if (token->m_type == TokenTag::KEYWORD_NULL) {
 		auto e = m_cst_allocator.make<CST::NullLiteral>();
 		advance_token_cursor();
-		return make_writer<CST::CST*>(e);
+		return make_writer(e);
 	}
 
 	if (token->m_type == TokenTag::KEYWORD_TRUE) {
 		auto e = m_cst_allocator.make<CST::BooleanLiteral>();
 		e->m_token = token;
 		advance_token_cursor();
-		return make_writer<CST::CST*>(e);
+		return make_writer(e);
 	}
 
 	if (token->m_type == TokenTag::KEYWORD_FALSE) {
 		auto e = m_cst_allocator.make<CST::BooleanLiteral>();
 		e->m_token = token;
 		advance_token_cursor();
-		return make_writer<CST::CST*>(e);
+		return make_writer(e);
 	}
 
 	if (token->m_type == TokenTag::SUB || token->m_type == TokenTag::ADD) {
@@ -558,14 +558,14 @@ Writer<CST::CST*> Parser::parse_terminal() {
 			e->m_sign = token;
 			e->m_token = peek();
 			advance_token_cursor();
-			return make_writer<CST::CST*>(e);
+			return make_writer(e);
 		} else if (match(TokenTag::NUMBER)) {
 			auto e = m_cst_allocator.make<CST::NumberLiteral>();
 			e->m_negative = token->m_type == TokenTag::SUB;
 			e->m_sign = token;
 			e->m_token = peek();
 			advance_token_cursor();
-			return make_writer<CST::CST*>(e);
+			return make_writer(e);
 		}
 
 		return token->m_type == TokenTag::SUB
@@ -577,28 +577,28 @@ Writer<CST::CST*> Parser::parse_terminal() {
 		auto e = m_cst_allocator.make<CST::IntegerLiteral>();
 		e->m_token = token;
 		advance_token_cursor();
-		return make_writer<CST::CST*>(e);
+		return make_writer(e);
 	}
 
 	if (token->m_type == TokenTag::NUMBER) {
 		auto e = m_cst_allocator.make<CST::NumberLiteral>();
 		e->m_token = token;
 		advance_token_cursor();
-		return make_writer<CST::CST*>(e);
+		return make_writer(e);
 	}
 
 	if (token->m_type == TokenTag::IDENTIFIER) {
 		auto e = m_cst_allocator.make<CST::Identifier>();
 		e->m_token = token;
 		advance_token_cursor();
-		return make_writer<CST::CST*>(e);
+		return make_writer(e);
 	}
 
 	if (token->m_type == TokenTag::STRING) {
 		auto e = m_cst_allocator.make<CST::StringLiteral>();
 		e->m_token = token;
 		advance_token_cursor();
-		return make_writer<CST::CST*>(e);
+		return make_writer(e);
 	}
 
 	if (token->m_type == TokenTag::KEYWORD_FN) {
@@ -673,7 +673,7 @@ Writer<CST::CST*> Parser::parse_ternary_expression(CST::CST* condition) {
 	e->m_then_expr = then_expr;
 	e->m_else_expr = else_expr;
 
-	return make_writer<CST::CST*>(e);
+	return make_writer(e);
 }
 
 Writer<CST::Identifier*> Parser::parse_identifier(bool types_allowed) {
@@ -692,7 +692,7 @@ Writer<CST::Identifier*> Parser::parse_identifier(bool types_allowed) {
 	auto e = m_cst_allocator.make<CST::Identifier>();
 	e->m_token = token;
 
-	return make_writer<CST::Identifier*>(e);
+	return make_writer(e);
 }
 
 Writer<CST::CST*> Parser::parse_array_literal() {
@@ -707,7 +707,7 @@ Writer<CST::CST*> Parser::parse_array_literal() {
 	auto e = m_cst_allocator.make<CST::ArrayLiteral>();
 	e->m_elements = std::move(elements);
 
-	return make_writer<CST::CST*>(e);
+	return make_writer(e);
 }
 
 Writer<CST::FuncParameters> Parser::parse_function_parameters() {
@@ -776,7 +776,7 @@ Writer<CST::CST*> Parser::parse_function() {
 		e->m_body = expression;
 		e->m_args = std::move(func_args);
 
-		return make_writer<CST::CST*>(e);
+		return make_writer(e);
 	} else if (match(TokenTag::BRACE_OPEN)) {
 		auto block = TRY_WITH(result, parse_block());
 
@@ -784,7 +784,7 @@ Writer<CST::CST*> Parser::parse_function() {
 		e->m_body = block;
 		e->m_args = std::move(func_args);
 
-		return make_writer<CST::CST*>(e);
+		return make_writer(e);
 	} else {
 		return make_expected_error("'=>' or '{'", peek());
 	}
@@ -832,7 +832,7 @@ Writer<CST::CST*> Parser::parse_return_statement() {
 	auto e = m_cst_allocator.make<CST::ReturnStatement>();
 	e->m_value = value;
 
-	return make_writer<CST::CST*>(e);
+	return make_writer(e);
 }
 Writer<CST::CST*> Parser::parse_if_else_stmt_or_expr() {
 	Writer<CST::CST*> result = {{"Failed to parse if-else statement or expression"}};
@@ -863,7 +863,7 @@ Writer<CST::CST*> Parser::parse_if_else_stmt_or_expr() {
 		e->m_else_body = TRY_WITH(result, parse_statement());
 	}
 
-	return make_writer<CST::CST*>(e);
+	return make_writer(e);
 }
 
 Writer<CST::CST*> Parser::parse_for_statement() {
@@ -889,7 +889,7 @@ Writer<CST::CST*> Parser::parse_for_statement() {
 	e->m_action = action;
 	e->m_body = body;
 
-	return make_writer<CST::CST*>(e);
+	return make_writer(e);
 }
 
 Writer<CST::CST*> Parser::parse_while_statement() {
@@ -907,7 +907,7 @@ Writer<CST::CST*> Parser::parse_while_statement() {
 	e->m_condition = condition;
 	e->m_body = body;
 
-	return make_writer<CST::CST*>(e);
+	return make_writer(e);
 }
 
 Writer<CST::CST*> Parser::parse_match_expression() {
@@ -947,7 +947,7 @@ Writer<CST::CST*> Parser::parse_match_expression() {
 	match->m_type_hint = matchee_and_hint.second;
 	match->m_cases = std::move(cases);
 
-	return make_writer<CST::CST*>(match);
+	return make_writer(match);
 }
 
 Writer<CST::CST*> Parser::parse_sequence_expression() {
@@ -959,7 +959,7 @@ Writer<CST::CST*> Parser::parse_sequence_expression() {
 	auto expr = m_cst_allocator.make<CST::SequenceExpression>();
 	expr->m_body = body;
 
-	return make_writer<CST::CST*>(expr);
+	return make_writer(expr);
 }
 
 Writer<std::pair<Token const*, CST::CST*>> Parser::parse_name_and_type(bool required_type) {
@@ -993,7 +993,7 @@ Writer<CST::CST*> Parser::parse_statement() {
 
 			auto declaration = TRY_WITH(result, parse_declaration());
 
-			return make_writer<CST::CST*>(declaration);
+			return make_writer(declaration);
 		} else {
 			auto expression = TRY_WITH(result, parse_expression());
 			REQUIRE(result, TokenTag::SEMICOLON);
@@ -1044,14 +1044,14 @@ Writer<CST::CST*> Parser::parse_type_term() {
 	auto callee = TRY_WITH(result, parse_identifier(true));
 
 	if (!match(TokenTag::POLY_OPEN))
-		return make_writer<CST::CST*>(callee);
+		return make_writer(callee);
 
 	auto args = TRY_WITH(result, parse_type_term_arguments());
 
 	auto e = m_cst_allocator.make<CST::TypeTerm>();
 	e->m_callee = callee;
 	e->m_args = std::move(args);
-	return make_writer<CST::CST*>(e);
+	return make_writer(e);
 }
 
 Writer<std::pair<std::vector<CST::Identifier>, std::vector<CST::CST*>>> Parser::parse_type_list(
@@ -1093,7 +1093,7 @@ Writer<CST::CST*> Parser::parse_type_var() {
 	auto t = m_cst_allocator.make<CST::TypeVar>();
 	t->m_token = token;
 
-	return make_writer<CST::CST*>(t);
+	return make_writer(t);
 }
 
 Writer<CST::CST*> Parser::parse_type_function() {
@@ -1106,7 +1106,7 @@ Writer<CST::CST*> Parser::parse_type_function() {
 		u->m_constructors = std::move(tl.first);
 		u->m_types = std::move(tl.second);
 
-		return make_writer<CST::CST*>(u);
+		return make_writer(u);
 	} else if (consume(TokenTag::KEYWORD_STRUCT)) {
 		auto tl = TRY_WITH(result, parse_type_list(true));
 
@@ -1114,7 +1114,7 @@ Writer<CST::CST*> Parser::parse_type_function() {
 		s->m_fields = std::move(tl.first);
 		s->m_types = std::move(tl.second);
 
-		return make_writer<CST::CST*>(s);
+		return make_writer(s);
 	}
 
 	return result;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -602,13 +602,11 @@ Writer<CST::CST*> Parser::parse_terminal() {
 	}
 
 	if (token->m_type == TokenTag::KEYWORD_FN) {
-		auto function = TRY(parse_function());
-		return make_writer(function);
+		return parse_function();
 	}
 
 	if (token->m_type == TokenTag::KEYWORD_IF) {
-		auto ternary = TRY(parse_ternary_expression());
-		return make_writer(ternary);
+		return parse_ternary_expression();
 	}
 
 	// parse a parenthesized expression.
@@ -620,25 +618,21 @@ Writer<CST::CST*> Parser::parse_terminal() {
 	}
 
 	if (token->m_type == TokenTag::KEYWORD_ARRAY) {
-		auto array = TRY(parse_array_literal());
-		return make_writer(array);
+		return parse_array_literal();
 	}
 
 	if (token->m_type == TokenTag::KEYWORD_UNION ||
 	    token->m_type == TokenTag::KEYWORD_STRUCT) {
 		// TODO: do the other type functions
-		auto type = TRY(parse_type_function());
-		return make_writer(type);
+		return parse_type_function();
 	}
 
 	if (token->m_type == TokenTag::KEYWORD_MATCH) {
-		auto match_expr = TRY(parse_match_expression());
-		return make_writer(match_expr);
+		return parse_match_expression();
 	}
 
 	if (token->m_type == TokenTag::KEYWORD_SEQ) {
-		auto expr = TRY(parse_sequence_expression());
-		return make_writer(expr);
+		return parse_sequence_expression();
 	}
 
 	return make_expected_error("a literal, a conditional expression, or an identifier", token);

--- a/src/utils/error_report.cpp
+++ b/src/utils/error_report.cpp
@@ -22,3 +22,7 @@ ErrorReport make_located_error(string_view text, SourceLocation location) {
 	ss << "At " << location.to_string() << " : " << text;
 	return ErrorReport {ss.str()};
 }
+
+void ErrorReport::add_sub_error(ErrorReport other) {
+	m_sub_errors.push_back(std::move(other));
+}

--- a/src/utils/error_report.hpp
+++ b/src/utils/error_report.hpp
@@ -12,6 +12,8 @@ struct ErrorReport {
 
 	bool ok() const;
 	void print(int d = 1) const;
+
+	void add_sub_error(ErrorReport);
 };
 
 ErrorReport make_located_error(string_view text, SourceLocation location);


### PR DESCRIPTION
In [SerenityOS/serenity](https://github.com/SerenityOS/serenity), they do error handling using a type called `AK::Result<T>` (essentially Haskell's `Either`). To avoid writing tons of code that just checks and returns the error, they came up with a really cool `TRY` macro:

```c++
auto x = TRY(failable_operation());

// essentially, expands to:
auto temp_ = failable_operation();
if (temp.is_error()) return temp.error();
auto x = temp_.value();
```

I took that and adapted it for our parser. I also made `TRY_WITH` that, instead of just returning the error, will append it to an existing error object and return that instead. (much like our old `CHECK_AND_RETURN` macro). For extra convenience, I made `REQUIRE` and `REQUIRE_WITH`, which are just calls to `Parser::require` wrapped in the other macros.

To be clear, the advantage over `CHECK_AND_RETURN` and `CHECK_AND_EXTRACT` is that the new macros behave like expressions (so they can appear within other expressions), while the old ones were full-on statements (so they'd need to be on their own line).

Using these, error handling in the parser has become much much cleaner.

----------------

I also did a few more readability changes:

- Simplify usage of `make_writer` where possible. (At some point I made it so that `Writer<SubClass*>` can be implicitly converted to `Writer<SuperClass*>`, but we never took advantage of that in the parser).
- Add `add_sub_error` method to `ErrorReport`, which makes it compatible with the new error handling macros.
- Replace `Writer<T>` with `ErrorReport` where possible.
- Add some missing error handling on `parse_expression`.

Finally, I used `TRY` instead of `TRY_WITH` in a bunch of places where we were using `CHECK_AND_RETURN`, (meaning some errors won't get wrapped with extra information about the parser's call stack) which made error messages a lot shorter yet -- i think -- a lot more readable.

-----------------

Serenity's original TRY macro can be seen here:
https://github.com/SerenityOS/serenity/blob/eed63e817422ef6582607df93d29577607202bde/AK/Try.h