### PR TITLE
Remove token array

### DIFF
--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -11,7 +11,6 @@
 #include "../parser.hpp"
 #include "../symbol_resolution.hpp"
 #include "../symbol_table.hpp"
-#include "../token_array.hpp"
 #include "../typechecker/ct_eval.hpp"
 #include "../typechecker/metacheck.hpp"
 #include "../typechecker/typecheck.hpp"

--- a/src/interpreter/main.cpp
+++ b/src/interpreter/main.cpp
@@ -11,7 +11,6 @@
 #include "../lexer.hpp"
 #include "../parser.hpp"
 #include "../symbol_table.hpp"
-#include "../token_array.hpp"
 #include "eval.hpp"
 #include "execute.hpp"
 #include "exit_status_tag.hpp"

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -308,14 +308,14 @@ static void push_identifier_or_keyword(Automaton const& a, std::vector<Token>& t
 	if (KeywordLexer::EndStates::Count <= state || state == KeywordLexer::EndStates::Error) {
 		ta.push_back({
 			TokenTag::IDENTIFIER,
+			start_offset,
 			InternedString(str.begin(), str.size()),
-			start_offset
 		});
 	} else {
 		ta.push_back({
 			KeywordLexer::token_tags[state - 1],
+			start_offset,
 			KeywordLexer::fixed_strings[state - 1],
-			start_offset
 		});
 	}
 }
