### PR TITLE
Remove typefunc vars

### DIFF
--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -280,7 +280,9 @@ static void complete_type_function(AST::Expr* ast, TypeChecker& tc) {
 
 		int n = names.size();
 		for (int i = 0; i < n; ++i) {
-			tc.core().ll_unify(types[i], tc.core().get_type_function_data(tf).structure[names[i]]);
+			MonoId stub_ty = tc.core().get_type_function_data(tf).structure[names[i]];
+			MonoId actual_ty = types[i];
+			tc.core().ll_unify(stub_ty, actual_ty);
 		}
 
 	} break;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -307,7 +307,7 @@ static void complete_type_function(AST::Expr* ast, TypeChecker& tc) {
 	}
 }
 
-static void stub_type_function_id(AST::Expr* ast, TypeChecker& tc) {
+static void stub_type_function(AST::Expr* ast, TypeChecker& tc) {
 	switch (ast->type()) {
 
 	case ExprTag::StructExpression: {
@@ -380,7 +380,7 @@ static void do_the_thing(AST::Program* ast, TypeChecker& tc, AST::Allocator& all
 
 		// put a dummy var where required.
 		if (meta_type == MetaType::TypeFunction) {
-			stub_type_function_id(decl.m_value, tc);
+			stub_type_function(decl.m_value, tc);
 		} else if (meta_type == MetaType::Type) {
 			stub_monotype_id(decl.m_value, tc);
 		}

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -91,11 +91,6 @@ TypeFunctionId TypeSystemCore::new_type_function(
 	    type, 0, std::move(fields), std::move(structure), TypeFunctionStrength::Full);
 }
 
-TypeFunctionId TypeSystemCore::new_type_function_var() {
-	return create_type_function(
-	    TypeFunctionTag::Builtin, -1, {}, {}, TypeFunctionStrength::None);
-}
-
 TypeFunctionId TypeSystemCore::create_type_function(
     TypeFunctionTag tag,
     int arity,

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -10,8 +10,6 @@ TypeSystemCore::TypeSystemCore() {
 
 MonoId TypeSystemCore::new_term(
     TypeFunctionId tf, std::vector<int> args, char const* tag) {
-	tf = find_type_function(tf);
-
 	return ll_new_term(tf, std::move(args), tag);
 }
 
@@ -94,7 +92,7 @@ TypeFunctionId TypeSystemCore::create_type_function(
     int arity,
     std::vector<InternedString> fields,
     std::unordered_map<InternedString, MonoId> structure) {
-	TypeFunctionId result = m_type_function_uf.new_node();
+	TypeFunctionId result = m_type_functions.size();
 	m_type_functions.push_back(
 	    {tag, arity, std::move(fields), std::move(structure)});
 	return result;
@@ -120,9 +118,6 @@ static InternedString print_a_thing(int x) {
 }
 
 void TypeSystemCore::unify_type_function(TypeFunctionId i, TypeFunctionId j) {
-	i = find_type_function(i);
-	j = find_type_function(j);
-
 	if (i == j)
 		return;
 
@@ -259,16 +254,8 @@ bool TypeSystemCore::ll_is_var(int i) {
 	return ll_node_header[i].tag == Tag::Var;
 }
 
-void TypeSystemCore::point_type_function_at_another(TypeFunctionId a, TypeFunctionId b) {
-	m_type_function_uf.join_left_to_right(a, b);
-}
-
 TypeFunctionData& TypeSystemCore::get_type_function_data(TypeFunctionId tf) {
-	return m_type_functions[find_type_function(tf)];
-}
-
-TypeFunctionId TypeSystemCore::find_type_function(TypeFunctionId tf) {
-	return m_type_function_uf.find(tf);
+	return m_type_functions[tf];
 }
 
 bool TypeSystemCore::equals_var(MonoId t, VarId v) {

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -79,27 +79,24 @@ void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<MonoId>& f
 
 
 TypeFunctionId TypeSystemCore::new_builtin_type_function(int arity) {
-	return create_type_function(
-	    TypeFunctionTag::Builtin, arity, {}, {}, TypeFunctionStrength::Full);
+	return create_type_function(TypeFunctionTag::Builtin, arity, {}, {});
 }
 
 TypeFunctionId TypeSystemCore::new_type_function(
     TypeFunctionTag type,
     std::vector<InternedString> fields,
     std::unordered_map<InternedString, MonoId> structure) {
-	return create_type_function(
-	    type, 0, std::move(fields), std::move(structure), TypeFunctionStrength::Full);
+	return create_type_function(type, 0, std::move(fields), std::move(structure));
 }
 
 TypeFunctionId TypeSystemCore::create_type_function(
     TypeFunctionTag tag,
     int arity,
     std::vector<InternedString> fields,
-    std::unordered_map<InternedString, MonoId> structure,
-    TypeFunctionStrength strength) {
+    std::unordered_map<InternedString, MonoId> structure) {
 	TypeFunctionId result = m_type_function_uf.new_node();
 	m_type_functions.push_back(
-	    {tag, arity, std::move(fields), std::move(structure), strength});
+	    {tag, arity, std::move(fields), std::move(structure)});
 	return result;
 }
 
@@ -129,21 +126,7 @@ void TypeSystemCore::unify_type_function(TypeFunctionId i, TypeFunctionId j) {
 	if (i == j)
 		return;
 
-	if (get_type_function_data(i).strength == TypeFunctionStrength::Full &&
-		get_type_function_data(j).strength == TypeFunctionStrength::Full) {
-		Log::fatal() << "unified " << print_a_thing(i) << " with " << print_a_thing(j);
-		// Log::fatal() << "unified different type functions";
-	}
-
-	if (get_type_function_data(j).strength == TypeFunctionStrength::None)
-		std::swap(i, j);
-
-	if (get_type_function_data(i).strength == TypeFunctionStrength::None) {
-		point_type_function_at_another(i, j);
-		return;
-	}
-
-	assert(false);
+	Log::fatal() << "unified " << print_a_thing(i) << " with " << print_a_thing(j);
 }
 
 bool TypeSystemCore::occurs(VarId v, MonoId i) {

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -12,13 +12,6 @@ MonoId TypeSystemCore::new_term(
     TypeFunctionId tf, std::vector<int> args, char const* tag) {
 	tf = find_type_function(tf);
 
-	{
-		// This block of code ensures that tf has the right arity
-		TypeFunctionId dummy_tf = new_type_function_var();
-		get_type_function_data(dummy_tf).argument_count = args.size();
-		unify_type_function(tf, dummy_tf);
-	}
-
 	return ll_new_term(tf, std::move(args), tag);
 }
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -131,13 +131,9 @@ private:
 	bool ll_is_term(int i);
 
 	int ll_new_term(int f, std::vector<int> args = {}, const char* debug = nullptr);
-	void point_type_function_at_another(TypeFunctionId, TypeFunctionId);
-	void unify_type_function_data(TypeFunctionData&, TypeFunctionData&);
-	int compute_new_argument_count(TypeFunctionData const&, TypeFunctionData const&) const;
 public:
 	TypeFunctionData& get_type_function_data(TypeFunctionId);
 private:
-	TypeFunctionId find_type_function(TypeFunctionId);
 
 	TypeFunctionId create_type_function(
 	    TypeFunctionTag tag,
@@ -157,7 +153,6 @@ private:
 private:
 	// per-func data
 	std::vector<TypeFunctionData> m_type_functions;
-	UnionFind m_type_function_uf;
 
 	// per-poly data
 	std::vector<PolyData> poly_data;

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -75,15 +75,18 @@ struct TypeSystemCore {
 	    std::vector<InternedString> fields,
 	    std::unordered_map<InternedString, MonoId> structure);
 
-	TypeFunctionId new_type_function_for_ct_eval1(
-	    std::vector<InternedString> fields,
-	    std::unordered_map<InternedString, MonoId> structure) {
+	TypeFunctionId new_record(std::vector<InternedString> fields, std::vector<MonoId> const& types) {
+		std::unordered_map<InternedString, MonoId> structure;
+		for (int i = 0; i < fields.size(); ++i)
+			structure[fields[i]] = types[i];
 		return new_type_function(
 		    TypeFunctionTag::Record, std::move(fields), std::move(structure));
 	}
 
-	TypeFunctionId new_type_function_for_ct_eval2(
-	    std::unordered_map<InternedString, MonoId> structure) {
+	TypeFunctionId new_variant(std::vector<InternedString> const& fields, std::vector<MonoId> const& types) {
+		std::unordered_map<InternedString, MonoId> structure;
+		for (int i = 0; i < fields.size(); ++i)
+			structure[fields[i]] = types[i];
 		return new_type_function(TypeFunctionTag::Variant, {}, std::move(structure));
 	}
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -8,16 +8,6 @@
 #include "../utils/interned_string.hpp"
 #include "typechecker_types.hpp"
 
-// Type function strength is an ad-hoc concept, specific to our implementation
-// of unification.
-// If a typefunc has 'None' strength, its data is not even considered for
-// unification.
-// If it has 'Half' strength, its data is considered to be incomplete, so we
-// allow adding to it, but not removing.
-// If it has 'Full' strength, we only accept exact matches during unification.
-// We don't allow unifying two different full-strength type functions
-enum class TypeFunctionStrength { None, Full };
-
 enum class VarId {};
 
 enum class TypeFunctionTag { Builtin, Variant, Record };
@@ -35,8 +25,6 @@ struct TypeFunctionData {
 
 	std::vector<InternedString> fields;
 	std::unordered_map<InternedString, MonoId> structure;
-
-	TypeFunctionStrength strength;
 };
 
 // A polytype is a type where some amount of type variables can take
@@ -155,8 +143,7 @@ private:
 	    TypeFunctionTag tag,
 	    int arity,
 	    std::vector<InternedString> fields,
-	    std::unordered_map<InternedString, MonoId> structure,
-	    TypeFunctionStrength);
+	    std::unordered_map<InternedString, MonoId> structure);
 
 	void establish_substitution(VarId var_id, int type_id);
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -147,7 +147,9 @@ private:
 	void point_type_function_at_another(TypeFunctionId, TypeFunctionId);
 	void unify_type_function_data(TypeFunctionData&, TypeFunctionData&);
 	int compute_new_argument_count(TypeFunctionData const&, TypeFunctionData const&) const;
+public:
 	TypeFunctionData& get_type_function_data(TypeFunctionId);
+private:
 	TypeFunctionId find_type_function(TypeFunctionId);
 
 	TypeFunctionId create_type_function(

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -117,7 +117,6 @@ struct TypeSystemCore {
 	MonoId inst_fresh(PolyId poly);
 
 	TypeFunctionData& type_function_data_of(MonoId);
-	TypeFunctionId new_type_function_var();
 	void unify_type_function(TypeFunctionId, TypeFunctionId);
 private:
 


### PR DESCRIPTION
This PR gets rid of the concept of typefunc vars and typefunc unification.

---------------------

Typefunc unification served two purposes: allow for cycles to exist between typefuncs (by first creating a variable for each typefunc that other typefuncs can refer to, then unifying each typefunc with its variable) and arity checking on type applications.

The first is addressed more directly by constructing typefuncs in two phases, as in this PR.

The second only needs to be done through unification because we can't check the arity of typefunc vars until they are unified. This is a circular justification (we need unification to deal with unification variables) so, if there is no other reason, we can get rid of it.

------------------------

The new approach:

`stub_type_function` creates the required typefunc objects, but with a typevar instead of the correct type for each field. Then, after all typefuncs are stubbed, we call `complete_type_function` on each typefunc, which actually computes the type of each field.

This is useful because references to any typefunc during `complete_type_func` can be fully resolved and checked (worst case we get a reference to a stub, but it's ok because stubs look a whole lot like the real thing).

I believe this is simpler, more elegant and more understandable than the unification approach.

------------------------

Some things I want to tackle in near-future PRs

- expose a better typevar constraint API, replacing the `new_dummy_*` family that's left over from when we heavily relied on typefunc unification to impose type constraints.
- check typevar constraints -- right now `satisfies` just returns `true`
- expose better APIs for creating type objects -- `new_term`, `ll_new_var`, `new_poly` are too annoying to read and write, so I'm thinking something more like `app`, `fresh_var`, `forall`, etc
- use `VarId` instead of `MonoId` in a bunch of places -- notably in `PolyData` and `gather_free_vars`

I actually wrote a PR that tackled a bunch of these but it was too big, intertwined and probably too annoying to review :yum: 