### PR TITLE
Typesafe cst

### DIFF
--- a/src/convert_ast.cpp
+++ b/src/convert_ast.cpp
@@ -469,21 +469,6 @@ static AST* convert_stmt(CST::CST* cst, Allocator& alloc) {
 #undef DISPATCH
 }
 
-AST* convert_ast(CST::CST* cst, Allocator& alloc) {
-#define DISPATCH(type)                                                         \
-	case CSTTag::type:                                                         \
-		return convert(static_cast<CST::type*>(cst), alloc)
-
-	switch (cst->type()) {
-		DISPATCH(Program);
-	default:
-		return convert_stmt(cst, alloc);
-	}
-
-#undef DISPATCH
-}
-
-
 Program* convert_program(CST::Program* cst, Allocator& alloc) {
 	return convert(static_cast<CST::Program*>(cst), alloc);
 }

--- a/src/convert_ast.cpp
+++ b/src/convert_ast.cpp
@@ -172,7 +172,7 @@ static Declaration* convert(CST::BlockFuncDeclaration* cst, Allocator& alloc) {
 	return ast;
 }
 
-static AST* convert(CST::Program* cst, Allocator& alloc) {
+static Program* convert(CST::Program* cst, Allocator& alloc) {
 	auto ast = alloc.make<Program>();
 
 	for (auto& declaration : cst->m_declarations) {
@@ -479,6 +479,11 @@ AST* convert_ast(CST::CST* cst, Allocator& alloc) {
 	}
 
 #undef DISPATCH
+}
+
+
+Program* convert_program(CST::Program* cst, Allocator& alloc) {
+	return convert(static_cast<CST::Program*>(cst), alloc);
 }
 
 } // namespace AST

--- a/src/convert_ast.cpp
+++ b/src/convert_ast.cpp
@@ -7,8 +7,6 @@
 
 namespace AST {
 
-static Expr* convert_expr(CST::CST* cst, Allocator& alloc);
-
 static SequenceExpression* convert_and_wrap_in_seq(CST::Block* cst, Allocator& alloc) {
 	auto block = static_cast<Block*>(convert_ast(cst, alloc));
 	auto seq_expr = alloc.make<SequenceExpression>();
@@ -408,7 +406,7 @@ static TypeTerm* convert(CST::TypeTerm* cst, Allocator& alloc) {
 	return ast;
 }
 
-static Expr* convert_expr(CST::CST* cst, Allocator& alloc) {
+Expr* convert_expr(CST::CST* cst, Allocator& alloc) {
 #define DISPATCH(type)                                                         \
 	case CSTTag::type:                                                         \
 		return convert(static_cast<CST::type*>(cst), alloc)
@@ -438,7 +436,7 @@ static Expr* convert_expr(CST::CST* cst, Allocator& alloc) {
 		DISPATCH(TypeTerm);
 	}
 
-	Log::fatal() << "(internal) CST type not handled in convert_ast: "
+	Log::fatal() << "(internal) CST type not handled in convert_expr: "
 	             << cst_string[(int)cst->type()];
 
 #undef DISPATCH

--- a/src/convert_ast.cpp
+++ b/src/convert_ast.cpp
@@ -7,7 +7,7 @@
 
 namespace AST {
 
-static AST* convert_stmt(CST::CST* cst, Allocator& alloc);
+static AST* convert_stmt(CST::Stmt* cst, Allocator& alloc);
 
 static SequenceExpression* convert_and_wrap_in_seq(CST::Block* cst, Allocator& alloc) {
 	auto block = static_cast<Block*>(convert_stmt(cst, alloc));
@@ -408,7 +408,7 @@ static TypeTerm* convert(CST::TypeTerm* cst, Allocator& alloc) {
 	return ast;
 }
 
-Expr* convert_expr(CST::CST* cst, Allocator& alloc) {
+Expr* convert_expr(CST::Expr* cst, Allocator& alloc) {
 #define DISPATCH(type)                                                         \
 	case CSTTag::type:                                                         \
 		return convert(static_cast<CST::type*>(cst), alloc)
@@ -444,7 +444,7 @@ Expr* convert_expr(CST::CST* cst, Allocator& alloc) {
 #undef DISPATCH
 }
 
-static AST* convert_stmt(CST::CST* cst, Allocator& alloc) {
+static AST* convert_stmt(CST::Stmt* cst, Allocator& alloc) {
 #define DISPATCH(type)                                                         \
 	case CSTTag::type:                                                         \
 		return convert(static_cast<CST::type*>(cst), alloc)

--- a/src/convert_ast.cpp
+++ b/src/convert_ast.cpp
@@ -286,6 +286,8 @@ static SequenceExpression* convert(CST::SequenceExpression* cst, Allocator& allo
 	return result;
 }
 
+// Statements
+
 static Block* convert(CST::Block* cst, Allocator& alloc) {
 	auto ast = alloc.make<Block>();
 
@@ -358,6 +360,12 @@ static WhileStatement* convert(CST::WhileStatement* cst, Allocator& alloc) {
 
 	return ast;
 }
+
+static AST* convert(CST::ExpressionStatement* cst, Allocator& alloc) {
+	return convert_expr(cst->m_expression, alloc);
+}
+
+// Types
 
 static UnionExpression* convert(CST::UnionExpression* cst, Allocator& alloc) {
 	auto ast = alloc.make<UnionExpression>();
@@ -448,6 +456,7 @@ static AST* convert_stmt(CST::CST* cst, Allocator& alloc) {
 		DISPATCH(IfElseStatement);
 		DISPATCH(ForStatement);
 		DISPATCH(WhileStatement);
+		DISPATCH(ExpressionStatement);
 
 		DISPATCH(PlainDeclaration);
 		DISPATCH(FuncDeclaration);

--- a/src/convert_ast.hpp
+++ b/src/convert_ast.hpp
@@ -7,8 +7,10 @@ struct CST;
 namespace AST {
 
 struct AST;
+struct Expr;
 struct Allocator;
 
 AST* convert_ast(CST::CST*, Allocator& alloc);
+Expr* convert_expr(CST::CST* cst, Allocator& alloc);
 
 }

--- a/src/convert_ast.hpp
+++ b/src/convert_ast.hpp
@@ -12,8 +12,8 @@ struct Expr;
 struct Program;
 struct Allocator;
 
-AST* convert_ast(CST::CST*, Allocator& alloc);
 Program* convert_program(CST::Program*, Allocator& alloc);
+
 Expr* convert_expr(CST::CST* cst, Allocator& alloc);
 
 }

--- a/src/convert_ast.hpp
+++ b/src/convert_ast.hpp
@@ -2,15 +2,18 @@
 
 namespace CST {
 struct CST;
+struct Program;
 }
 
 namespace AST {
 
 struct AST;
 struct Expr;
+struct Program;
 struct Allocator;
 
 AST* convert_ast(CST::CST*, Allocator& alloc);
+Program* convert_program(CST::Program*, Allocator& alloc);
 Expr* convert_expr(CST::CST* cst, Allocator& alloc);
 
 }

--- a/src/convert_ast.hpp
+++ b/src/convert_ast.hpp
@@ -3,6 +3,7 @@
 namespace CST {
 struct CST;
 struct Program;
+struct Expr;
 }
 
 namespace AST {
@@ -14,6 +15,6 @@ struct Allocator;
 
 Program* convert_program(CST::Program*, Allocator& alloc);
 
-Expr* convert_expr(CST::CST* cst, Allocator& alloc);
+Expr* convert_expr(CST::Expr* cst, Allocator& alloc);
 
 }

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -374,6 +374,14 @@ struct WhileStatement : public Stmt {
 	    , m_body {body} {}
 };
 
+struct ExpressionStatement : public Stmt {
+	CST* m_expression;
+
+	ExpressionStatement(CST* expression)
+	    : Stmt {CSTTag::ExpressionStatement}
+	    , m_expression {expression} {}
+};
+
 // Type language
 
 struct TypeTerm : public CST {

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -41,8 +41,8 @@ struct Declaration;
 
 struct DeclarationData {
 	Token const* m_identifier_token;
-	CST* m_type_hint {nullptr};  // can be nullptr
-	CST* m_value {nullptr}; // can be nullptr
+	Expr* m_type_hint {nullptr};  // can be nullptr
+	Expr* m_value {nullptr}; // can be nullptr
 
 	InternedString const& identifier() const {
 		return m_identifier_token->m_text;
@@ -125,9 +125,9 @@ struct NullLiteral : public Expr {
 };
 
 struct ArrayLiteral : public Expr {
-	std::vector<CST*> m_elements;
+	std::vector<Expr*> m_elements;
 
-	ArrayLiteral(std::vector<CST*> elements)
+	ArrayLiteral(std::vector<Expr*> elements)
 	    : Expr {CSTTag::ArrayLiteral}
 	    , m_elements {std::move(elements)} {}
 };
@@ -143,10 +143,10 @@ struct BlockFunctionLiteral : public Expr {
 };
 
 struct FunctionLiteral : public Expr {
-	CST* m_body;
+	Expr* m_body;
 	FuncParameters m_args;
 
-	FunctionLiteral(CST* body, FuncParameters args)
+	FunctionLiteral(Expr* body, FuncParameters args)
 	    : Expr {CSTTag::FunctionLiteral}
 	    , m_body {body}
 	    , m_args {std::move(args)} {}
@@ -166,10 +166,10 @@ struct Identifier : public Expr {
 
 struct BinaryExpression : public Expr {
 	Token const* m_op_token;
-	CST* m_lhs;
-	CST* m_rhs;
+	Expr* m_lhs;
+	Expr* m_rhs;
 
-	BinaryExpression(Token const* op_token, CST* lhs, CST* rhs)
+	BinaryExpression(Token const* op_token, Expr* lhs, Expr* rhs)
 	    : Expr {CSTTag::BinaryExpression}
 	    , m_op_token {op_token}
 	    , m_lhs {lhs}
@@ -177,41 +177,41 @@ struct BinaryExpression : public Expr {
 };
 
 struct CallExpression : public Expr {
-	CST* m_callee;
-	std::vector<CST*> m_args;
+	Expr* m_callee;
+	std::vector<Expr*> m_args;
 
-	CallExpression(CST* callee, std::vector<CST*> args)
+	CallExpression(Expr* callee, std::vector<Expr*> args)
 	    : Expr {CSTTag::CallExpression}
 	    , m_callee {callee}
 	    , m_args {std::move(args)} {}
 };
 
 struct IndexExpression : public Expr {
-	CST* m_callee;
-	CST* m_index;
+	Expr* m_callee;
+	Expr* m_index;
 
-	IndexExpression(CST* callee, CST* index)
+	IndexExpression(Expr* callee, Expr* index)
 	    : Expr {CSTTag::IndexExpression}
 	    , m_callee {callee}
 	    , m_index {index} {}
 };
 
 struct AccessExpression : public Expr {
-	CST* m_record;
+	Expr* m_record;
 	Token const* m_member;
 
-	AccessExpression(CST* record, Token const* member)
+	AccessExpression(Expr* record, Token const* member)
 	    : Expr {CSTTag::AccessExpression}
 	    , m_record {record}
 	    , m_member {member} {}
 };
 
 struct TernaryExpression : public Expr {
-	CST* m_condition;
-	CST* m_then_expr;
-	CST* m_else_expr;
+	Expr* m_condition;
+	Expr* m_then_expr;
+	Expr* m_else_expr;
 
-	TernaryExpression(CST* condition, CST* then_expr, CST* else_expr)
+	TernaryExpression(Expr* condition, Expr* then_expr, Expr* else_expr)
 	    : Expr {CSTTag::TernaryExpression}
 	    , m_condition {condition}
 	    , m_then_expr {then_expr}
@@ -222,16 +222,16 @@ struct MatchExpression : public Expr {
 	struct CaseData {
 		Token const* m_name;
 		Token const* m_identifier;
-		CST* m_type_hint {nullptr};
-		CST* m_expression;
+		Expr* m_type_hint {nullptr};
+		Expr* m_expression;
 	};
 
 	// TODO: allow matching on arbitrary expressions
 	Identifier m_matchee {nullptr};
-	CST* m_type_hint {nullptr};
+	Expr* m_type_hint {nullptr};
 	std::vector<CaseData> m_cases;
 
-	MatchExpression(Identifier matchee, CST* type_hint, std::vector<CaseData> cases)
+	MatchExpression(Identifier matchee, Expr* type_hint, std::vector<CaseData> cases)
 	    : Expr {CSTTag::MatchExpression}
 	    , m_matchee {matchee}
 	    , m_type_hint {type_hint}
@@ -239,10 +239,10 @@ struct MatchExpression : public Expr {
 };
 
 struct ConstructorExpression : public Expr {
-	CST* m_constructor;
-	std::vector<CST*> m_args;
+	Expr* m_constructor;
+	std::vector<Expr*> m_args;
 
-	ConstructorExpression(CST* constructor, std::vector<CST*> args)
+	ConstructorExpression(Expr* constructor, std::vector<Expr*> args)
 	    : Expr {CSTTag::ConstructorExpression}
 	    , m_constructor {constructor}
 	    , m_args {std::move(args)} {}
@@ -285,7 +285,7 @@ struct PlainDeclaration : public Declaration {
 struct FuncDeclaration : public Declaration {
 	Token const* m_identifier;
 	FuncParameters m_args;
-	CST* m_body;
+	Expr* m_body;
 
 	InternedString const& identifier() const {
 		return m_identifier->m_text;
@@ -295,7 +295,7 @@ struct FuncDeclaration : public Declaration {
 		return identifier();
 	}
 
-	FuncDeclaration(Token const* identifier, FuncParameters args, CST* body)
+	FuncDeclaration(Token const* identifier, FuncParameters args, Expr* body)
 	    : Declaration {CSTTag::FuncDeclaration}
 	    , m_identifier {identifier}
 	    , m_args {std::move(args)}
@@ -331,19 +331,19 @@ struct Block : public Stmt {
 };
 
 struct ReturnStatement : public Stmt {
-	CST* m_value;
+	Expr* m_value;
 
-	ReturnStatement(CST* value)
+	ReturnStatement(Expr* value)
 	    : Stmt {CSTTag::ReturnStatement}
 	    , m_value {value} {}
 };
 
 struct IfElseStatement : public Stmt {
-	CST* m_condition;
+	Expr* m_condition;
 	Stmt* m_body;
 	Stmt* m_else_body {nullptr}; // can be nullptr
 
-	IfElseStatement(CST* condition, Stmt* body, Stmt* else_body)
+	IfElseStatement(Expr* condition, Stmt* body, Stmt* else_body)
 	    : Stmt {CSTTag::IfElseStatement}
 	    , m_condition {condition}
 	    , m_body {body}
@@ -352,11 +352,11 @@ struct IfElseStatement : public Stmt {
 
 struct ForStatement : public Stmt {
 	DeclarationData m_declaration;
-	CST* m_condition;
-	CST* m_action;
+	Expr* m_condition;
+	Expr* m_action;
 	Stmt* m_body;
 
-	ForStatement(DeclarationData declaration, CST* condition, CST* action, Stmt* body)
+	ForStatement(DeclarationData declaration, Expr* condition, Expr* action, Stmt* body)
 	    : Stmt {CSTTag::ForStatement}
 	    , m_declaration {std::move(declaration)}
 	    , m_condition {condition}
@@ -365,19 +365,19 @@ struct ForStatement : public Stmt {
 };
 
 struct WhileStatement : public Stmt {
-	CST* m_condition;
+	Expr* m_condition;
 	Stmt* m_body;
 
-	WhileStatement(CST* condition, Stmt* body)
+	WhileStatement(Expr* condition, Stmt* body)
 	    : Stmt {CSTTag::WhileStatement}
 	    , m_condition {condition}
 	    , m_body {body} {}
 };
 
 struct ExpressionStatement : public Stmt {
-	CST* m_expression;
+	Expr* m_expression;
 
-	ExpressionStatement(CST* expression)
+	ExpressionStatement(Expr* expression)
 	    : Stmt {CSTTag::ExpressionStatement}
 	    , m_expression {expression} {}
 };
@@ -385,10 +385,10 @@ struct ExpressionStatement : public Stmt {
 // Type language
 
 struct TypeTerm : public Expr {
-	CST* m_callee;
-	std::vector<CST*> m_args;
+	Expr* m_callee;
+	std::vector<Expr*> m_args;
 
-	TypeTerm(CST* callee, std::vector<CST*> args)
+	TypeTerm(Expr* callee, std::vector<Expr*> args)
 	    : Expr {CSTTag::TypeTerm}
 	    , m_callee {callee}
 	    , m_args {std::move(args)} {}
@@ -411,9 +411,9 @@ struct TypeVar : public Expr {
 struct UnionExpression : public Expr {
 	// TODO: better storage?
 	std::vector<Identifier> m_constructors;
-	std::vector<CST*> m_types;
+	std::vector<Expr*> m_types;
 
-	UnionExpression(std::vector<Identifier> constructors, std::vector<CST*> types)
+	UnionExpression(std::vector<Identifier> constructors, std::vector<Expr*> types)
 	    : Expr {CSTTag::UnionExpression}
 	    , m_constructors {std::move(constructors)}
 	    , m_types {std::move(types)} {}
@@ -422,9 +422,9 @@ struct UnionExpression : public Expr {
 struct StructExpression : public Expr {
 	// TODO: better storage?
 	std::vector<Identifier> m_fields;
-	std::vector<CST*> m_types;
+	std::vector<Expr*> m_types;
 
-	StructExpression(std::vector<Identifier> fields, std::vector<CST*> types)
+	StructExpression(std::vector<Identifier> fields, std::vector<Expr*> types)
 	    : Expr {CSTTag::StructExpression}
 	    , m_fields {std::move(fields)}
 	    , m_types {std::move(types)} {}

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -25,6 +25,16 @@ struct CST {
 	virtual ~CST() = default;
 };
 
+struct Expr : public CST {
+	Expr(CSTTag tag)
+	    : CST {tag} {}
+};
+
+struct Stmt : public CST {
+	Stmt(CSTTag tag)
+	    : CST {tag} {}
+};
+
 struct Block;
 
 struct DeclarationData {

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -49,12 +49,12 @@ struct DeclarationData {
 
 using FuncParameters = std::vector<DeclarationData>;
 
-struct Declaration : public CST {
+struct Declaration : public Stmt {
 	// This function is very cold -- it's ok to use virtuals
 	virtual InternedString const& identifier_virtual() const = 0;
 
 	Declaration(CSTTag tag)
-		: CST {tag} {}
+		: Stmt {tag} {}
 };
 
 struct PlainDeclaration : public Declaration {
@@ -316,54 +316,54 @@ struct SequenceExpression : public CST {
 	    , m_body {body} {}
 };
 
-struct Block : public CST {
+struct Block : public Stmt {
 	std::vector<CST*> m_body;
 
 	Block(std::vector<CST*> body)
-	    : CST {CSTTag::Block}
+	    : Stmt {CSTTag::Block}
 	    , m_body {body} {}
 };
 
-struct ReturnStatement : public CST {
+struct ReturnStatement : public Stmt {
 	CST* m_value;
 
 	ReturnStatement(CST* value)
-	    : CST {CSTTag::ReturnStatement}
+	    : Stmt {CSTTag::ReturnStatement}
 	    , m_value {value} {}
 };
 
-struct IfElseStatement : public CST {
+struct IfElseStatement : public Stmt {
 	CST* m_condition;
 	CST* m_body;
 	CST* m_else_body {nullptr}; // can be nullptr
 
 	IfElseStatement(CST* condition, CST* body, CST* else_body)
-	    : CST {CSTTag::IfElseStatement}
+	    : Stmt {CSTTag::IfElseStatement}
 	    , m_condition {condition}
 	    , m_body {body}
 	    , m_else_body {else_body} {}
 };
 
-struct ForStatement : public CST {
+struct ForStatement : public Stmt {
 	DeclarationData m_declaration;
 	CST* m_condition;
 	CST* m_action;
 	CST* m_body;
 
 	ForStatement(DeclarationData declaration, CST* condition, CST* action, CST* body)
-	    : CST {CSTTag::ForStatement}
+	    : Stmt {CSTTag::ForStatement}
 	    , m_declaration {std::move(declaration)}
 	    , m_condition {condition}
 	    , m_action {action}
 	    , m_body {body} {}
 };
 
-struct WhileStatement : public CST {
+struct WhileStatement : public Stmt {
 	CST* m_condition;
 	CST* m_body;
 
 	WhileStatement(CST* condition, CST* body)
-	    : CST {CSTTag::WhileStatement}
+	    : Stmt {CSTTag::WhileStatement}
 	    , m_condition {condition}
 	    , m_body {body} {}
 };

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -62,7 +62,7 @@ struct Program : public CST {
 
 // Expression language
 
-struct IntegerLiteral : public CST {
+struct IntegerLiteral : public Expr {
 	bool m_negative {false};
 	Token const* m_sign {nullptr};
 	Token const* m_token;
@@ -72,13 +72,13 @@ struct IntegerLiteral : public CST {
 	}
 
 	IntegerLiteral(bool negative, Token const* sign, Token const* token)
-	    : CST {CSTTag::IntegerLiteral}
+	    : Expr {CSTTag::IntegerLiteral}
 	    , m_negative {negative}
 	    , m_sign {sign}
 	    , m_token {token} {}
 };
 
-struct NumberLiteral : public CST {
+struct NumberLiteral : public Expr {
 	bool m_negative {false};
 	Token const* m_sign {nullptr};
 	Token const* m_token;
@@ -88,13 +88,13 @@ struct NumberLiteral : public CST {
 	}
 
 	NumberLiteral(bool negative, Token const* sign, Token const* token)
-	    : CST {CSTTag::NumberLiteral}
+	    : Expr {CSTTag::NumberLiteral}
 	    , m_negative {negative}
 	    , m_sign {sign}
 	    , m_token {token} {}
 };
 
-struct StringLiteral : public CST {
+struct StringLiteral : public Expr {
 	Token const* m_token;
 
 	std::string const& text() {
@@ -102,11 +102,11 @@ struct StringLiteral : public CST {
 	}
 
 	StringLiteral(Token const* token)
-	    : CST {CSTTag::StringLiteral}
+	    : Expr {CSTTag::StringLiteral}
 	    , m_token {token} {}
 };
 
-struct BooleanLiteral : public CST {
+struct BooleanLiteral : public Expr {
 	Token const* m_token;
 
 	std::string const& text() {
@@ -114,45 +114,45 @@ struct BooleanLiteral : public CST {
 	}
 
 	BooleanLiteral(Token const* token)
-	    : CST {CSTTag::BooleanLiteral}
+	    : Expr {CSTTag::BooleanLiteral}
 	    , m_token {token} {}
 };
 
-struct NullLiteral : public CST {
+struct NullLiteral : public Expr {
 
 	NullLiteral()
-	    : CST {CSTTag::NullLiteral} {}
+	    : Expr {CSTTag::NullLiteral} {}
 };
 
-struct ArrayLiteral : public CST {
+struct ArrayLiteral : public Expr {
 	std::vector<CST*> m_elements;
 
 	ArrayLiteral(std::vector<CST*> elements)
-	    : CST {CSTTag::ArrayLiteral}
+	    : Expr {CSTTag::ArrayLiteral}
 	    , m_elements {std::move(elements)} {}
 };
 
-struct BlockFunctionLiteral : public CST {
+struct BlockFunctionLiteral : public Expr {
 	Block* m_body;
 	FuncParameters m_args;
 
 	BlockFunctionLiteral(Block* body, FuncParameters args)
-	    : CST {CSTTag::BlockFunctionLiteral}
+	    : Expr {CSTTag::BlockFunctionLiteral}
 	    , m_body {body}
 	    , m_args {std::move(args)} {}
 };
 
-struct FunctionLiteral : public CST {
+struct FunctionLiteral : public Expr {
 	CST* m_body;
 	FuncParameters m_args;
 
 	FunctionLiteral(CST* body, FuncParameters args)
-	    : CST {CSTTag::FunctionLiteral}
+	    : Expr {CSTTag::FunctionLiteral}
 	    , m_body {body}
 	    , m_args {std::move(args)} {}
 };
 
-struct Identifier : public CST {
+struct Identifier : public Expr {
 	Token const* m_token;
 
 	InternedString const& text() {
@@ -160,65 +160,65 @@ struct Identifier : public CST {
 	}
 
 	Identifier(Token const* token)
-	    : CST {CSTTag::Identifier}
+	    : Expr {CSTTag::Identifier}
 	    , m_token {token} {}
 };
 
-struct BinaryExpression : public CST {
+struct BinaryExpression : public Expr {
 	Token const* m_op_token;
 	CST* m_lhs;
 	CST* m_rhs;
 
 	BinaryExpression(Token const* op_token, CST* lhs, CST* rhs)
-	    : CST {CSTTag::BinaryExpression}
+	    : Expr {CSTTag::BinaryExpression}
 	    , m_op_token {op_token}
 	    , m_lhs {lhs}
 	    , m_rhs {rhs} {}
 };
 
-struct CallExpression : public CST {
+struct CallExpression : public Expr {
 	CST* m_callee;
 	std::vector<CST*> m_args;
 
 	CallExpression(CST* callee, std::vector<CST*> args)
-	    : CST {CSTTag::CallExpression}
+	    : Expr {CSTTag::CallExpression}
 	    , m_callee {callee}
 	    , m_args {std::move(args)} {}
 };
 
-struct IndexExpression : public CST {
+struct IndexExpression : public Expr {
 	CST* m_callee;
 	CST* m_index;
 
 	IndexExpression(CST* callee, CST* index)
-	    : CST {CSTTag::IndexExpression}
+	    : Expr {CSTTag::IndexExpression}
 	    , m_callee {callee}
 	    , m_index {index} {}
 };
 
-struct AccessExpression : public CST {
+struct AccessExpression : public Expr {
 	CST* m_record;
 	Token const* m_member;
 
 	AccessExpression(CST* record, Token const* member)
-	    : CST {CSTTag::AccessExpression}
+	    : Expr {CSTTag::AccessExpression}
 	    , m_record {record}
 	    , m_member {member} {}
 };
 
-struct TernaryExpression : public CST {
+struct TernaryExpression : public Expr {
 	CST* m_condition;
 	CST* m_then_expr;
 	CST* m_else_expr;
 
 	TernaryExpression(CST* condition, CST* then_expr, CST* else_expr)
-	    : CST {CSTTag::TernaryExpression}
+	    : Expr {CSTTag::TernaryExpression}
 	    , m_condition {condition}
 	    , m_then_expr {then_expr}
 	    , m_else_expr {else_expr} {}
 };
 
-struct MatchExpression : public CST {
+struct MatchExpression : public Expr {
 	struct CaseData {
 		Token const* m_name;
 		Token const* m_identifier;
@@ -232,27 +232,27 @@ struct MatchExpression : public CST {
 	std::vector<CaseData> m_cases;
 
 	MatchExpression(Identifier matchee, CST* type_hint, std::vector<CaseData> cases)
-	    : CST {CSTTag::MatchExpression}
+	    : Expr {CSTTag::MatchExpression}
 	    , m_matchee {matchee}
 	    , m_type_hint {type_hint}
 	    , m_cases {cases} {}
 };
 
-struct ConstructorExpression : public CST {
+struct ConstructorExpression : public Expr {
 	CST* m_constructor;
 	std::vector<CST*> m_args;
 
 	ConstructorExpression(CST* constructor, std::vector<CST*> args)
-	    : CST {CSTTag::ConstructorExpression}
+	    : Expr {CSTTag::ConstructorExpression}
 	    , m_constructor {constructor}
 	    , m_args {std::move(args)} {}
 };
 
-struct SequenceExpression : public CST {
+struct SequenceExpression : public Expr {
 	Block* m_body;
 
 	SequenceExpression(Block* body)
-	    : CST {CSTTag::SequenceExpression}
+	    : Expr {CSTTag::SequenceExpression}
 	    , m_body {body} {}
 };
 
@@ -384,19 +384,19 @@ struct ExpressionStatement : public Stmt {
 
 // Type language
 
-struct TypeTerm : public CST {
+struct TypeTerm : public Expr {
 	CST* m_callee;
 	std::vector<CST*> m_args;
 
 	TypeTerm(CST* callee, std::vector<CST*> args)
-	    : CST {CSTTag::TypeTerm}
+	    : Expr {CSTTag::TypeTerm}
 	    , m_callee {callee}
 	    , m_args {std::move(args)} {}
 };
 
 // A TypeVar is a name, bound to a type variable of any kind.
 // e.g. a type function, a polytype or a monotype
-struct TypeVar : public CST {
+struct TypeVar : public Expr {
 	Token const* m_token;
 
 	std::string const& text() {
@@ -404,28 +404,28 @@ struct TypeVar : public CST {
 	}
 
 	TypeVar(Token const* token)
-	    : CST {CSTTag::TypeVar}
+	    : Expr {CSTTag::TypeVar}
 	    , m_token {token} {}
 };
 
-struct UnionExpression : public CST {
+struct UnionExpression : public Expr {
 	// TODO: better storage?
 	std::vector<Identifier> m_constructors;
 	std::vector<CST*> m_types;
 
 	UnionExpression(std::vector<Identifier> constructors, std::vector<CST*> types)
-	    : CST {CSTTag::UnionExpression}
+	    : Expr {CSTTag::UnionExpression}
 	    , m_constructors {std::move(constructors)}
 	    , m_types {std::move(types)} {}
 };
 
-struct StructExpression : public CST {
+struct StructExpression : public Expr {
 	// TODO: better storage?
 	std::vector<Identifier> m_fields;
 	std::vector<CST*> m_types;
 
 	StructExpression(std::vector<Identifier> fields, std::vector<CST*> types)
-	    : CST {CSTTag::StructExpression}
+	    : Expr {CSTTag::StructExpression}
 	    , m_fields {std::move(fields)}
 	    , m_types {std::move(types)} {}
 };

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -323,9 +323,9 @@ struct BlockFuncDeclaration : public Declaration {
 };
 
 struct Block : public Stmt {
-	std::vector<CST*> m_body;
+	std::vector<Stmt*> m_body;
 
-	Block(std::vector<CST*> body)
+	Block(std::vector<Stmt*> body)
 	    : Stmt {CSTTag::Block}
 	    , m_body {body} {}
 };
@@ -340,10 +340,10 @@ struct ReturnStatement : public Stmt {
 
 struct IfElseStatement : public Stmt {
 	CST* m_condition;
-	CST* m_body;
-	CST* m_else_body {nullptr}; // can be nullptr
+	Stmt* m_body;
+	Stmt* m_else_body {nullptr}; // can be nullptr
 
-	IfElseStatement(CST* condition, CST* body, CST* else_body)
+	IfElseStatement(CST* condition, Stmt* body, Stmt* else_body)
 	    : Stmt {CSTTag::IfElseStatement}
 	    , m_condition {condition}
 	    , m_body {body}
@@ -354,9 +354,9 @@ struct ForStatement : public Stmt {
 	DeclarationData m_declaration;
 	CST* m_condition;
 	CST* m_action;
-	CST* m_body;
+	Stmt* m_body;
 
-	ForStatement(DeclarationData declaration, CST* condition, CST* action, CST* body)
+	ForStatement(DeclarationData declaration, CST* condition, CST* action, Stmt* body)
 	    : Stmt {CSTTag::ForStatement}
 	    , m_declaration {std::move(declaration)}
 	    , m_condition {condition}
@@ -366,9 +366,9 @@ struct ForStatement : public Stmt {
 
 struct WhileStatement : public Stmt {
 	CST* m_condition;
-	CST* m_body;
+	Stmt* m_body;
 
-	WhileStatement(CST* condition, CST* body)
+	WhileStatement(CST* condition, Stmt* body)
 	    : Stmt {CSTTag::WhileStatement}
 	    , m_condition {condition}
 	    , m_body {body} {}

--- a/src/cst.hpp
+++ b/src/cst.hpp
@@ -37,6 +37,8 @@ struct Stmt : public CST {
 
 struct Block;
 
+struct Declaration;
+
 struct DeclarationData {
 	Token const* m_identifier_token;
 	CST* m_type_hint {nullptr};  // can be nullptr
@@ -49,69 +51,6 @@ struct DeclarationData {
 
 using FuncParameters = std::vector<DeclarationData>;
 
-struct Declaration : public Stmt {
-	// This function is very cold -- it's ok to use virtuals
-	virtual InternedString const& identifier_virtual() const = 0;
-
-	Declaration(CSTTag tag)
-		: Stmt {tag} {}
-};
-
-struct PlainDeclaration : public Declaration {
-	DeclarationData m_data;
-
-	InternedString const& identifier() const {
-		return m_data.identifier();
-	}
-
-	InternedString const& identifier_virtual() const override {
-		return identifier();
-	}
-
-	PlainDeclaration(DeclarationData data)
-	    : Declaration {CSTTag::PlainDeclaration}
-	    , m_data {std::move(data)} {}
-};
-
-struct FuncDeclaration : public Declaration {
-	Token const* m_identifier;
-	FuncParameters m_args;
-	CST* m_body;
-
-	InternedString const& identifier() const {
-		return m_identifier->m_text;
-	}
-
-	InternedString const& identifier_virtual() const override {
-		return identifier();
-	}
-
-	FuncDeclaration(Token const* identifier, FuncParameters args, CST* body)
-	    : Declaration {CSTTag::FuncDeclaration}
-	    , m_identifier {identifier}
-	    , m_args {std::move(args)}
-	    , m_body {body} {}
-};
-
-struct BlockFuncDeclaration : public Declaration {
-	Token const* m_identifier;
-	FuncParameters m_args;
-	Block* m_body;
-
-	InternedString const& identifier() const {
-		return m_identifier->m_text;
-	}
-
-	InternedString const& identifier_virtual() const override {
-		return identifier();
-	}
-
-	BlockFuncDeclaration(Token const* identifier, FuncParameters args, Block* body)
-	    : Declaration {CSTTag::BlockFuncDeclaration}
-	    , m_identifier {identifier}
-	    , m_args {std::move(args)}
-	    , m_body {body} {}
-};
 
 struct Program : public CST {
 	std::vector<Declaration*> m_declarations;
@@ -120,6 +59,8 @@ struct Program : public CST {
 	    : CST {CSTTag::Program}
 	    , m_declarations {std::move(declarations)} {}
 };
+
+// Expression language
 
 struct IntegerLiteral : public CST {
 	bool m_negative {false};
@@ -307,12 +248,77 @@ struct ConstructorExpression : public CST {
 	    , m_args {std::move(args)} {}
 };
 
-
 struct SequenceExpression : public CST {
 	Block* m_body;
 
 	SequenceExpression(Block* body)
 	    : CST {CSTTag::SequenceExpression}
+	    , m_body {body} {}
+};
+
+// Statement language
+
+struct Declaration : public Stmt {
+	// This function is very cold -- it's ok to use virtuals
+	virtual InternedString const& identifier_virtual() const = 0;
+
+	Declaration(CSTTag tag)
+		: Stmt {tag} {}
+};
+
+struct PlainDeclaration : public Declaration {
+	DeclarationData m_data;
+
+	InternedString const& identifier() const {
+		return m_data.identifier();
+	}
+
+	InternedString const& identifier_virtual() const override {
+		return identifier();
+	}
+
+	PlainDeclaration(DeclarationData data)
+	    : Declaration {CSTTag::PlainDeclaration}
+	    , m_data {std::move(data)} {}
+};
+
+struct FuncDeclaration : public Declaration {
+	Token const* m_identifier;
+	FuncParameters m_args;
+	CST* m_body;
+
+	InternedString const& identifier() const {
+		return m_identifier->m_text;
+	}
+
+	InternedString const& identifier_virtual() const override {
+		return identifier();
+	}
+
+	FuncDeclaration(Token const* identifier, FuncParameters args, CST* body)
+	    : Declaration {CSTTag::FuncDeclaration}
+	    , m_identifier {identifier}
+	    , m_args {std::move(args)}
+	    , m_body {body} {}
+};
+
+struct BlockFuncDeclaration : public Declaration {
+	Token const* m_identifier;
+	FuncParameters m_args;
+	Block* m_body;
+
+	InternedString const& identifier() const {
+		return m_identifier->m_text;
+	}
+
+	InternedString const& identifier_virtual() const override {
+		return identifier();
+	}
+
+	BlockFuncDeclaration(Token const* identifier, FuncParameters args, Block* body)
+	    : Declaration {CSTTag::BlockFuncDeclaration}
+	    , m_identifier {identifier}
+	    , m_args {std::move(args)}
 	    , m_body {body} {}
 };
 
@@ -367,6 +373,8 @@ struct WhileStatement : public Stmt {
 	    , m_condition {condition}
 	    , m_body {body} {}
 };
+
+// Type language
 
 struct TypeTerm : public CST {
 	CST* m_callee;

--- a/src/cst_tag.hpp
+++ b/src/cst_tag.hpp
@@ -10,10 +10,8 @@
 	X(BlockFunctionLiteral)                                                    \
 	X(FunctionLiteral)                                                         \
                                                                                \
-	X(Program)                                                         \
-	X(PlainDeclaration)                                                        \
-	X(FuncDeclaration)                                                         \
-	X(BlockFuncDeclaration)                                                    \
+	X(Program)                                                                 \
+                                                                               \
 	X(Identifier)                                                              \
 	X(BinaryExpression)                                                        \
 	X(CallExpression)                                                          \
@@ -21,14 +19,18 @@
 	X(AccessExpression)                                                        \
 	X(MatchExpression)                                                         \
 	X(ConstructorExpression)                                                   \
+	X(TernaryExpression)                                                       \
 	X(SequenceExpression)                                                      \
                                                                                \
+	X(PlainDeclaration)                                                        \
+	X(FuncDeclaration)                                                         \
+	X(BlockFuncDeclaration)                                                    \
 	X(Block)                                                                   \
 	X(ReturnStatement)                                                         \
 	X(IfElseStatement)                                                         \
-	X(TernaryExpression)                                                       \
 	X(ForStatement)                                                            \
 	X(WhileStatement)                                                          \
+	X(ExpressionStatement)                                                     \
                                                                                \
 	X(TypeTerm)                                                                \
 	X(TypeVar)                                                                 \

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -104,7 +104,9 @@ Value eval_expression(
 		Log::fatal() << "parser error";
 	}
 
-	auto ast = AST::convert_expr(parse_result.cst(), ast_allocator);
+	// TODO: add some type safety to ensure the cst is an Expr
+
+	auto ast = AST::convert_expr(static_cast<CST::Expr*>(parse_result.cst()), ast_allocator);
 
 	{
 		auto err = Frontend::resolve_symbols(ast, parse_result.file_context(), context);

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -44,10 +44,7 @@ ExitStatus execute(
 	if (settings.dump_cst)
 		print(parse_result.cst(), 1);
 
-	// TODO: replace runtime check with type safety
-	assert(parse_result.cst()->type() == CSTTag::Program);
-
-	auto ast = AST::convert_program(static_cast<CST::Program*>(parse_result.cst()), ast_allocator);
+	auto ast = AST::convert_program(parse_result.cst(), ast_allocator);
 
 	// creates and stores a bunch of builtin declarations
 	TypeChecker::TypeChecker tc{ast_allocator};
@@ -104,9 +101,7 @@ Value eval_expression(
 		Log::fatal() << "parser error";
 	}
 
-	// TODO: add some type safety to ensure the cst is an Expr
-
-	auto ast = AST::convert_expr(static_cast<CST::Expr*>(parse_result.cst()), ast_allocator);
+	auto ast = AST::convert_expr(parse_result.cst(), ast_allocator);
 
 	{
 		auto err = Frontend::resolve_symbols(ast, parse_result.file_context(), context);

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -47,7 +47,7 @@ ExitStatus execute(
 	// TODO: replace runtime check with type safety
 	assert(parse_result.cst()->type() == CSTTag::Program);
 
-	auto ast = AST::convert_ast(parse_result.cst(), ast_allocator);
+	auto ast = AST::convert_program(static_cast<CST::Program*>(parse_result.cst()), ast_allocator);
 
 	// creates and stores a bunch of builtin declarations
 	TypeChecker::TypeChecker tc{ast_allocator};

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -61,7 +61,7 @@ ExitStatus execute(
 		}
 	}
 
-	tc.compute_declaration_order(static_cast<AST::Program*>(ast));
+	tc.compute_declaration_order(ast);
 
 	if (settings.typecheck) {
 		tc.core().m_meta_core.comp = &tc.declaration_order();

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -104,7 +104,7 @@ Value eval_expression(
 		Log::fatal() << "parser error";
 	}
 
-	auto ast = AST::convert_ast(parse_result.cst(), ast_allocator);
+	auto ast = AST::convert_expr(parse_result.cst(), ast_allocator);
 
 	{
 		auto err = Frontend::resolve_symbols(ast, parse_result.file_context(), context);

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -56,10 +56,8 @@ int main(int argc, char** argv) {
 				CST::Allocator cst_allocator;
 				auto parser_result = parse_expression(lexer_result, cst_allocator);
 
-				// TODO: add some type safety to ensure the cst is an Expr
-
 				AST::Allocator ast_allocator;
-				auto ast = AST::convert_expr(static_cast<CST::Expr*>(parser_result.cst()), ast_allocator);
+				auto ast = AST::convert_expr(parser_result.cst(), ast_allocator);
 
 				eval(ast, env);
 				auto result = env.m_stack.pop_unsafe();

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -56,8 +56,10 @@ int main(int argc, char** argv) {
 				CST::Allocator cst_allocator;
 				auto parser_result = parse_expression(lexer_result, cst_allocator);
 
+				// TODO: add some type safety to ensure the cst is an Expr
+
 				AST::Allocator ast_allocator;
-				auto ast = AST::convert_expr(parser_result.cst(), ast_allocator);
+				auto ast = AST::convert_expr(static_cast<CST::Expr*>(parser_result.cst()), ast_allocator);
 
 				eval(ast, env);
 				auto result = env.m_stack.pop_unsafe();

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
 				auto parser_result = parse_expression(lexer_result, cst_allocator);
 
 				AST::Allocator ast_allocator;
-				auto ast = AST::convert_ast(parser_result.cst(), ast_allocator);
+				auto ast = AST::convert_expr(parser_result.cst(), ast_allocator);
 
 				eval(ast, env);
 				auto result = env.m_stack.pop_unsafe();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -690,7 +690,7 @@ Writer<CST::Block*> Parser::parse_block() {
 
 	auto opening_brace = REQUIRE_WITH(result, TokenTag::BRACE_OPEN);
 
-	std::vector<CST::CST*> statements;
+	std::vector<CST::Stmt*> statements;
 
 	// loop until we find a matching closing bracket
 	while (1) {
@@ -739,7 +739,7 @@ Writer<CST::Stmt*> Parser::parse_if_else_stmt_or_expr() {
 
 		auto body = TRY(parse_statement());
 
-		CST::CST* else_body = nullptr;
+		CST::Stmt* else_body = nullptr;
 		if (consume(TokenTag::KEYWORD_ELSE))
 			else_body = TRY(parse_statement());
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -922,13 +922,13 @@ Writer<std::pair<Token const*, CST::Expr*>> Parser::parse_name_and_type(bool req
 }
 
 
-ParserResult parse_program(LexerResult lexer_result, CST::Allocator& allocator) {
+ParserResult<CST::Program> parse_program(LexerResult lexer_result, CST::Allocator& allocator) {
 	Parser p {lexer_result.tokens, lexer_result.file_context, allocator};
 	Writer<CST::Program*> w = p.parse_top_level();
 	return {w.m_result, std::move(w.m_error), std::move(lexer_result.tokens), std::move(lexer_result.file_context)};
 }
 
-ParserResult parse_expression(LexerResult lexer_result, CST::Allocator& allocator) {
+ParserResult<CST::Expr> parse_expression(LexerResult lexer_result, CST::Allocator& allocator) {
 	Parser p {lexer_result.tokens, lexer_result.file_context, allocator};
 	Writer<CST::Expr*> w = p.parse_expression();
 	return {w.m_result, std::move(w.m_error), std::move(lexer_result.tokens), std::move(lexer_result.file_context)};

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -7,7 +7,9 @@
 
 namespace CST {
 struct Allocator;
+struct Program;
+struct Expr;
 }
 
-ParserResult parse_program(LexerResult, CST::Allocator&);
-ParserResult parse_expression(LexerResult, CST::Allocator&);
+ParserResult<CST::Program> parse_program(LexerResult, CST::Allocator&);
+ParserResult<CST::Expr> parse_expression(LexerResult, CST::Allocator&);

--- a/src/parser_result.hpp
+++ b/src/parser_result.hpp
@@ -6,12 +6,11 @@
 
 #include <cassert>
 
-namespace CST {
-struct CST;
-}
-
+template<typename T>
 struct ParserResult {
-	ParserResult(CST::CST* cst, ErrorReport error, TokenArray tokens, Frontend::Context file_context)
+	// TODO: check that T is CST or a subtype of CST
+
+	ParserResult(T* cst, ErrorReport error, TokenArray tokens, Frontend::Context file_context)
 	    : m_cst {cst}
 		, m_file_context {std::move(file_context)}
 	    , m_error {std::move(error)}
@@ -21,7 +20,7 @@ struct ParserResult {
 		return m_error.ok();
 	}
 
-	CST::CST* cst() const {
+	T* cst() const {
 		assert(ok());
 		return m_cst;
 	}
@@ -35,7 +34,7 @@ struct ParserResult {
 	}
 
 private:
-	CST::CST* m_cst;
+	T* m_cst;
 	Frontend::Context m_file_context;
 	ErrorReport m_error;
 	TokenArray m_tokens;


### PR DESCRIPTION
Though it's not written anywhere in the code, there were two types of CST nodes: statements and expressions. Roughly, statements go inside seq-blocks, and expressions go on the right hand side of declarations.

I reified this separation through some subclasses of `struct CST`. It was remarkably easy to do, as the code already didn't mix these two types of nodes, except in a few cases that were simple enough to work around.

Once this was in place, some APIs could be made more type safe by distinguishing between the two, and I was able to remove some long standing runtime checks in the interpreter.

Some future steps:
- Do the same thing for `AST` (it's partially done, with `AST::Expr`. Need to add `AST::Stmt` and make APIs stronger-typed)
- Remove all references to `struct CST`, excluding those in `CSTAllocator`
- Remove tag from `struct CST`, put it in `struct Stmt` and `struct Expr`
- Separate `CSTTag` into two tag types, perhaps `CST::StmtTag` and `CST::ExprTag`