@@ -358,8 +358,8 @@ static std::vector<Token> tokenize(char const* p) {
 		if(state <= MainLexer::EndStates::last_fixed_string) {
 			ta.push_back({
 				MainLexer::token_tags[state - 1],
-				MainLexer::fixed_strings[state - 1],
 				p0 - code_start,
+				MainLexer::fixed_strings[state - 1],
 			});
 		} else if(state == MainLexer::EndStates::Identifier) {
 			push_identifier_or_keyword(ka, ta, string_view(p0, p - p0), p0 - code_start);
@@ -368,20 +368,20 @@ static std::vector<Token> tokenize(char const* p) {
 		} else if(state == MainLexer::EndStates::String) {
 			ta.push_back({
 				MainLexer::token_tags[state - 1],
-				InternedString(p0 + 1, p - p0 - 2),
 				p0 - code_start,
+				InternedString(p0 + 1, p - p0 - 2),
 			});
 		} else {
 			ta.push_back({
 				MainLexer::token_tags[state - 1],
-				InternedString(p0, p - p0),
 				p0 - code_start,
+				InternedString(p0, p - p0),
 			});
 		}
 
 		eat_whitespace();
 	}
-	ta.push_back({TokenTag::END, InternedString(), p-code_start});
+	ta.push_back({TokenTag::END, p-code_start, InternedString()});
 
 	return ta;
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -3,7 +3,6 @@
 #include "./algorithms/automaton.hpp"
 #include "./utils/string_view.hpp"
 #include "token.hpp"
-#include "token_array.hpp"
 
 #include <cstdint>
 #include <cstdio>
@@ -297,7 +296,7 @@ static void print_error(char const* p) {
 	printf("Error -- last two chars are: %c%c\n", *(p-2), *(p-1));
 }
 
-static void push_identifier_or_keyword(Automaton const& a, TokenArray& ta, string_view str, int start_offset) {
+static void push_identifier_or_keyword(Automaton const& a, std::vector<Token>& ta, string_view str, int start_offset) {
 
 	int state = state_count - 1;
 	for (int i = 0; i < str.size(); ++i) {
@@ -321,7 +320,7 @@ static void push_identifier_or_keyword(Automaton const& a, TokenArray& ta, strin
 	}
 }
 
-static TokenArray tokenize(char const* p) {
+static std::vector<Token> tokenize(char const* p) {
 	// Implementation detail: We store indices into the source buffer
 	// in the source_locations at first, then resolve them in another pass.
 
@@ -330,7 +329,7 @@ static TokenArray tokenize(char const* p) {
 	constexpr Automaton a = MainLexer::make();
 	constexpr Automaton ka = KeywordLexer::make();
 
-	TokenArray ta;
+	std::vector<Token> ta;
 
 	auto eat_whitespace = [&] {
 		while (*p == ' ' || *p == '\t' || *p == '\n') {

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -2,6 +2,5 @@
 
 #include "frontend_context.hpp"
 #include "lexer_result.hpp"
-#include "token_array.hpp"
 
 LexerResult tokenize(Frontend::Context);

--- a/src/lexer_result.hpp
+++ b/src/lexer_result.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "token_array.hpp"
 #include "frontend_context.hpp"
+
+#include <vector>
+
+struct Token;
 
 struct LexerResult {
 	Frontend::Context file_context;
-	TokenArray tokens;
+	std::vector<Token> tokens;
 };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -7,7 +7,6 @@
 #include "cst_allocator.hpp"
 #include "frontend_context.hpp"
 #include "lexer_result.hpp"
-#include "token_array.hpp"
 
 #include <sstream>
 #include <utility>
@@ -23,12 +22,12 @@ Writer<T> make_writer(T x) {
 
 struct Parser {
 	/* token handler */
-	TokenArray const& m_tokens;
+	std::vector<Token> const& m_tokens;
 	Frontend::Context const& m_file_context;
 	CST::Allocator& m_cst_allocator;
 	int m_token_cursor { 0 };
 
-	Parser(TokenArray const& tokens, Frontend::Context const& file_context, CST::Allocator& cst_allocator)
+	Parser(std::vector<Token> const& tokens, Frontend::Context const& file_context, CST::Allocator& cst_allocator)
 	    : m_tokens {tokens}
 		, m_file_context {file_context}
 	    , m_cst_allocator {cst_allocator} {}

--- a/src/parser_result.hpp
+++ b/src/parser_result.hpp
@@ -2,7 +2,6 @@
 
 #include "./utils/error_report.hpp"
 #include "frontend_context.hpp"
-#include "token_array.hpp"
 
 #include <cassert>
 
@@ -10,7 +9,7 @@ template<typename T>
 struct ParserResult {
 	// TODO: check that T is CST or a subtype of CST
 
-	ParserResult(T* cst, ErrorReport error, TokenArray tokens, Frontend::Context file_context)
+	ParserResult(T* cst, ErrorReport error, std::vector<Token> tokens, Frontend::Context file_context)
 	    : m_cst {cst}
 		, m_file_context {std::move(file_context)}
 	    , m_error {std::move(error)}
@@ -37,5 +36,5 @@ private:
 	T* m_cst;
 	Frontend::Context m_file_context;
 	ErrorReport m_error;
-	TokenArray m_tokens;
+	std::vector<Token> m_tokens;
 };

--- a/src/playground/main.cpp
+++ b/src/playground/main.cpp
@@ -8,7 +8,6 @@
 #include "../cst_allocator.hpp"
 #include "../lexer.hpp"
 #include "../parser.hpp"
-#include "../token_array.hpp"
 
 int main(int argc, char** argv) {
 
@@ -33,7 +32,7 @@ int main(int argc, char** argv) {
 	std::string source = file_content.str();
 
 	{
-		TokenArray const ta = tokenize(source.c_str());
+		std::vector<Token> const ta = tokenize(source.c_str());
 
 		CST::Allocator cst_allocator;
 		auto parse_result = parse_program(ta, cst_allocator);

--- a/src/playground/main.cpp
+++ b/src/playground/main.cpp
@@ -32,17 +32,17 @@ int main(int argc, char** argv) {
 	std::string source = file_content.str();
 
 	{
-		std::vector<Token> const ta = tokenize(source.c_str());
+		auto ta = tokenize({source});
 
 		CST::Allocator cst_allocator;
 		auto parse_result = parse_program(ta, cst_allocator);
 
 		if (not parse_result.ok()) {
-			parse_result.m_error.print();
+			parse_result.error().print();
 			return 1;
 		}
 
-		print(parse_result.m_result, 0);
+		// CST::print(parse_result.cst(), 0);
 		std::cout << "\n";
 	}
 

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -7,8 +7,8 @@
 struct Token {
 	/* internal representation of token */
 	TokenTag m_type;
+	int m_start_offset;
+
 	/* source code representation of token */
 	InternedString m_text;
-
-	int m_start_offset;
 };

--- a/src/token_array.hpp
+++ b/src/token_array.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "./utils/chunked_array.hpp"
+#include<vector>
 
 struct Token;
 
-using TokenArray = ChunkedArray<Token>;
+using TokenArray = std::vector<Token>;

--- a/src/token_array.hpp
+++ b/src/token_array.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#include<vector>
-
-struct Token;
-
-using TokenArray = std::vector<Token>;


### PR DESCRIPTION
TokenArray (later generalized to ChunkedArray) was created because we needed a container with address stability across push_back operations. This was needed because the lexer ran concurrently with the parser, so new tokens were created as we held and stored pointers to older tokens in the CST.

We now (for quite a while, really) fully tokenize source files before parsing. This means we don't need address stability on tokens, so we can just use a vector.

------------

While looking at this I also noticed that tokens had a really inefficient memory layout. They measured 24 bytes, and 8 of those (33%) were padding! By just reordering the members, I got rid of that padding, bringing them down to 16 bytes.

------------

The two changes combined made running the playground (without printing) on a 1MB file go from taking 0.072s to 0.063s (more than a 10% improvement). Neither the lexer nor the parser are bottlenecks in Jasper, but this is performance for absolutely free, so I'm gladly taking it.