### PR TITLE
Remove typefunc unification

### DIFF
--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -185,12 +185,11 @@ static AST::Constructor* constructor_from_ast(
 
 		auto case_name = access->m_member;
 
-		MonoId expected_ty = tc.core().ll_new_var();
-		VarId v = tc.core().get_var_id(expected_ty);
-
+		VarId v = tc.core().fresh_var();
 		tc.core().add_variant_constraint(v);
 		tc.core().add_field_constraint(v, case_name, tc.core().ll_new_var());
 
+		MonoId expected_ty = tc.core().var(v);
 		MonoId actual_ty = compute_mono(access->m_target, tc);
 
 		tc.core().ll_unify(expected_ty, actual_ty);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -183,14 +183,20 @@ static AST::Constructor* constructor_from_ast(
 
 		auto access = static_cast<AST::AccessExpression*>(ast);
 
-		MonoId dummy_monotype = tc.core().new_dummy_for_ct_eval(access->m_member);
+		auto case_name = access->m_member;
 
-		MonoId monotype = compute_mono(access->m_target, tc);
+		MonoId expected_ty = tc.core().ll_new_var();
+		VarId v = tc.core().get_var_id(expected_ty);
 
-		tc.core().ll_unify(dummy_monotype, monotype);
+		tc.core().add_variant_constraint(v);
+		tc.core().add_field_constraint(v, case_name, tc.core().ll_new_var());
 
-		constructor->m_mono = monotype;
-		constructor->m_id = access->m_member;
+		MonoId actual_ty = compute_mono(access->m_target, tc);
+
+		tc.core().ll_unify(expected_ty, actual_ty);
+
+		constructor->m_mono = actual_ty;
+		constructor->m_id = case_name;
 	} else {
 		Log::fatal() << "Constructor invokation on a non-constructor -- MetaType(" << int(meta) << ")";
 	}

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -224,13 +224,12 @@ static void infer(AST::TernaryExpression* ast, TypecheckHelper& tc) {
 static void infer(AST::AccessExpression* ast, TypecheckHelper& tc) {
 	infer(ast->m_target, tc);
 
-	MonoId expected_ty = tc.new_var();
+	VarId v = tc.core().fresh_var();
 	MonoId field_ty = tc.new_var();
-	VarId v = tc.core().get_var_id(expected_ty);
-
 	tc.core().add_record_constraint(v);
 	tc.core().add_field_constraint(v, ast->m_member, field_ty);
 
+	MonoId expected_ty = tc.core().var(v);
 	MonoId actual_ty = ast->m_target->m_value_type;
 
 	tc.unify(actual_ty, expected_ty);
@@ -265,8 +264,7 @@ static void infer(AST::MatchExpression* ast, TypecheckHelper& tc) {
 		dummy_structure[kv.first] = case_data.m_declaration.m_value_type;
 	}
 
-	MonoId expected_ty = tc.new_var();
-	VarId v = tc.core().get_var_id(expected_ty);
+	VarId v = tc.core().fresh_var();
 
 	tc.core().add_variant_constraint(v);
 	for (auto& kv : dummy_structure) {
@@ -275,6 +273,7 @@ static void infer(AST::MatchExpression* ast, TypecheckHelper& tc) {
 		tc.core().add_field_constraint(v, case_name, case_ty);
 	}
 
+	MonoId expected_ty = tc.core().var(v);
 	MonoId actual_ty = ast->m_target.m_value_type;
 
 	tc.unify(actual_ty, expected_ty);

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -69,7 +69,7 @@ private:
 	Frontend::SymbolTable symbol_table;
 	TypeChecker& tc;
 
-	bool is_bound_to_env(MonoId var) {
+	bool is_bound_to_env(VarId var) {
 
 		for (auto& kv : symbol_table.bindings()) {
 			auto decl = kv.second;
@@ -86,8 +86,8 @@ private:
 		return false;
 	}
 
-	std::unordered_set<MonoId> free_vars_of(MonoId mono) {
-		std::unordered_set<MonoId> free_vars;
+	std::set<VarId> free_vars_of(MonoId mono) {
+		std::set<VarId> free_vars;
 		core().gather_free_vars(mono, free_vars);
 		return free_vars;
 	}
@@ -98,9 +98,9 @@ private:
 PolyId TypecheckHelper::generalize(MonoId mono) {
 
 	std::vector<VarId> vars;
-	for (MonoId var : free_vars_of(mono)) {
+	for (VarId var : free_vars_of(mono)) {
 		if (!is_bound_to_env(var)) {
-			vars.push_back(core().get_var_id(var));
+			vars.push_back(var);
 		}
 	}
 

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -97,10 +97,10 @@ private:
 // quantifies all free variables in the given monotype
 PolyId TypecheckHelper::generalize(MonoId mono) {
 
-	std::vector<MonoId> vars;
+	std::vector<VarId> vars;
 	for (MonoId var : free_vars_of(mono)) {
 		if (!is_bound_to_env(var)) {
-			vars.push_back(var);
+			vars.push_back(core().get_var_id(var));
 		}
 	}
 

--- a/src/typechecker/typechecker.cpp
+++ b/src/typechecker/typechecker.cpp
@@ -43,8 +43,8 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 	};
 
 	{
-		MonoId a_ty = new_var();
-		VarId a_var = core().get_var_id(a_ty);
+		VarId a_var = core().fresh_var();
+		MonoId a_ty = core().var(a_var);
 
 		MonoId array_a_ty = array_ty(a_ty, "array");
 

--- a/src/typechecker/typechecker.cpp
+++ b/src/typechecker/typechecker.cpp
@@ -29,7 +29,7 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 	// TODO: refactor, figure out a nice way to build types
 	// HACK: this is an ugly hack. bear with me...
 
-	auto forall = [&](std::vector<MonoId> quantified_vars, MonoId inner_ty) -> PolyId {
+	auto forall = [&](std::vector<VarId> quantified_vars, MonoId inner_ty) -> PolyId {
 		return core().new_poly(inner_ty, std::move(quantified_vars));
 	};
 
@@ -44,7 +44,7 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 
 	{
 		MonoId a_ty = new_var();
-		MonoId a_var = a_ty;
+		VarId a_var = core().get_var_id(a_ty);
 
 		MonoId array_a_ty = array_ty(a_ty, "array");
 

--- a/src/typechecker/typechecker_types.hpp
+++ b/src/typechecker/typechecker_types.hpp
@@ -5,7 +5,6 @@ using TypeFunctionId = int;
 using TermId = int;
 using MonoId = int;
 using PolyId = int;
-using TypeVarId = int;
 
 using MetaTypeId = int;
 

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -33,14 +33,14 @@ PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<VarId> vars) {
 }
 
 MonoId TypeSystemCore::inst_impl(
-    MonoId mono, std::unordered_map<int, MonoId> const& mapping) {
+    MonoId mono, std::map<VarId, MonoId> const& mapping) {
 
 	mono = ll_find(mono);
 	NodeHeader header = ll_node_header[mono];
 
 	if (header.tag == Tag::Var) {
 		VarId var = get_var_id(mono);
-		auto it = mapping.find(static_cast<int>(var));
+		auto it = mapping.find(var);
 		return it == mapping.end() ? mono : it->second;
 	} else {
 		TermId term = header.data_idx;
@@ -56,9 +56,9 @@ MonoId TypeSystemCore::inst_with(PolyId poly, std::vector<MonoId> const& vals) {
 
 	assert(data.vars.size() == vals.size());
 
-	std::unordered_map<int, MonoId> old_to_new;
+	std::map<VarId, MonoId> old_to_new;
 	for (int i {0}; i != data.vars.size(); ++i) {
-		old_to_new[static_cast<int>(data.vars[i])] = vals[i];
+		old_to_new[data.vars[i]] = vals[i];
 	}
 
 	return inst_impl(data.base, old_to_new);
@@ -71,12 +71,12 @@ MonoId TypeSystemCore::inst_fresh(PolyId poly) {
 	return inst_with(poly, vals);
 }
 
-void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<MonoId>& free_vars) {
+void TypeSystemCore::gather_free_vars(MonoId mono, std::set<VarId>& free_vars) {
 	mono = ll_find(mono);
 	const NodeHeader& header = ll_node_header[mono];
 
 	if (header.tag == Tag::Var) {
-		free_vars.insert(mono);
+		free_vars.insert(get_var_id(mono));
 	} else {
 		TermId term = header.data_idx;
 		for (MonoId arg : ll_term_data[term].argument_idx)

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -91,11 +91,6 @@ TypeFunctionId TypeSystemCore::new_type_function(
 	    type, 0, std::move(fields), std::move(structure), TypeFunctionStrength::Full);
 }
 
-TypeFunctionId TypeSystemCore::new_type_function_var() {
-	return create_type_function(
-	    TypeFunctionTag::Builtin, -1, {}, {}, TypeFunctionStrength::None);
-}
-
 TypeFunctionId TypeSystemCore::create_type_function(
     TypeFunctionTag tag,
     int arity,

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -236,10 +236,6 @@ void TypeSystemCore::ll_unify(int i, int j) {
 }
 
 int TypeSystemCore::ll_new_var(char const* debug) {
-	return new_constrained_var({}, debug);
-}
-
-int TypeSystemCore::new_constrained_var(Constraint c, char const* debug) {
 	int var_id = m_var_counter++;
 	int uf_node = m_type_var_uf.new_node();
 
@@ -247,7 +243,7 @@ int TypeSystemCore::new_constrained_var(Constraint c, char const* debug) {
 	assert(m_substitution.size() == var_id);
 	assert(m_constraints.size() == var_id);
 	m_substitution.push_back(-1);
-	m_constraints.push_back(std::move(c));
+	m_constraints.push_back({});
 
 	int type_id = m_type_counter++;
 	assert(ll_node_header.size() == type_id);

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -270,10 +270,6 @@ bool TypeSystemCore::ll_is_var(int i) {
 	return ll_node_header[i].tag == Tag::Var;
 }
 
-void TypeSystemCore::point_type_function_at_another(TypeFunctionId a, TypeFunctionId b) {
-	m_type_function_uf.join_left_to_right(a, b);
-}
-
 TypeFunctionData& TypeSystemCore::get_type_function_data(TypeFunctionId tf) {
 	return m_type_functions[find_type_function(tf)];
 }

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -149,7 +149,6 @@ void TypeSystemCore::add_left_constraints_to_right(VarId vi, VarId vj) {
 }
 
 bool TypeSystemCore::satisfies(MonoId t, Constraint const& c) {
-#if 0
 	assert(ll_node_header[t].tag == Tag::Term);
 
 	int tid = ll_node_header[t].data_idx;
@@ -164,9 +163,9 @@ bool TypeSystemCore::satisfies(MonoId t, Constraint const& c) {
 
 	for (auto& kv : c.structure) {
 		if (!tf_data.structure.count(kv.first)) return false;
-		// ll_unify(kv.second, t_tf_data.structure[kv.first]);
+		ll_unify(kv.second, tf_data.structure[kv.first]);
 	}
-#endif
+
 	return true;
 }
 

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -10,15 +10,7 @@ TypeSystemCore::TypeSystemCore() {
 
 MonoId TypeSystemCore::new_term(
     TypeFunctionId tf, std::vector<int> args, char const* tag) {
-	tf = find_type_function(tf);
-
-	{
-		// This block of code ensures that tf has the right arity
-		TypeFunctionId dummy_tf = new_type_function_var();
-		get_type_function_data(dummy_tf).argument_count = args.size();
-		unify_type_function(tf, dummy_tf);
-	}
-
+	assert(get_type_function_data(tf).argument_count == args.size() || get_type_function_data(tf).argument_count == -1);
 	return ll_new_term(tf, std::move(args), tag);
 }
 
@@ -135,27 +127,7 @@ static InternedString print_a_thing(int x) {
 }
 
 void TypeSystemCore::unify_type_function(TypeFunctionId i, TypeFunctionId j) {
-	i = find_type_function(i);
-	j = find_type_function(j);
-
-	if (i == j)
-		return;
-
-	if (get_type_function_data(i).strength == TypeFunctionStrength::Full &&
-		get_type_function_data(j).strength == TypeFunctionStrength::Full) {
-		Log::fatal() << "unified " << print_a_thing(i) << " with " << print_a_thing(j);
-		// Log::fatal() << "unified different type functions";
-	}
-
-	if (get_type_function_data(j).strength == TypeFunctionStrength::None)
-		std::swap(i, j);
-
-	if (get_type_function_data(i).strength == TypeFunctionStrength::None) {
-		point_type_function_at_another(i, j);
-		return;
-	}
-
-	assert(false);
+	assert(i == j);
 }
 
 bool TypeSystemCore::occurs(VarId v, MonoId i) {
@@ -304,11 +276,7 @@ void TypeSystemCore::point_type_function_at_another(TypeFunctionId a, TypeFuncti
 }
 
 TypeFunctionData& TypeSystemCore::get_type_function_data(TypeFunctionId tf) {
-	return m_type_functions[find_type_function(tf)];
-}
-
-TypeFunctionId TypeSystemCore::find_type_function(TypeFunctionId tf) {
-	return m_type_function_uf.find(tf);
+	return m_type_functions[tf];
 }
 
 bool TypeSystemCore::equals_var(MonoId t, VarId v) {

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -135,14 +135,6 @@ void TypeSystemCore::unify_type_function(TypeFunctionId i, TypeFunctionId j) {
 		// Log::fatal() << "unified different type functions";
 	}
 
-	if (get_type_function_data(j).strength == TypeFunctionStrength::None)
-		std::swap(i, j);
-
-	if (get_type_function_data(i).strength == TypeFunctionStrength::None) {
-		point_type_function_at_another(i, j);
-		return;
-	}
-
 	assert(false);
 }
 

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -117,13 +117,6 @@ static InternedString print_a_thing(int x) {
 	return "a user defined type";
 }
 
-void TypeSystemCore::unify_type_function(TypeFunctionId i, TypeFunctionId j) {
-	if (i == j)
-		return;
-
-	Log::fatal() << "unified " << print_a_thing(i) << " with " << print_a_thing(j);
-}
-
 bool TypeSystemCore::occurs(VarId v, MonoId i) {
 	i = ll_find(i);
 
@@ -206,7 +199,12 @@ void TypeSystemCore::ll_unify(int i, int j) {
 			TermData& i_data = ll_term_data[vi];
 			TermData& j_data = ll_term_data[vj];
 
-			unify_type_function(i_data.function_id, j_data.function_id);
+			TypeFunctionId i_tf = i_data.function_id;
+			TypeFunctionId j_tf = j_data.function_id;
+
+			if (i_tf != j_tf) {
+				Log::fatal() << "unified " << print_a_thing(i_tf) << " with " << print_a_thing(j_tf);
+			}
 		}
 
 		assert(ll_term_data[vi].argument_idx.size() == ll_term_data[vj].argument_idx.size());

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -79,27 +79,24 @@ void TypeSystemCore::gather_free_vars(MonoId mono, std::set<VarId>& free_vars) {
 
 
 TypeFunctionId TypeSystemCore::new_builtin_type_function(int arity) {
-	return create_type_function(
-	    TypeFunctionTag::Builtin, arity, {}, {}, TypeFunctionStrength::Full);
+	return create_type_function(TypeFunctionTag::Builtin, arity, {}, {});
 }
 
 TypeFunctionId TypeSystemCore::new_type_function(
     TypeFunctionTag type,
     std::vector<InternedString> fields,
     std::unordered_map<InternedString, MonoId> structure) {
-	return create_type_function(
-	    type, 0, std::move(fields), std::move(structure), TypeFunctionStrength::Full);
+	return create_type_function(type, 0, std::move(fields), std::move(structure));
 }
 
 TypeFunctionId TypeSystemCore::create_type_function(
     TypeFunctionTag tag,
     int arity,
     std::vector<InternedString> fields,
-    std::unordered_map<InternedString, MonoId> structure,
-    TypeFunctionStrength strength) {
+    std::unordered_map<InternedString, MonoId> structure) {
 	TypeFunctionId result = m_type_function_uf.new_node();
 	m_type_functions.push_back(
-	    {tag, arity, std::move(fields), std::move(structure), strength});
+	    {tag, arity, std::move(fields), std::move(structure)});
 	return result;
 }
 
@@ -129,13 +126,7 @@ void TypeSystemCore::unify_type_function(TypeFunctionId i, TypeFunctionId j) {
 	if (i == j)
 		return;
 
-	if (get_type_function_data(i).strength == TypeFunctionStrength::Full &&
-		get_type_function_data(j).strength == TypeFunctionStrength::Full) {
-		Log::fatal() << "unified " << print_a_thing(i) << " with " << print_a_thing(j);
-		// Log::fatal() << "unified different type functions";
-	}
-
-	assert(false);
+	Log::fatal() << "unified " << print_a_thing(i) << " with " << print_a_thing(j);
 }
 
 bool TypeSystemCore::occurs(VarId v, MonoId i) {

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -212,21 +212,24 @@ void TypeSystemCore::ll_unify(int i, int j) {
 	}
 }
 
-int TypeSystemCore::ll_new_var(char const* debug) {
-	int var_id = m_var_counter++;
-	int uf_node = m_type_var_uf.new_node();
-
-	assert(uf_node == var_id);
-	assert(m_substitution.size() == var_id);
-	assert(m_constraints.size() == var_id);
+VarId TypeSystemCore::fresh_var() {
+	VarId v = static_cast<VarId>(m_var_counter++);
+	m_type_var_uf.new_node();
 	m_substitution.push_back(-1);
 	m_constraints.push_back({});
+	return v;
+}
 
+MonoId TypeSystemCore::var(VarId v, char const* debug) {
+	int var_id = static_cast<int>(v);
 	int type_id = m_type_counter++;
 	assert(ll_node_header.size() == type_id);
 	ll_node_header.push_back({Tag::Var, var_id, debug});
-
 	return type_id;
+}
+
+int TypeSystemCore::ll_new_var(char const* debug) {
+	return var(fresh_var(), debug);
 }
 
 int TypeSystemCore::ll_new_term(int f, std::vector<int> args, char const* debug) {

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -23,7 +23,6 @@ MonoId TypeSystemCore::new_term(
 }
 
 PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<VarId> vars) {
-	// TODO: check that the given vars are actually vars
 	PolyData data;
 	data.base = mono;
 	data.vars = std::move(vars);
@@ -47,7 +46,7 @@ MonoId TypeSystemCore::inst_impl(
 		std::vector<MonoId> new_args;
 		for (MonoId arg : ll_term_data[term].argument_idx)
 			new_args.push_back(inst_impl(arg, mapping));
-		return new_term(ll_term_data[term].function_id, std::move(new_args));
+		return ll_new_term(ll_term_data[term].function_id, std::move(new_args));
 	}
 }
 
@@ -191,6 +190,24 @@ void TypeSystemCore::add_left_constraints_to_right(VarId vi, VarId vj) {
 }
 
 bool TypeSystemCore::satisfies(MonoId t, Constraint const& c) {
+#if 0
+	assert(ll_node_header[t].tag == Tag::Term);
+
+	int tid = ll_node_header[t].data_idx;
+
+	TermData& t_data = ll_term_data[tid];
+	int tf = t_data.function_id;
+	auto& tf_data = get_type_function_data(tf);
+
+	if (c.shape == Constraint::Shape::Record  && tf_data.tag != TypeFunctionTag::Record ) return false;
+	if (c.shape == Constraint::Shape::Variant && tf_data.tag != TypeFunctionTag::Variant) return false;
+	if (!c.structure.empty() && tf_data.tag == TypeFunctionTag::Builtin) return false;
+
+	for (auto& kv : c.structure) {
+		if (!tf_data.structure.count(kv.first)) return false;
+		// ll_unify(kv.second, t_tf_data.structure[kv.first]);
+	}
+#endif
 	return true;
 }
 

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -10,8 +10,6 @@ TypeSystemCore::TypeSystemCore() {
 
 MonoId TypeSystemCore::new_term(
     TypeFunctionId tf, std::vector<int> args, char const* tag) {
-	tf = find_type_function(tf);
-
 	return ll_new_term(tf, std::move(args), tag);
 }
 
@@ -94,7 +92,7 @@ TypeFunctionId TypeSystemCore::create_type_function(
     int arity,
     std::vector<InternedString> fields,
     std::unordered_map<InternedString, MonoId> structure) {
-	TypeFunctionId result = m_type_function_uf.new_node();
+	TypeFunctionId result = m_type_functions.size();
 	m_type_functions.push_back(
 	    {tag, arity, std::move(fields), std::move(structure)});
 	return result;
@@ -120,9 +118,6 @@ static InternedString print_a_thing(int x) {
 }
 
 void TypeSystemCore::unify_type_function(TypeFunctionId i, TypeFunctionId j) {
-	i = find_type_function(i);
-	j = find_type_function(j);
-
 	if (i == j)
 		return;
 
@@ -271,11 +266,7 @@ bool TypeSystemCore::ll_is_var(int i) {
 }
 
 TypeFunctionData& TypeSystemCore::get_type_function_data(TypeFunctionId tf) {
-	return m_type_functions[find_type_function(tf)];
-}
-
-TypeFunctionId TypeSystemCore::find_type_function(TypeFunctionId tf) {
-	return m_type_function_uf.find(tf);
+	return m_type_functions[tf];
 }
 
 bool TypeSystemCore::equals_var(MonoId t, VarId v) {

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -10,7 +10,15 @@ TypeSystemCore::TypeSystemCore() {
 
 MonoId TypeSystemCore::new_term(
     TypeFunctionId tf, std::vector<int> args, char const* tag) {
-	assert(get_type_function_data(tf).argument_count == args.size() || get_type_function_data(tf).argument_count == -1);
+	tf = find_type_function(tf);
+
+	{
+		// This block of code ensures that tf has the right arity
+		TypeFunctionId dummy_tf = new_type_function_var();
+		get_type_function_data(dummy_tf).argument_count = args.size();
+		unify_type_function(tf, dummy_tf);
+	}
+
 	return ll_new_term(tf, std::move(args), tag);
 }
 
@@ -127,7 +135,27 @@ static InternedString print_a_thing(int x) {
 }
 
 void TypeSystemCore::unify_type_function(TypeFunctionId i, TypeFunctionId j) {
-	assert(i == j);
+	i = find_type_function(i);
+	j = find_type_function(j);
+
+	if (i == j)
+		return;
+
+	if (get_type_function_data(i).strength == TypeFunctionStrength::Full &&
+		get_type_function_data(j).strength == TypeFunctionStrength::Full) {
+		Log::fatal() << "unified " << print_a_thing(i) << " with " << print_a_thing(j);
+		// Log::fatal() << "unified different type functions";
+	}
+
+	if (get_type_function_data(j).strength == TypeFunctionStrength::None)
+		std::swap(i, j);
+
+	if (get_type_function_data(i).strength == TypeFunctionStrength::None) {
+		point_type_function_at_another(i, j);
+		return;
+	}
+
+	assert(false);
 }
 
 bool TypeSystemCore::occurs(VarId v, MonoId i) {
@@ -276,7 +304,11 @@ void TypeSystemCore::point_type_function_at_another(TypeFunctionId a, TypeFuncti
 }
 
 TypeFunctionData& TypeSystemCore::get_type_function_data(TypeFunctionId tf) {
-	return m_type_functions[tf];
+	return m_type_functions[find_type_function(tf)];
+}
+
+TypeFunctionId TypeSystemCore::find_type_function(TypeFunctionId tf) {
+	return m_type_function_uf.find(tf);
 }
 
 bool TypeSystemCore::equals_var(MonoId t, VarId v) {

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -9,8 +9,11 @@ TypeSystemCore::TypeSystemCore() {
 }
 
 MonoId TypeSystemCore::new_term(
-    TypeFunctionId tf, std::vector<int> args, char const* tag) {
-	return ll_new_term(tf, std::move(args), tag);
+    TypeFunctionId tf, std::vector<int> args, char const* debug) {
+	int type_id = m_type_counter++;
+	ll_node_header.push_back({Tag::Term, static_cast<int>(ll_term_data.size()), debug});
+	ll_term_data.push_back({tf, std::move(args)});
+	return type_id;
 }
 
 PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<VarId> vars) {
@@ -37,7 +40,7 @@ MonoId TypeSystemCore::inst_impl(
 		std::vector<MonoId> new_args;
 		for (MonoId arg : ll_term_data[term].argument_idx)
 			new_args.push_back(inst_impl(arg, mapping));
-		return ll_new_term(ll_term_data[term].function_id, std::move(new_args));
+		return new_term(ll_term_data[term].function_id, std::move(new_args));
 	}
 }
 
@@ -230,14 +233,6 @@ MonoId TypeSystemCore::var(VarId v, char const* debug) {
 
 int TypeSystemCore::ll_new_var(char const* debug) {
 	return var(fresh_var(), debug);
-}
-
-int TypeSystemCore::ll_new_term(int f, std::vector<int> args, char const* debug) {
-	int type_id = m_type_counter++;
-	assert(ll_node_header.size() == type_id);
-	ll_node_header.push_back({Tag::Term, static_cast<int>(ll_term_data.size()), debug});
-	ll_term_data.push_back({f, std::move(args)});
-	return type_id;
 }
 
 int TypeSystemCore::ll_find(int i) {

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -12,13 +12,6 @@ MonoId TypeSystemCore::new_term(
     TypeFunctionId tf, std::vector<int> args, char const* tag) {
 	tf = find_type_function(tf);
 
-	{
-		// This block of code ensures that tf has the right arity
-		TypeFunctionId dummy_tf = new_type_function_var();
-		get_type_function_data(dummy_tf).argument_count = args.size();
-		unify_type_function(tf, dummy_tf);
-	}
-
 	return ll_new_term(tf, std::move(args), tag);
 }
 

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -22,7 +22,7 @@ MonoId TypeSystemCore::new_term(
 	return ll_new_term(tf, std::move(args), tag);
 }
 
-PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
+PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<VarId> vars) {
 	// TODO: check that the given vars are actually vars
 	PolyData data;
 	data.base = mono;
@@ -33,13 +33,14 @@ PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
 }
 
 MonoId TypeSystemCore::inst_impl(
-    MonoId mono, std::unordered_map<MonoId, MonoId> const& mapping) {
+    MonoId mono, std::unordered_map<int, MonoId> const& mapping) {
 
 	mono = ll_find(mono);
 	NodeHeader header = ll_node_header[mono];
 
 	if (header.tag == Tag::Var) {
-		auto it = mapping.find(mono);
+		VarId var = get_var_id(mono);
+		auto it = mapping.find(static_cast<int>(var));
 		return it == mapping.end() ? mono : it->second;
 	} else {
 		TermId term = header.data_idx;
@@ -55,9 +56,9 @@ MonoId TypeSystemCore::inst_with(PolyId poly, std::vector<MonoId> const& vals) {
 
 	assert(data.vars.size() == vals.size());
 
-	std::unordered_map<MonoId, MonoId> old_to_new;
+	std::unordered_map<int, MonoId> old_to_new;
 	for (int i {0}; i != data.vars.size(); ++i) {
-		old_to_new[data.vars[i]] = vals[i];
+		old_to_new[static_cast<int>(data.vars[i])] = vals[i];
 	}
 
 	return inst_impl(data.base, old_to_new);

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -174,22 +174,19 @@ bool TypeSystemCore::occurs(VarId v, MonoId i) {
 }
 
 void TypeSystemCore::unify_vars_left_to_right(VarId vi, VarId vj) {
-	combine_constraints_left_to_right(vi, vj);
+	add_left_constraints_to_right(vi, vj);
 	m_type_var_uf.join_left_to_right(static_cast<int>(vi), static_cast<int>(vj));
 }
 
-void TypeSystemCore::combine_constraints_left_to_right(VarId vi, VarId vj) {
-	// TODO
-	auto& i_constraints = m_constraints[static_cast<int>(vi)];
-	auto& j_constraints = m_constraints[static_cast<int>(vj)];
-	for (auto const& kv : i_constraints.structure) {
-		auto it = j_constraints.structure.find(kv.first);
-		if (it == j_constraints.structure.end()) {
-			j_constraints.structure.insert(kv);
-		} else {
-			ll_unify(kv.second, it->second);
-		}
-	}
+void TypeSystemCore::add_left_constraints_to_right(VarId vi, VarId vj) {
+	if (vi == vj) return;
+	auto& i_data = m_constraints[static_cast<int>(vi)];
+	if (i_data.shape == Constraint::Shape::Record)
+		add_record_constraint(vj);
+	if (i_data.shape == Constraint::Shape::Variant)
+		add_variant_constraint(vj);
+	for (auto const& kv : i_data.structure)
+		add_field_constraint(vj, kv.first, kv.second);
 	return;
 }
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -146,7 +146,6 @@ private:
 	bool ll_is_term(int i);
 
 	int ll_new_term(int f, std::vector<int> args = {}, const char* debug = nullptr);
-	void point_type_function_at_another(TypeFunctionId, TypeFunctionId);
 	void unify_type_function_data(TypeFunctionData&, TypeFunctionData&);
 	int compute_new_argument_count(TypeFunctionData const&, TypeFunctionData const&) const;
 public:

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -147,7 +147,6 @@ private:
 	bool ll_is_var(int i);
 	bool ll_is_term(int i);
 
-	int ll_new_term(int f, std::vector<int> args = {}, const char* debug = nullptr);
 	void unify_type_function_data(TypeFunctionData&, TypeFunctionData&);
 	int compute_new_argument_count(TypeFunctionData const&, TypeFunctionData const&) const;
 public:

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -151,7 +151,6 @@ private:
 public:
 	TypeFunctionData& get_type_function_data(TypeFunctionId);
 private:
-	TypeFunctionId find_type_function(TypeFunctionId);
 
 	TypeFunctionId create_type_function(
 	    TypeFunctionTag tag,
@@ -173,7 +172,6 @@ public:
 private:
 	// per-func data
 	std::vector<TypeFunctionData> m_type_functions;
-	UnionFind m_type_function_uf;
 
 	// per-poly data
 	std::vector<PolyData> poly_data;

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -140,8 +140,6 @@ struct TypeSystemCore {
 	}
 private:
 
-	int new_constrained_var(Constraint c, char const* debug = nullptr);
-
 	enum class Tag { Var, Term, };
 
 	struct NodeHeader {

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -89,7 +89,6 @@ struct TypeSystemCore {
 	MonoId inst_fresh(PolyId poly);
 
 	TypeFunctionData& type_function_data_of(MonoId);
-	void unify_type_function(TypeFunctionId, TypeFunctionId);
 
 	void add_record_constraint(VarId v) {
 		int i = static_cast<int>(v);

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -12,11 +12,9 @@
 
 // Type function strength is an ad-hoc concept, specific to our implementation
 // of unification.
-// If a typefunc has 'None' strength, its data is not even considered for
-// unification.
 // If it has 'Full' strength, we only accept exact matches during unification.
 // We don't allow unifying two different full-strength type functions
-enum class TypeFunctionStrength { None, Full };
+enum class TypeFunctionStrength { Full };
 
 enum class VarId {};
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -43,7 +43,7 @@ struct TypeFunctionData {
 // any value, and still give a valid typing.
 struct PolyData {
 	MonoId base;
-	std::vector<MonoId> vars;
+	std::vector<VarId> vars;
 };
 
 struct Constraint {
@@ -67,7 +67,7 @@ struct TypeSystemCore {
 	    std::vector<MonoId> args,
 	    char const* tag = nullptr);
 
-	PolyId new_poly(MonoId mono, std::vector<MonoId> vars);
+	PolyId new_poly(MonoId mono, std::vector<VarId> vars);
 
 	TypeFunctionId new_builtin_type_function(int arguments);
 	TypeFunctionId new_type_function(
@@ -161,6 +161,8 @@ private:
 	void unify_vars_left_to_right(VarId vi, VarId vj);
 	void combine_constraints_left_to_right(VarId vi, VarId vj);
 	bool satisfies(MonoId t, Constraint const& c);
+
+public:
 	VarId get_var_id(MonoId i);
 
 private:

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "../algorithms/union_find.hpp"
+#include "../log/log.hpp"
 #include "../utils/interned_string.hpp"
 #include "typechecker_types.hpp"
 
@@ -123,6 +124,39 @@ struct TypeSystemCore {
 	TypeFunctionData& type_function_data_of(MonoId);
 	TypeFunctionId new_type_function_var();
 	void unify_type_function(TypeFunctionId, TypeFunctionId);
+
+	void add_record_constraint(VarId v) {
+		int i = static_cast<int>(v);
+		auto& current_shape = m_constraints[i].shape;
+		if (current_shape == Constraint::Shape::Unknown) {
+			current_shape = Constraint::Shape::Record;
+		} else if (current_shape == Constraint::Shape::Record) {
+			// OK!
+		} else {
+			Log::fatal() << "Some typevar is both union and struct";
+		}
+	}
+
+	void add_variant_constraint(VarId v) {
+		int i = static_cast<int>(v);
+		auto& current_shape = m_constraints[i].shape;
+		if (current_shape == Constraint::Shape::Unknown) {
+			current_shape = Constraint::Shape::Variant;
+		} else if (current_shape == Constraint::Shape::Variant) {
+			// OK!
+		} else {
+			Log::fatal() << "Some typevar is both variant and struct";
+		}
+	}
+
+	void add_field_constraint(VarId v, InternedString x, MonoId t) {
+		int i = static_cast<int>(v);
+		if (m_constraints[i].structure.count(x)) {
+			ll_unify(m_constraints[i].structure[x], t);
+		} else {
+			m_constraints[i].structure[x] = t;
+		}
+	}
 private:
 
 	int new_constrained_var(Constraint c, char const* debug = nullptr);

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -53,6 +53,9 @@ struct TypeSystemCore {
 
 	TypeSystemCore();
 
+	VarId fresh_var();
+	MonoId var(VarId, const char* debug = nullptr);
+
 	int ll_new_var(const char* debug = nullptr);
 	void ll_unify(int i, int j);
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -10,12 +10,6 @@
 #include "../utils/interned_string.hpp"
 #include "typechecker_types.hpp"
 
-// Type function strength is an ad-hoc concept, specific to our implementation
-// of unification.
-// If it has 'Full' strength, we only accept exact matches during unification.
-// We don't allow unifying two different full-strength type functions
-enum class TypeFunctionStrength { Full };
-
 enum class VarId {};
 
 inline bool operator<(VarId a, VarId b) {
@@ -27,6 +21,7 @@ inline bool operator==(VarId a, VarId b) {
 }
 
 enum class TypeFunctionTag { Builtin, Variant, Record };
+
 // Concrete type function. If it's a built-in, we use argument_count
 // to tell how many arguments it takes. Else, for variant, and record,
 // we store their structure as a hash from names to monotypes.
@@ -36,8 +31,6 @@ struct TypeFunctionData {
 
 	std::vector<InternedString> fields;
 	std::unordered_map<InternedString, MonoId> structure;
-
-	TypeFunctionStrength strength;
 };
 
 // A polytype is a type where some amount of type variables can take
@@ -165,8 +158,7 @@ private:
 	    TypeFunctionTag tag,
 	    int arity,
 	    std::vector<InternedString> fields,
-	    std::unordered_map<InternedString, MonoId> structure,
-	    TypeFunctionStrength);
+	    std::unordered_map<InternedString, MonoId> structure);
 
 	void establish_substitution(VarId var_id, int type_id);
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -13,8 +13,6 @@
 // of unification.
 // If a typefunc has 'None' strength, its data is not even considered for
 // unification.
-// If it has 'Half' strength, its data is considered to be incomplete, so we
-// allow adding to it, but not removing.
 // If it has 'Full' strength, we only accept exact matches during unification.
 // We don't allow unifying two different full-strength type functions
 enum class TypeFunctionStrength { None, Full };

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -159,7 +159,9 @@ private:
 	void point_type_function_at_another(TypeFunctionId, TypeFunctionId);
 	void unify_type_function_data(TypeFunctionData&, TypeFunctionData&);
 	int compute_new_argument_count(TypeFunctionData const&, TypeFunctionData const&) const;
+public:
 	TypeFunctionData& get_type_function_data(TypeFunctionId);
+private:
 	TypeFunctionId find_type_function(TypeFunctionId);
 
 	TypeFunctionId create_type_function(

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -32,11 +32,6 @@ enum class TypeFunctionTag { Builtin, Variant, Record };
 // Concrete type function. If it's a built-in, we use argument_count
 // to tell how many arguments it takes. Else, for variant, and record,
 // we store their structure as a hash from names to monotypes.
-//
-// Dummy type functions are for unification purposes only, but do not count
-// as 'deduced', because they were not created by the user/
-//
-// TODO: change for polymorphic approach
 struct TypeFunctionData {
 	TypeFunctionTag tag;
 	int argument_count; // -1 means variadic
@@ -95,7 +90,7 @@ struct TypeSystemCore {
 		return new_type_function(TypeFunctionTag::Variant, {}, std::move(structure));
 	}
 
-	// qualifies all unbound variables in the given monotype
+	// finds all free variables in the given monotype
 	void gather_free_vars(MonoId mono, std::set<VarId>& free_vars);
 
 	MonoId inst_impl(MonoId mono, std::map<VarId, MonoId> const& mapping);
@@ -179,7 +174,7 @@ private:
 	bool occurs(VarId v, MonoId i);
 	bool equals_var(MonoId t, VarId v);
 	void unify_vars_left_to_right(VarId vi, VarId vj);
-	void combine_constraints_left_to_right(VarId vi, VarId vj);
+	void add_left_constraints_to_right(VarId vi, VarId vj);
 	bool satisfies(MonoId t, Constraint const& c);
 
 public:

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -98,7 +98,6 @@ struct TypeSystemCore {
 	MonoId inst_fresh(PolyId poly);
 
 	TypeFunctionData& type_function_data_of(MonoId);
-	TypeFunctionId new_type_function_var();
 	void unify_type_function(TypeFunctionId, TypeFunctionId);
 
 	void add_record_constraint(VarId v) {

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -95,18 +95,6 @@ struct TypeSystemCore {
 		return new_type_function(TypeFunctionTag::Variant, {}, std::move(structure));
 	}
 
-	MonoId new_dummy_for_typecheck1(
-		std::unordered_map<InternedString, MonoId> structure) {
-		return new_constrained_var(
-		    {std::move(structure), Constraint::Shape::Variant});
-	}
-
-	MonoId new_dummy_for_typecheck2(
-		std::unordered_map<InternedString, MonoId> structure) {
-		return new_constrained_var(
-		    {std::move(structure), Constraint::Shape::Record});
-	}
-
 	// qualifies all unbound variables in the given monotype
 	void gather_free_vars(MonoId mono, std::set<VarId>& free_vars);
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <unordered_map>
-#include <unordered_set>
+#include <set>
+#include <map>
 #include <vector>
 
 #include "../algorithms/union_find.hpp"
@@ -19,6 +20,14 @@
 enum class TypeFunctionStrength { None, Full };
 
 enum class VarId {};
+
+inline bool operator<(VarId a, VarId b) {
+	return static_cast<int>(a) < static_cast<int>(b);
+}
+
+inline bool operator==(VarId a, VarId b) {
+	return static_cast<int>(a) == static_cast<int>(b);
+}
 
 enum class TypeFunctionTag { Builtin, Variant, Record };
 // Concrete type function. If it's a built-in, we use argument_count
@@ -107,9 +116,9 @@ struct TypeSystemCore {
 	}
 
 	// qualifies all unbound variables in the given monotype
-	void gather_free_vars(MonoId mono, std::unordered_set<MonoId>& free_vars);
+	void gather_free_vars(MonoId mono, std::set<VarId>& free_vars);
 
-	MonoId inst_impl(MonoId mono, std::unordered_map<MonoId, MonoId> const& mapping);
+	MonoId inst_impl(MonoId mono, std::map<VarId, MonoId> const& mapping);
 	MonoId inst_with(PolyId poly, std::vector<MonoId> const& vals);
 	MonoId inst_fresh(PolyId poly);
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -95,13 +95,6 @@ struct TypeSystemCore {
 		return new_type_function(TypeFunctionTag::Variant, {}, std::move(structure));
 	}
 
-	// dummy with one constructor, the one used
-	MonoId new_dummy_for_ct_eval(InternedString member) {
-		return new_constrained_var(
-		    {{{member, ll_new_var()}}, Constraint::Shape::Variant},
-		    "Union Constructor Access");
-	}
-
 	MonoId new_dummy_for_typecheck1(
 		std::unordered_map<InternedString, MonoId> structure) {
 		return new_constrained_var(


### PR DESCRIPTION
The idea of typefunc variables and dummy typefuncs was a source of complexity and confusion since their very inception. At their core, they existed to allow reference cycles between typefunc definitions: We first stub each typefunc with a variable, then we create the real typefuncs with references to those variables, and finally unify each typefunc with its corresponding variable, which creates the desired cycles.

Although this could works, it's a complete overkill. It's much easier to create the typefunc objects in two phases: first create an incomplete stub with no references to other typefuncs then add all the references after that.

In this PR I removed the concept of typefunc unification and the infrastructure around it (i.e. `TypeFunctionStrength`, `TypeSystemCore::m_type_func_uf`).

All the constraints that were expressed indirectly through typefunc vars are now expressed explicitly through typevar constraints. I consider this approach to be simpler, more readable and more elegant.

This moves a bit of logic from `typesystem` to `typecheck` et al, but that's probably the right place for it anyways.

I also took the time to use the strongly-typed `VarId` in more places.

-------------------

So, it ended up being 20 lines longer than we started with but I can live with that. Also, this probably opens up further simplifications that will make the code shorter. Just have to read through the various functions and notice duplicated or convoluted code.

I really like how the stub/complete_type_function pair (in ct_eval) turned out, it makes me want to delete compute_type_func. Maybe it can be written like this?

    compute_type_func(ast) {
      stub_type_function(ast);
      complete_type_function(ast);
      return get_type_function(ast);
    }