### PR TITLE
Bytecode interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ COMMON_TARGETS := \
 INTERPRETER_DIR := interpreter
 INTERPRETER_ENTRY := main
 INTERPRETER_TARGETS := \
+	bytecode \
 	error \
 	eval \
 	execute \

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -4,6 +4,7 @@
 #include "./log/log.hpp"
 #include "cst.hpp"
 #include "ast.hpp"
+#include "interpreter/bytecode.hpp"
 
 namespace AST {
 
@@ -26,6 +27,10 @@ InternedString const& Declaration::identifier_text() const {
 
 Token const* Identifier::token() const {
 	return static_cast<CST::Identifier*>(m_cst)->m_token;
+}
+
+FunctionLiteral::~FunctionLiteral() {
+	delete bytecode;
 }
 
 } // namespace AST

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -163,6 +163,8 @@ struct FunctionLiteral : public Expr {
 
 	FunctionLiteral()
 	    : Expr {ExprTag::FunctionLiteral} {}
+
+	~FunctionLiteral();
 };
 
 struct Identifier : public Expr {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -17,6 +17,10 @@ namespace CST {
 struct CST;
 }
 
+namespace Bytecode {
+struct Executable;
+};
+
 namespace AST {
 
 struct AST {
@@ -153,6 +157,9 @@ struct FunctionLiteral : public Expr {
 	std::vector<Declaration> m_args;
 	std::unordered_map<InternedString, CaptureData> m_captures;
 	FunctionLiteral* m_surrounding_function {nullptr};
+
+	bool tried_compilation {false};
+	Bytecode::Executable* bytecode {nullptr};
 
 	FunctionLiteral()
 	    : Expr {ExprTag::FunctionLiteral} {}

--- a/src/interpreter/bytecode.cpp
+++ b/src/interpreter/bytecode.cpp
@@ -11,10 +11,10 @@ Writer<T> make_writer(T x) {
 
 namespace Bytecode {
 
-ErrorReport visit(BasicBlock&, AST::Expr*);
+static ErrorReport visit(BasicBlock&, AST::Expr*);
 
-ErrorReport success() { return {}; }
-ErrorReport failure() { return {"Failed to generate bytecode"}; }
+static ErrorReport success() { return {}; }
+static ErrorReport failure() { return {"Failed to generate bytecode"}; }
 
 Writer<Executable> compile(AST::Expr* expr) {
 	Executable result;
@@ -38,7 +38,7 @@ void emit_instruction(BasicBlock& b, InstructionType instruction) {
 		b.bytecode.push_back(buffer[i]);
 }
 
-ErrorReport compile_identifier(BasicBlock& b, AST::Identifier* expr) {
+static ErrorReport compile_identifier(BasicBlock& b, AST::Identifier* expr) {
 	if (expr->m_origin != AST::Identifier::Origin::Global)
 		return failure();
 
@@ -46,7 +46,7 @@ ErrorReport compile_identifier(BasicBlock& b, AST::Identifier* expr) {
 	return success();
 }
 
-ErrorReport compile_call_expression(BasicBlock& b, AST::CallExpression* expr) {
+static ErrorReport compile_call_expression(BasicBlock& b, AST::CallExpression* expr) {
 	auto status1 = visit(b, expr->m_callee);
 	if (!status1.ok()) return status1;
 
@@ -59,7 +59,7 @@ ErrorReport compile_call_expression(BasicBlock& b, AST::CallExpression* expr) {
 	return success();
 }
 
-ErrorReport compile_integer_literal(BasicBlock& b, AST::IntegerLiteral* expr) {
+static ErrorReport compile_integer_literal(BasicBlock& b, AST::IntegerLiteral* expr) {
 	emit_instruction(b, NewInteger {expr->m_value});
 	return success();
 }
@@ -76,7 +76,7 @@ ErrorReport visit(BasicBlock& b, AST::Expr* expr) {
 	return failure();
 }
 
-int decode(char const* stream, Interpreter::Interpreter& e) {
+static int decode(char const* stream, Interpreter::Interpreter& e) {
 	Instruction const* punned = reinterpret_cast<Instruction const*>(stream);
 	switch (punned->tag()) {
 	case Instruction::Tag::NewInteger: {

--- a/src/interpreter/bytecode.cpp
+++ b/src/interpreter/bytecode.cpp
@@ -1,7 +1,44 @@
 #include "bytecode.hpp"
 
+template <typename T>
+Writer<T> make_writer(T x) {
+	return {{}, std::move(x)};
+}
+
 namespace Bytecode {
 
+ErrorReport visit(BasicBlock&, AST::Expr*);
 
+ErrorReport failure() { return {"Failed to generate bytecode"}; }
+
+Writer<Executable> compile(AST::Expr* expr) {
+	Executable result;
+	BasicBlock main_block;
+	ErrorReport status = visit(main_block, expr);
+	if (status.ok()) {
+	} else {
+		return status;
+	}
+
+	result.blocks.push_back(std::move(main_block));
+	return make_writer(std::move(result));
+}
+
+ErrorReport visit(BasicBlock& b, AST::Expr* expr) {
+	switch (expr->type()) {
+	}
+	return failure();
+}
+
+int decode(char const* stream, Interpreter::Interpreter& e) {
+	return 1024;
+}
+
+void execute(Executable const& exe, Interpreter::Interpreter& e) {
+	int cursor = 0;
+	while (cursor < exe.blocks[0].bytecode.size()) {
+		cursor += decode(&exe.blocks[0].bytecode[cursor], e);
+	}
+}
 
 } // namespace Bytecode

--- a/src/interpreter/bytecode.cpp
+++ b/src/interpreter/bytecode.cpp
@@ -1,0 +1,7 @@
+#include "bytecode.hpp"
+
+namespace Bytecode {
+
+
+
+} // namespace Bytecode

--- a/src/interpreter/bytecode.cpp
+++ b/src/interpreter/bytecode.cpp
@@ -1,5 +1,7 @@
 #include "bytecode.hpp"
 
+#include <cstring>
+
 template <typename T>
 Writer<T> make_writer(T x) {
 	return {{}, std::move(x)};
@@ -9,6 +11,7 @@ namespace Bytecode {
 
 ErrorReport visit(BasicBlock&, AST::Expr*);
 
+ErrorReport success() { return {}; }
 ErrorReport failure() { return {"Failed to generate bytecode"}; }
 
 Writer<Executable> compile(AST::Expr* expr) {
@@ -24,13 +27,52 @@ Writer<Executable> compile(AST::Expr* expr) {
 	return make_writer(std::move(result));
 }
 
+template<typename InstructionType>
+void emit_instruction(BasicBlock& b, InstructionType instruction) {
+	constexpr auto byte_count = sizeof(instruction);
+	char buffer[byte_count];
+	memcpy(buffer, &instruction, byte_count);
+	for (int i = 0; i < byte_count; ++i)
+		b.bytecode.push_back(buffer[i]);
+}
+
+ErrorReport compile_identifier(BasicBlock& b, AST::Identifier* expr) {
+	if (expr->m_origin != AST::Identifier::Origin::Global)
+		return failure();
+
+	emit_instruction(b, GetGlobal {expr->m_text});
+	return success();
+}
+
+ErrorReport compile_integer_literal(BasicBlock& b, AST::IntegerLiteral* expr) {
+	emit_instruction(b, NewInteger {expr->m_value});
+	return success();
+}
+
 ErrorReport visit(BasicBlock& b, AST::Expr* expr) {
 	switch (expr->type()) {
+	case AST::ExprTag::Identifier:
+		return compile_identifier(b, static_cast<AST::Identifier*>(expr));
+	case AST::ExprTag::IntegerLiteral:
+		return compile_integer_literal(b, static_cast<AST::IntegerLiteral*>(expr));
 	}
 	return failure();
 }
 
 int decode(char const* stream, Interpreter::Interpreter& e) {
+	Instruction const* punned = reinterpret_cast<Instruction const*>(stream);
+	switch (punned->tag()) {
+	case Instruction::Tag::NewInteger: {
+		auto op = static_cast<NewInteger const*>(punned);
+		e.push_integer(op->m_value);
+		return sizeof(*op);
+	}
+	case Instruction::Tag::GetGlobal: {
+		auto op = static_cast<GetGlobal const*>(punned);
+		e.m_stack.push(Interpreter::Value{e.global_access(op->m_name)});
+		return sizeof(*op);
+	}
+	}
 	return 1024;
 }
 

--- a/src/interpreter/bytecode.hpp
+++ b/src/interpreter/bytecode.hpp
@@ -8,7 +8,7 @@
 namespace Bytecode {
 
 struct Instruction {
-	enum class Tag { NewInteger };
+	enum class Tag { GetGlobal, NewInteger };
 
 	Instruction(Tag tag)
 	    : m_tag {tag} {}
@@ -16,6 +16,14 @@ struct Instruction {
 	Tag tag() const { return m_tag; }
 private:
 	Tag m_tag;
+};
+
+struct GetGlobal : Instruction {
+	GetGlobal(InternedString name)
+	    : Instruction {Tag::GetGlobal}
+	    , m_name {name} {}
+
+	InternedString m_name;
 };
 
 struct NewInteger : Instruction {

--- a/src/interpreter/bytecode.hpp
+++ b/src/interpreter/bytecode.hpp
@@ -8,7 +8,7 @@
 namespace Bytecode {
 
 struct Instruction {
-	enum class Tag { GetGlobal, NewInteger };
+	enum class Tag { GetGlobal, NewInteger, Call };
 
 	Instruction(Tag tag)
 	    : m_tag {tag} {}
@@ -24,6 +24,14 @@ struct GetGlobal : Instruction {
 	    , m_name {name} {}
 
 	InternedString m_name;
+};
+
+struct Call : Instruction {
+	Call(int argument_count)
+	    : Instruction {Tag::Call}
+	    , m_argument_count {argument_count} {}
+
+	int m_argument_count;
 };
 
 struct NewInteger : Instruction {

--- a/src/interpreter/bytecode.hpp
+++ b/src/interpreter/bytecode.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <vector>
+#include "../ast.hpp"
+#include "../utils/writer.hpp"
+#include "interpreter.hpp"
 
 namespace Bytecode {
 
@@ -30,5 +33,9 @@ struct BasicBlock {
 struct Executable {
 	std::vector<BasicBlock> blocks;
 };
+
+Writer<Executable> compile(AST::Expr*);
+
+void execute(Executable const&, Interpreter::Interpreter&);
 
 } // namespace Bytecode

--- a/src/interpreter/bytecode.hpp
+++ b/src/interpreter/bytecode.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <vector>
+
+namespace Bytecode {
+
+struct Instruction {
+	enum class Tag { NewInteger };
+
+	Instruction(Tag tag)
+	    : m_tag {tag} {}
+
+	Tag tag() const { return m_tag; }
+private:
+	Tag m_tag;
+};
+
+struct NewInteger : Instruction {
+	NewInteger(int value)
+	    : Instruction {Tag::NewInteger}
+	    , m_value {value} {}
+
+	int m_value;
+};
+
+struct BasicBlock {
+	std::vector<char> bytecode;
+};
+
+struct Executable {
+	std::vector<BasicBlock> blocks;
+};
+
+} // namespace Bytecode

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -94,53 +94,6 @@ auto is_callable_type(ValueTag t) -> bool {
 	return t == ValueTag::Function || t == ValueTag::NativeFunction;
 }
 
-void eval_call_function(Function* callee, int arg_count, Interpreter& e) {
-
-	for (int i = 0; i < arg_count; ++i) {
-		auto ref = e.new_reference(Value {nullptr});
-		ref->m_value = value_of(e.m_stack.access(i));
-		e.m_stack.access(i) = ref.as_value();
-	}
-
-	// TODO: error handling ?
-	assert(callee->m_def->m_args.size() == arg_count);
-
-	if (!callee->m_def->tried_compilation) {
-		callee->m_def->tried_compilation = true;
-
-		Writer<Bytecode::Executable> bytecode = Bytecode::compile(callee->m_def->m_body);
-		if (bytecode.ok()) {
-			callee->m_def->bytecode =
-			    new Bytecode::Executable {std::move(bytecode.m_result)};
-		}
-	}
-
-	for (auto capture : callee->m_captures)
-		e.m_stack.push(Value{capture});
-
-	if (callee->m_def->bytecode) {
-		Bytecode::execute(*callee->m_def->bytecode, e);
-	} else {
-		eval(callee->m_def->m_body, e);
-	}
-
-}
-
-void eval_call_native_function(NativeFunction* callee, int arg_count, Interpreter& e) {
-	auto args = e.m_stack.frame_range(0, arg_count);
-	e.m_stack.push(callee(args, e));
-}
-
-void eval_call_callable(Value callee, int arg_count, Interpreter& e) {
-	if (callee.type() == ValueTag::Function) {
-		eval_call_function(callee.get_cast<Function>(), arg_count, e);
-	} else if (callee.type() == ValueTag::NativeFunction) {
-		eval_call_native_function(callee.get_native_func(), arg_count, e);
-	} else {
-		Log::fatal("Attempted to call a non function at runtime");
-	}
-}
-
 void eval(AST::CallExpression* ast, Interpreter& e) {
 
 	eval(ast->m_callee, e);

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -95,6 +95,12 @@ auto is_callable_type(ValueTag t) -> bool {
 
 void eval_call_function(Function* callee, int arg_count, Interpreter& e) {
 
+	for (int i = 0; i < arg_count; ++i) {
+		auto ref = e.new_reference(Value {nullptr});
+		ref->m_value = value_of(e.m_stack.access(i));
+		e.m_stack.access(i) = ref.as_value();
+	}
+
 	// TODO: error handling ?
 	assert(callee->m_def->m_args.size() == arg_count);
 
@@ -102,7 +108,21 @@ void eval_call_function(Function* callee, int arg_count, Interpreter& e) {
 		e.m_stack.push(Value{capture});
 
 	eval(callee->m_def->m_body, e);
+}
 
+void eval_call_native_function(NativeFunction* callee, int arg_count, Interpreter& e) {
+	auto args = e.m_stack.frame_range(0, arg_count);
+	e.m_stack.push(callee(args, e));
+}
+
+void eval_call_callable(Value callee, int arg_count, Interpreter& e) {
+	if (callee.type() == ValueTag::Function) {
+		eval_call_function(callee.get_cast<Function>(), arg_count, e);
+	} else if (callee.type() == ValueTag::NativeFunction) {
+		eval_call_native_function(callee.get_native_func(), arg_count, e);
+	} else {
+		Log::fatal("Attempted to call a non function at runtime");
+	}
 }
 
 void eval(AST::CallExpression* ast, Interpreter& e) {
@@ -116,35 +136,15 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 	auto& arglist = ast->m_args;
 	int arg_count = arglist.size();
 
-	int frame_start = e.m_stack.m_stack_ptr;
-	if (callee.type() == ValueTag::Function) {
-		for (auto expr : arglist) {
-			// put arg on stack
-			eval(expr, e);
+	for (auto expr : arglist)
+		eval(expr, e);
 
-			// wrap arg in reference
-			auto ref = e.new_reference(Value {nullptr});
-			ref->m_value = value_of(e.m_stack.access(0));
-			e.m_stack.access(0) = ref.as_value();
-		}
-		e.m_stack.start_stack_frame(frame_start);
+	e.m_stack.start_stack_frame(e.m_stack.m_stack_ptr - arg_count);
 
-		eval_call_function(callee.get_cast<Function>(), arg_count, e);
+	eval_call_callable(callee, arg_count, e);
 
-		// pop the result of the function, and clobber the callee
-		e.m_stack.frame_at(-1) = e.m_stack.pop_unsafe();
-	} else if (callee.type() == ValueTag::NativeFunction) {
-		for (auto expr : arglist)
-			eval(expr, e);
-		e.m_stack.start_stack_frame(frame_start);
-		auto args = e.m_stack.frame_range(0, arg_count);
-
-		// compute the result of the function, and clobber the callee
-		e.m_stack.frame_at(-1) = callee.get_native_func()(args, e);
-	} else {
-		Log::fatal("Attempted to call a non function at runtime");
-	}
-
+	// pop the result of the function, and clobber the callee
+	e.m_stack.frame_at(-1) = e.m_stack.pop_unsafe();
 
 	e.m_stack.end_stack_frame();
 }

--- a/src/interpreter/utils.cpp
+++ b/src/interpreter/utils.cpp
@@ -1,5 +1,9 @@
 #include "utils.hpp"
 
+#include "../log/log.hpp"
+#include "bytecode.hpp"
+#include "eval.hpp"
+#include "interpreter.hpp"
 #include "value.hpp"
 
 namespace Interpreter {
@@ -15,5 +19,56 @@ Value value_of(Value h) {
 	auto ref = h.get_cast<Reference>();
 	return ref->m_value;
 }
+
+
+void eval_call_function(Function* callee, int arg_count, Interpreter& e) {
+
+	for (int i = 0; i < arg_count; ++i) {
+		auto ref = e.new_reference(Value {nullptr});
+		ref->m_value = value_of(e.m_stack.access(i));
+		e.m_stack.access(i) = ref.as_value();
+	}
+
+	// TODO: error handling ?
+	assert(callee->m_def->m_args.size() == arg_count);
+
+	if (!callee->m_def->tried_compilation) {
+		callee->m_def->tried_compilation = true;
+
+		Writer<Bytecode::Executable> bytecode = Bytecode::compile(callee->m_def->m_body);
+		if (bytecode.ok()) {
+			callee->m_def->bytecode =
+			    new Bytecode::Executable {std::move(bytecode.m_result)};
+		}
+	}
+
+	for (auto capture : callee->m_captures)
+		e.m_stack.push(Value{capture});
+
+	if (callee->m_def->bytecode) {
+		Bytecode::execute(*callee->m_def->bytecode, e);
+	} else {
+		eval(callee->m_def->m_body, e);
+	}
+
+}
+
+void eval_call_native_function(NativeFunction* callee, int arg_count, Interpreter& e) {
+	auto args = e.m_stack.frame_range(0, arg_count);
+	e.m_stack.push(callee(args, e));
+}
+
+void eval_call_callable(Value callee, int arg_count, Interpreter& e) {
+	if (callee.type() == ValueTag::Function) {
+		eval_call_function(callee.get_cast<Function>(), arg_count, e);
+	} else if (callee.type() == ValueTag::NativeFunction) {
+		eval_call_native_function(callee.get_native_func(), arg_count, e);
+	} else {
+		Log::fatal("Attempted to call a non function at runtime");
+	}
+}
+
+
+
 
 } // namespace Interpreter

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -14,4 +14,6 @@ T* value_as(Value h) {
 	return value_of(h).get_cast<T>();
 }
 
+void eval_call_callable(Value callee, int arg_count, Interpreter&);
+
 } // namespace Interpreter


### PR DESCRIPTION
Repeatedly walking a tree is not the most efficient way to evaluate a piece of code.

There is a cool observation here: The most important thing that eval() does is fiddle with the interpreter stack and garbage collector. In fact, most of its behavior on a given run can be characterized by the sequence of method calls that it performs on those objects.

Therefore, what we could do is -- roughly -- store the sequence of method calls in an array, then read them off and perform them one by one. This will be faster when the sequence needs to be repeated multiple times because it's more cache friendly (although our ASTs are decent in that regard) and it needs to take fewer branches.

---------------

The general approach is that each Jasper function will get compiled to a list of bytecode instructions on its first call. If it succeeds, we execute bytecode. If it fails, we fall back on the old tree-walking interpreter.

This allows for the call stack to interweave bytecode functions and tree-walk functions (i.e. BC functions can call TW functions and vice-versa). This means the bytecode compiler and interpreters can be written incrementally, along several pull requests.

Since different bytecode instructions will have different sizes, we just memcpy them into an array of bytes.