### PR TITLE
Parser initialize nodes on allocation

### DIFF
--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -58,8 +58,9 @@ struct PlainDeclaration : public Declaration {
 		return identifier();
 	}
 
-	PlainDeclaration()
-	    : Declaration {CSTTag::PlainDeclaration} {}
+	PlainDeclaration(DeclarationData data)
+	    : Declaration {CSTTag::PlainDeclaration}
+	    , m_data {std::move(data)} {}
 };
 
 struct FuncDeclaration : public Declaration {
@@ -75,8 +76,11 @@ struct FuncDeclaration : public Declaration {
 		return identifier();
 	}
 
-	FuncDeclaration()
-	    : Declaration {CSTTag::FuncDeclaration} {}
+	FuncDeclaration(Token const* identifier, FuncParameters args, CST* body)
+	    : Declaration {CSTTag::FuncDeclaration}
+	    , m_identifier {identifier}
+	    , m_args {std::move(args)}
+	    , m_body {body} {}
 };
 
 struct BlockFuncDeclaration : public Declaration {
@@ -92,15 +96,19 @@ struct BlockFuncDeclaration : public Declaration {
 		return identifier();
 	}
 
-	BlockFuncDeclaration()
-	    : Declaration {CSTTag::BlockFuncDeclaration} {}
+	BlockFuncDeclaration(Token const* identifier, FuncParameters args, Block* body)
+	    : Declaration {CSTTag::BlockFuncDeclaration}
+	    , m_identifier {identifier}
+	    , m_args {std::move(args)}
+	    , m_body {body} {}
 };
 
 struct Program : public CST {
 	std::vector<Declaration*> m_declarations;
 
-	Program()
-	    : CST {CSTTag::Program} {}
+	Program(std::vector<Declaration*> declarations)
+	    : CST {CSTTag::Program}
+	    , m_declarations {std::move(declarations)} {}
 };
 
 struct IntegerLiteral : public CST {
@@ -112,8 +120,11 @@ struct IntegerLiteral : public CST {
 		return m_token->m_text.str();
 	}
 
-	IntegerLiteral()
-	    : CST {CSTTag::IntegerLiteral} {}
+	IntegerLiteral(bool negative, Token const* sign, Token const* token)
+	    : CST {CSTTag::IntegerLiteral}
+	    , m_negative {negative}
+	    , m_sign {sign}
+	    , m_token {token} {}
 };
 
 struct NumberLiteral : public CST {
@@ -125,8 +136,11 @@ struct NumberLiteral : public CST {
 		return m_token->m_text.str();
 	}
 
-	NumberLiteral()
-	    : CST {CSTTag::NumberLiteral} {}
+	NumberLiteral(bool negative, Token const* sign, Token const* token)
+	    : CST {CSTTag::NumberLiteral}
+	    , m_negative {negative}
+	    , m_sign {sign}
+	    , m_token {token} {}
 };
 
 struct StringLiteral : public CST {
@@ -136,8 +150,9 @@ struct StringLiteral : public CST {
 		return m_token->m_text.str();
 	}
 
-	StringLiteral()
-	    : CST {CSTTag::StringLiteral} {}
+	StringLiteral(Token const* token)
+	    : CST {CSTTag::StringLiteral}
+	    , m_token {token} {}
 };
 
 struct BooleanLiteral : public CST {
@@ -147,8 +162,9 @@ struct BooleanLiteral : public CST {
 		return m_token->m_text.str();
 	}
 
-	BooleanLiteral()
-	    : CST {CSTTag::BooleanLiteral} {}
+	BooleanLiteral(Token const* token)
+	    : CST {CSTTag::BooleanLiteral}
+	    , m_token {token} {}
 };
 
 struct NullLiteral : public CST {
@@ -160,24 +176,29 @@ struct NullLiteral : public CST {
 struct ArrayLiteral : public CST {
 	std::vector<CST*> m_elements;
 
-	ArrayLiteral()
-	    : CST {CSTTag::ArrayLiteral} {}
+	ArrayLiteral(std::vector<CST*> elements)
+	    : CST {CSTTag::ArrayLiteral}
+	    , m_elements {std::move(elements)} {}
 };
 
 struct BlockFunctionLiteral : public CST {
 	Block* m_body;
 	FuncParameters m_args;
 
-	BlockFunctionLiteral()
-	    : CST {CSTTag::BlockFunctionLiteral} {}
+	BlockFunctionLiteral(Block* body, FuncParameters args)
+	    : CST {CSTTag::BlockFunctionLiteral}
+	    , m_body {body}
+	    , m_args {std::move(args)} {}
 };
 
 struct FunctionLiteral : public CST {
 	CST* m_body;
 	FuncParameters m_args;
 
-	FunctionLiteral()
-	    : CST {CSTTag::FunctionLiteral} {}
+	FunctionLiteral(CST* body, FuncParameters args)
+	    : CST {CSTTag::FunctionLiteral}
+	    , m_body {body}
+	    , m_args {std::move(args)} {}
 };
 
 struct Identifier : public CST {
@@ -197,8 +218,11 @@ struct BinaryExpression : public CST {
 	CST* m_lhs;
 	CST* m_rhs;
 
-	BinaryExpression()
-	    : CST {CSTTag::BinaryExpression} {}
+	BinaryExpression(Token const* op_token, CST* lhs, CST* rhs)
+	    : CST {CSTTag::BinaryExpression}
+	    , m_op_token {op_token}
+	    , m_lhs {lhs}
+	    , m_rhs {rhs} {}
 };
 
 struct CallExpression : public CST {
@@ -215,16 +239,20 @@ struct IndexExpression : public CST {
 	CST* m_callee;
 	CST* m_index;
 
-	IndexExpression()
-	    : CST {CSTTag::IndexExpression} {}
+	IndexExpression(CST* callee, CST* index)
+	    : CST {CSTTag::IndexExpression}
+	    , m_callee {callee}
+	    , m_index {index} {}
 };
 
 struct AccessExpression : public CST {
 	CST* m_record;
 	Token const* m_member;
 
-	AccessExpression()
-	    : CST {CSTTag::AccessExpression} {}
+	AccessExpression(CST* record, Token const* member)
+	    : CST {CSTTag::AccessExpression}
+	    , m_record {record}
+	    , m_member {member} {}
 };
 
 struct TernaryExpression : public CST {
@@ -232,8 +260,11 @@ struct TernaryExpression : public CST {
 	CST* m_then_expr;
 	CST* m_else_expr;
 
-	TernaryExpression()
-	    : CST {CSTTag::TernaryExpression} {}
+	TernaryExpression(CST* condition, CST* then_expr, CST* else_expr)
+	    : CST {CSTTag::TernaryExpression}
+	    , m_condition {condition}
+	    , m_then_expr {then_expr}
+	    , m_else_expr {else_expr} {}
 };
 
 struct MatchExpression : public CST {
@@ -249,38 +280,46 @@ struct MatchExpression : public CST {
 	CST* m_type_hint {nullptr};
 	std::vector<CaseData> m_cases;
 
-	MatchExpression()
-	    : CST {CSTTag::MatchExpression} {}
+	MatchExpression(Identifier matchee, CST* type_hint, std::vector<CaseData> cases)
+	    : CST {CSTTag::MatchExpression}
+	    , m_matchee {matchee}
+	    , m_type_hint {type_hint}
+	    , m_cases {cases} {}
 };
 
 struct ConstructorExpression : public CST {
 	CST* m_constructor;
 	std::vector<CST*> m_args;
 
-	ConstructorExpression()
-	    : CST {CSTTag::ConstructorExpression} {}
+	ConstructorExpression(CST* constructor, std::vector<CST*> args)
+	    : CST {CSTTag::ConstructorExpression}
+	    , m_constructor {constructor}
+	    , m_args {std::move(args)} {}
 };
 
 
 struct SequenceExpression : public CST {
 	Block* m_body;
 
-	SequenceExpression()
-	    : CST {CSTTag::SequenceExpression} {}
+	SequenceExpression(Block* body)
+	    : CST {CSTTag::SequenceExpression}
+	    , m_body {body} {}
 };
 
 struct Block : public CST {
 	std::vector<CST*> m_body;
 
-	Block()
-	    : CST {CSTTag::Block} {}
+	Block(std::vector<CST*> body)
+	    : CST {CSTTag::Block}
+	    , m_body {body} {}
 };
 
 struct ReturnStatement : public CST {
 	CST* m_value;
 
-	ReturnStatement()
-	    : CST {CSTTag::ReturnStatement} {}
+	ReturnStatement(CST* value)
+	    : CST {CSTTag::ReturnStatement}
+	    , m_value {value} {}
 };
 
 struct IfElseStatement : public CST {
@@ -288,8 +327,11 @@ struct IfElseStatement : public CST {
 	CST* m_body;
 	CST* m_else_body {nullptr}; // can be nullptr
 
-	IfElseStatement()
-	    : CST {CSTTag::IfElseStatement} {}
+	IfElseStatement(CST* condition, CST* body, CST* else_body)
+	    : CST {CSTTag::IfElseStatement}
+	    , m_condition {condition}
+	    , m_body {body}
+	    , m_else_body {else_body} {}
 };
 
 struct ForStatement : public CST {
@@ -298,24 +340,32 @@ struct ForStatement : public CST {
 	CST* m_action;
 	CST* m_body;
 
-	ForStatement()
-	    : CST {CSTTag::ForStatement} {}
+	ForStatement(DeclarationData declaration, CST* condition, CST* action, CST* body)
+	    : CST {CSTTag::ForStatement}
+	    , m_declaration {std::move(declaration)}
+	    , m_condition {condition}
+	    , m_action {action}
+	    , m_body {body} {}
 };
 
 struct WhileStatement : public CST {
 	CST* m_condition;
 	CST* m_body;
 
-	WhileStatement()
-	    : CST {CSTTag::WhileStatement} {}
+	WhileStatement(CST* condition, CST* body)
+	    : CST {CSTTag::WhileStatement}
+	    , m_condition {condition}
+	    , m_body {body} {}
 };
 
 struct TypeTerm : public CST {
 	CST* m_callee;
 	std::vector<CST*> m_args;
 
-	TypeTerm()
-	    : CST {CSTTag::TypeTerm} {}
+	TypeTerm(CST* callee, std::vector<CST*> args)
+	    : CST {CSTTag::TypeTerm}
+	    , m_callee {callee}
+	    , m_args {std::move(args)} {}
 };
 
 // A TypeVar is a name, bound to a type variable of any kind.
@@ -327,8 +377,9 @@ struct TypeVar : public CST {
 		return m_token->m_text.str();
 	}
 
-	TypeVar()
-	    : CST {CSTTag::TypeVar} {}
+	TypeVar(Token const* token)
+	    : CST {CSTTag::TypeVar}
+	    , m_token {token} {}
 };
 
 struct UnionExpression : public CST {
@@ -336,8 +387,10 @@ struct UnionExpression : public CST {
 	std::vector<Identifier> m_constructors;
 	std::vector<CST*> m_types;
 
-	UnionExpression()
-	    : CST {CSTTag::UnionExpression} {}
+	UnionExpression(std::vector<Identifier> constructors, std::vector<CST*> types)
+	    : CST {CSTTag::UnionExpression}
+	    , m_constructors {std::move(constructors)}
+	    , m_types {std::move(types)} {}
 };
 
 struct StructExpression : public CST {
@@ -345,8 +398,10 @@ struct StructExpression : public CST {
 	std::vector<Identifier> m_fields;
 	std::vector<CST*> m_types;
 
-	StructExpression()
-	    : CST {CSTTag::StructExpression} {}
+	StructExpression(std::vector<Identifier> fields, std::vector<CST*> types)
+	    : CST {CSTTag::StructExpression}
+	    , m_fields {std::move(fields)}
+	    , m_types {std::move(types)} {}
 };
 
 void print(CST*, int);

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -205,8 +205,10 @@ struct CallExpression : public CST {
 	CST* m_callee;
 	std::vector<CST*> m_args;
 
-	CallExpression()
-	    : CST {CSTTag::CallExpression} {}
+	CallExpression(CST* callee, std::vector<CST*> args)
+	    : CST {CSTTag::CallExpression}
+	    , m_callee {callee}
+	    , m_args {std::move(args)} {}
 };
 
 struct IndexExpression : public CST {

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -187,8 +187,9 @@ struct Identifier : public CST {
 		return m_token->m_text;
 	}
 
-	Identifier()
-	    : CST {CSTTag::Identifier} {}
+	Identifier(Token const* token)
+	    : CST {CSTTag::Identifier}
+	    , m_token {token} {}
 };
 
 struct BinaryExpression : public CST {
@@ -242,7 +243,7 @@ struct MatchExpression : public CST {
 	};
 
 	// TODO: allow matching on arbitrary expressions
-	Identifier m_matchee;
+	Identifier m_matchee {nullptr};
 	CST* m_type_hint {nullptr};
 	std::vector<CaseData> m_cases;
 

--- a/src/cst_allocator.hpp
+++ b/src/cst_allocator.hpp
@@ -4,6 +4,8 @@
 #include "./utils/polymorphic_dumb_allocator.hpp"
 #include "cst.hpp"
 
+#include <utility>
+
 namespace CST {
 
 struct Allocator {
@@ -16,12 +18,12 @@ struct Allocator {
 	    : m_small(small_size, 4 * 4096)
 	    , m_big {4 * 4096} {}
 
-	template<typename T>
-	T* make() {
+	template<typename T, typename ...Args>
+	T* make(Args&& ...args) {
 		if (small_size < sizeof(T)) {
-			return m_big.make<T>();
+			return m_big.make<T>(std::forward<Args>(args)...);
 		} else {
-			return m_small.make<T>();
+			return m_small.make<T>(std::forward<Args>(args)...);
 		}
 	}
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -555,10 +555,8 @@ Writer<CST::CST*> Parser::parse_terminal() {
 	}
 
 	if (token->m_type == TokenTag::IDENTIFIER) {
-		auto e = m_cst_allocator.make<CST::Identifier>();
-		e->m_token = token;
 		advance_token_cursor();
-		return make_writer(e);
+		return make_writer(m_cst_allocator.make<CST::Identifier>(token));
 	}
 
 	if (token->m_type == TokenTag::STRING) {
@@ -640,10 +638,8 @@ Writer<CST::Identifier*> Parser::parse_term_identifier() {
 	ErrorReport result = {{"Failed to parse identifier"}};
 
 	Token const* token = REQUIRE_WITH(result, TokenTag::IDENTIFIER);
-	auto e = m_cst_allocator.make<CST::Identifier>();
-	e->m_token = token;
 
-	return make_writer(e);
+	return make_writer(m_cst_allocator.make<CST::Identifier>(token));
 }
 
 Writer<CST::Identifier*> Parser::parse_type_identifier() {
@@ -657,10 +653,7 @@ Writer<CST::Identifier*> Parser::parse_type_identifier() {
 		advance_token_cursor();
 	}
 
-	auto e = m_cst_allocator.make<CST::Identifier>();
-	e->m_token = token;
-
-	return make_writer(e);
+	return make_writer(m_cst_allocator.make<CST::Identifier>(token));
 }
 
 Writer<CST::CST*> Parser::parse_array_literal() {
@@ -900,8 +893,7 @@ Writer<CST::CST*> Parser::parse_match_expression() {
 		     expression});
 	}
 
-	CST::Identifier matchee;
-	matchee.m_token = matchee_and_hint.first;
+	CST::Identifier matchee {matchee_and_hint.first};
 
 	auto match = m_cst_allocator.make<CST::MatchExpression>();
 	match->m_matchee = std::move(matchee);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -415,12 +415,8 @@ Writer<CST::CST*> Parser::parse_expression(CST::CST* lhs, int bp) {
 			break;
 
 		if (op->m_type == TokenTag::PAREN_OPEN) {
-			auto args = TRY(parse_argument_list());
-
-			auto e = m_cst_allocator.make<CST::CallExpression>();
-			e->m_callee = lhs;
-			e->m_args = std::move(args);
-			lhs = e;
+			lhs = m_cst_allocator.make<CST::CallExpression>(
+			    lhs, TRY(parse_argument_list()));
 
 			continue;
 		}

--- a/src/utils/polymorphic_block_allocator.hpp
+++ b/src/utils/polymorphic_block_allocator.hpp
@@ -3,6 +3,7 @@
 #include "block_allocator.hpp"
 
 #include <type_traits>
+#include <utility>
 
 #include <cstring>
 
@@ -17,13 +18,13 @@ struct PolymorphicBlockAllocator {
 	PolymorphicBlockAllocator(int bytes_per_slot, int target_bytes_per_block)
 	    : m_allocator {bytes_per_slot, target_bytes_per_block} {}
 
-	template <typename T>
-	T* make() {
+	template <typename T, typename...Args>
+	T* make(Args&& ...args) {
 		static_assert(
 		    std::is_base_of<Base, T>::value, "T must be a subtype of Base");
 
 		auto data = m_allocator.allocate(sizeof(T));
-		return new(data) T();
+		return new(data) T(std::forward<Args>(args)...);
 	}
 
 	~PolymorphicBlockAllocator(){

--- a/src/utils/polymorphic_dumb_allocator.hpp
+++ b/src/utils/polymorphic_dumb_allocator.hpp
@@ -3,6 +3,7 @@
 #include "block_allocator.hpp"
 
 #include <type_traits>
+#include <utility>
 
 #include <cstring>
 
@@ -22,12 +23,12 @@ struct PolymorphicDumbAllocator {
 	PolymorphicDumbAllocator(int target_bytes_per_block)
 	    : m_allocator {8, target_bytes_per_block} {}
 
-	template <typename T>
-	T* make() {
+	template <typename T, typename...Args>
+	T* make(Args&&...args) {
 		static_assert(
 		    std::is_base_of<Base, T>::value, "T must be a subtype of Base");
 		auto storage = m_allocator.allocate(8);
-		auto result = new T;
+		auto result = new T(std::forward<Args>(args)...);
 		memcpy(storage, &result, 8);
 		return result;
 	}


### PR DESCRIPTION
I extended CSTAllocator so that it can take constructor parameters for the objects it creates. I also made all CST nodes take their members through the constructor.

This makes it so that instead of writing this code:

```c++
auto e = m_cst_allocator.make<T>();
e->m_foo = foo;
e->m_bar = bar;
e->m_baz = baz;
return make_writer(e);
```

We can write it like this:

```c++
return make_writer(m_cst_allocator.make<T>(foo, bar, baz));
```

> No need to look into it, but:
>
> - The technique used to implement `CSTAllocator::make` is called "perfect forwarding". [I wrote a blog about it a while a ago (in spanish)](https://sebmestre.blogspot.com/2022/09/sobre-perfect-forwarding-en-c.html)
> - To make it work with arbitrary amounts of parameters, I also used [template parameter packs](https://en.cppreference.com/w/cpp/language/parameter_pack).

Of course, this gets a bit long, so I added a helper on `struct Parser` to help with that:

```c++
return make_writer(make<T>(foo, bar, baz));
```

It might be a good idea to also abstract the call to `make_writer`, not sure... It doesn't feel like allocating an object and wrapping it in a Writer<T> is a concept by itself. (but to be fair, the standard library does have `std::make_unique`, `std::vector::emplace` and others)

-------------

Other that that, I noticed this pattern a lot:

```c++
auto tok = peek();
if (tok->m_type == xxx) {
    ...
} else if (tok->m_type == yyy) {
    advance_token_cursor();
    ...
} // and so on
```

Which I'm pretty sure is a piece of good 'ol premature optimization introduced by yours truly. (`match` and `consume` both call `peek` and, in this case, they'd be peeking on the same token, so we save some peek operations by checking explicitly)

I changed all those to the more readable form:

```c++
if (match(xxx)) {
    ...
} else if (consume(yyy)) {
    ...
} // and so on
```