### PR TITLE
Use VarId where appropriate

### DIFF
--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -97,14 +97,14 @@ private:
 // quantifies all free variables in the given monotype
 PolyId TypecheckHelper::generalize(MonoId mono) {
 
-	std::vector<MonoId> vars;
+	std::vector<VarId> vars;
 	for (MonoId var : free_vars_of(mono)) {
 		if (!is_bound_to_env(var)) {
-			vars.push_back(var);
+			vars.push_back(core().get_var_id(var));
 		}
 	}
 
-	return core().new_poly(mono, std::move(vars));
+	return core().forall(std::move(vars), mono);
 }
 
 static void infer(AST::Expr* ast, TypecheckHelper& tc);

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -69,7 +69,7 @@ private:
 	Frontend::SymbolTable symbol_table;
 	TypeChecker& tc;
 
-	bool is_bound_to_env(MonoId var) {
+	bool is_bound_to_env(VarId var) {
 
 		for (auto& kv : symbol_table.bindings()) {
 			auto decl = kv.second;
@@ -86,8 +86,8 @@ private:
 		return false;
 	}
 
-	std::unordered_set<MonoId> free_vars_of(MonoId mono) {
-		std::unordered_set<MonoId> free_vars;
+	std::set<VarId> free_vars_of(MonoId mono) {
+		std::set<VarId> free_vars;
 		core().gather_free_vars(mono, free_vars);
 		return free_vars;
 	}
@@ -98,9 +98,9 @@ private:
 PolyId TypecheckHelper::generalize(MonoId mono) {
 
 	std::vector<VarId> vars;
-	for (MonoId var : free_vars_of(mono)) {
+	for (VarId var : free_vars_of(mono)) {
 		if (!is_bound_to_env(var)) {
-			vars.push_back(core().get_var_id(var));
+			vars.push_back(var);
 		}
 	}
 

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -86,8 +86,8 @@ private:
 		return false;
 	}
 
-	std::set<VarId> free_vars_of(MonoId mono) {
-		std::set<VarId> free_vars;
+	std::unordered_set<VarId> free_vars_of(MonoId mono) {
+		std::unordered_set<VarId> free_vars;
 		core().gather_free_vars(mono, free_vars);
 		return free_vars;
 	}

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -79,18 +79,13 @@ private:
 			if (decl->m_is_polymorphic) continue;
 
 			auto bound_type = decl->m_value_type;
-			if (free_vars_of(bound_type).count(var) != 0)
+			if (core().free_vars(bound_type).count(var) != 0)
 				return true;
 		}
 
 		return false;
 	}
 
-	std::unordered_set<VarId> free_vars_of(MonoId mono) {
-		std::unordered_set<VarId> free_vars;
-		core().gather_free_vars(mono, free_vars);
-		return free_vars;
-	}
 };
 
 
@@ -98,7 +93,7 @@ private:
 PolyId TypecheckHelper::generalize(MonoId mono) {
 
 	std::vector<VarId> vars;
-	for (VarId var : free_vars_of(mono)) {
+	for (VarId var : core().free_vars(mono)) {
 		if (!is_bound_to_env(var)) {
 			vars.push_back(var);
 		}

--- a/src/typechecker/typechecker.cpp
+++ b/src/typechecker/typechecker.cpp
@@ -30,24 +30,25 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 	// HACK: this is an ugly hack. bear with me...
 
 	{
-		auto var_id = new_var();
+		auto var_ty = new_var();
+		VarId var_id = core().get_var_id(var_ty);
 
 		{
-			auto poly = core().new_poly(var_id, {var_id});
+			auto poly = core().forall({var_id}, var_ty);
 			declare_builtin_value("print", poly);
 		}
 
 		{
 			auto array_mono_id =
-			    core().new_term(BuiltinType::Array, {var_id}, "array");
+			    core().new_term(BuiltinType::Array, {var_ty}, "array");
 
 			{
 				auto term_mono_id = core().new_term(
 				    BuiltinType::Function,
-				    {array_mono_id, var_id, mono_unit()},
+				    {array_mono_id, var_ty, mono_unit()},
 				    "[builtin] (array(<a>), a) -> unit");
 
-				auto poly_id = core().new_poly(term_mono_id, {var_id});
+				auto poly_id = core().forall({var_id}, term_mono_id);
 				declare_builtin_value("array_append", poly_id);
 			}
 			{
@@ -56,7 +57,7 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 				    {array_mono_id, mono_int()},
 				    "[builtin] (array(<a>)) -> int");
 
-				auto poly_id = core().new_poly(term_mono_id, {var_id});
+				auto poly_id = core().forall({var_id}, term_mono_id);
 				declare_builtin_value("size", poly_id);
 			}
 			{
@@ -65,7 +66,7 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 				    {array_mono_id, array_mono_id, array_mono_id},
 				    "[builtin] (array(<a>), array(<a>)) -> array(<a>)");
 
-				auto poly_id = core().new_poly(term_mono_id, {var_id});
+				auto poly_id = core().forall({var_id}, term_mono_id);
 				declare_builtin_value("array_extend", poly_id);
 			}
 			{
@@ -77,16 +78,16 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 				    {array_mono_id, mono_string(), mono_string()},
 				    "[builtin] (array(<int>), string)) -> string");
 
-				auto poly_id = core().new_poly(term_mono_id, {});
+				auto poly_id = core().forall({}, term_mono_id);
 				declare_builtin_value("array_join", poly_id);
 			}
 			{
 				auto term_mono_id = core().new_term(
 				    BuiltinType::Function,
-				    {array_mono_id, mono_int(), var_id},
+				    {array_mono_id, mono_int(), var_ty},
 				    "[builtin] (array(<a>), int) -> a");
 
-				auto poly_id = core().new_poly(term_mono_id, {var_id});
+				auto poly_id = core().forall({var_id}, term_mono_id);
 				declare_builtin_value("array_at", poly_id);
 			}
 		}
@@ -94,10 +95,10 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 		{
 			auto term_mono_id = core().new_term(
 			    BuiltinType::Function,
-			    {var_id, var_id, var_id},
+			    {var_ty, var_ty, var_ty},
 			    "[builtin] (a, a) -> a");
 
-			auto poly_id = core().new_poly(term_mono_id, {var_id});
+			auto poly_id = core().forall({var_id}, term_mono_id);
 
 			declare_builtin_value("+", poly_id);
 			declare_builtin_value("-", poly_id);
@@ -110,10 +111,10 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 		{
 			auto term_mono_id = core().new_term(
 			    BuiltinType::Function,
-			    {var_id, var_id, mono_boolean()},
+			    {var_ty, var_ty, mono_boolean()},
 			    "[builtin] (a, a) -> Bool");
 
-			auto poly_id = core().new_poly(term_mono_id, {var_id});
+			auto poly_id = core().forall({var_id}, term_mono_id);
 
 			declare_builtin_value( "<", poly_id);
 			declare_builtin_value(">=", poly_id);
@@ -129,7 +130,7 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 			    {mono_boolean(), mono_boolean(), mono_boolean()},
 			    "[builtin] (Bool, Bool) -> Bool");
 
-			auto poly_id = core().new_poly(term_mono_id, {});
+			auto poly_id = core().forall({}, term_mono_id);
 
 			declare_builtin_value("&&", poly_id);
 			declare_builtin_value("||", poly_id);
@@ -138,21 +139,21 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 		{
 			auto term_mono_id = core().new_term(
 			    BuiltinType::Function, {mono_int()}, "[builtin] () -> Integer");
-			auto poly_id = core().new_poly(term_mono_id, {});
+			auto poly_id = core().forall({}, term_mono_id);
 			declare_builtin_value("read_integer", poly_id);
 		}
 
 		{
 			auto term_mono_id = core().new_term(
 			    BuiltinType::Function, {mono_float()}, "[builtin] () -> Number");
-			auto poly_id = core().new_poly(term_mono_id, {});
+			auto poly_id = core().forall({}, term_mono_id);
 			declare_builtin_value("read_number", poly_id);
 		}
 
 		{
 			auto term_mono_id = core().new_term(
 			    BuiltinType::Function, {mono_string()}, "[builtin] () -> String");
-			auto poly_id = core().new_poly(term_mono_id, {});
+			auto poly_id = core().forall({}, term_mono_id);
 			declare_builtin_value("read_string", poly_id);
 			declare_builtin_value("read_line", poly_id);
 		}

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -23,10 +23,7 @@ PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
 
 PolyId TypeSystemCore::forall(std::vector<VarId> vars, MonoId ty) {
 	PolyId poly = poly_data.size();
-	PolyData data;
-	data.base = ty;
-	data.vars = std::move(vars);
-	poly_data.push_back(std::move(data));
+	poly_data.push_back({ty, std::move(vars)});
 	return poly;
 }
 

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -20,7 +20,7 @@ PolyId TypeSystemCore::forall(std::vector<VarId> vars, MonoId ty) {
 }
 
 MonoId TypeSystemCore::inst_impl(
-    MonoId mono, std::map<VarId, MonoId> const& mapping) {
+    MonoId mono, std::unordered_map<VarId, MonoId> const& mapping) {
 
 	mono = ll_find(mono);
 	NodeHeader header = ll_node_header[mono];
@@ -42,7 +42,7 @@ MonoId TypeSystemCore::inst_with(PolyId poly, std::vector<MonoId> const& vals) {
 
 	assert(data.vars.size() == vals.size());
 
-	std::map<VarId, MonoId> old_to_new;
+	std::unordered_map<VarId, MonoId> old_to_new;
 	for (int i {0}; i != data.vars.size(); ++i) {
 		old_to_new[data.vars[i]] = vals[i];
 	}
@@ -57,7 +57,7 @@ MonoId TypeSystemCore::inst_fresh(PolyId poly) {
 	return inst_with(poly, vals);
 }
 
-void TypeSystemCore::gather_free_vars(MonoId mono, std::set<VarId>& free_vars) {
+void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<VarId>& free_vars) {
 	mono = ll_find(mono);
 	const NodeHeader& header = ll_node_header[mono];
 

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -13,12 +13,19 @@ MonoId TypeSystemCore::new_term(
 	return ll_new_term(tf, std::move(args), tag);
 }
 
+
 PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
 	// TODO: check that the given vars are actually vars
-	PolyData data;
-	data.base = mono;
 	std::vector<VarId> actual_vars;
 	for (MonoId ty : vars) actual_vars.push_back(get_var_id(ty));
+
+	PolyId poly = forall(std::move(actual_vars), mono);
+	return poly;
+}
+
+PolyId TypeSystemCore::forall(std::vector<VarId> actual_vars, MonoId mono) {
+	PolyData data;
+	data.base = mono;
 	data.vars = std::move(actual_vars);
 	PolyId poly = poly_data.size();
 	poly_data.push_back(std::move(data));

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -57,12 +57,12 @@ MonoId TypeSystemCore::inst_fresh(PolyId poly) {
 	return inst_with(poly, vals);
 }
 
-void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<MonoId>& free_vars) {
+void TypeSystemCore::gather_free_vars(MonoId mono, std::set<VarId>& free_vars) {
 	mono = ll_find(mono);
 	const NodeHeader& header = ll_node_header[mono];
 
 	if (header.tag == Tag::Var) {
-		free_vars.insert(mono);
+		free_vars.insert(get_var_id(mono));
 	} else {
 		TermId term = header.data_idx;
 		for (MonoId arg : ll_term_data[term].argument_idx)

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -18,9 +18,7 @@ PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
 	// TODO: check that the given vars are actually vars
 	std::vector<VarId> actual_vars;
 	for (MonoId ty : vars) actual_vars.push_back(get_var_id(ty));
-
-	PolyId poly = forall(std::move(actual_vars), mono);
-	return poly;
+	return forall(std::move(actual_vars), mono);
 }
 
 PolyId TypeSystemCore::forall(std::vector<VarId> actual_vars, MonoId mono) {

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -57,6 +57,12 @@ MonoId TypeSystemCore::inst_fresh(PolyId poly) {
 	return inst_with(poly, vals);
 }
 
+std::unordered_set<VarId> TypeSystemCore::free_vars(MonoId mono) {
+	std::unordered_set<VarId> result;
+	gather_free_vars(mono, result);
+	return result;
+}
+
 void TypeSystemCore::gather_free_vars(MonoId mono, std::unordered_set<VarId>& free_vars) {
 	mono = ll_find(mono);
 	const NodeHeader& header = ll_node_header[mono];

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -21,11 +21,11 @@ PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
 	return forall(std::move(actual_vars), mono);
 }
 
-PolyId TypeSystemCore::forall(std::vector<VarId> actual_vars, MonoId mono) {
-	PolyData data;
-	data.base = mono;
-	data.vars = std::move(actual_vars);
+PolyId TypeSystemCore::forall(std::vector<VarId> vars, MonoId ty) {
 	PolyId poly = poly_data.size();
+	PolyData data;
+	data.base = ty;
+	data.vars = std::move(vars);
 	poly_data.push_back(std::move(data));
 	return poly;
 }

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -17,20 +17,22 @@ PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
 	// TODO: check that the given vars are actually vars
 	PolyData data;
 	data.base = mono;
-	data.vars = std::move(vars);
+	std::vector<VarId> actual_vars;
+	for (MonoId ty : vars) actual_vars.push_back(get_var_id(ty));
+	data.vars = std::move(actual_vars);
 	PolyId poly = poly_data.size();
 	poly_data.push_back(std::move(data));
 	return poly;
 }
 
 MonoId TypeSystemCore::inst_impl(
-    MonoId mono, std::unordered_map<MonoId, MonoId> const& mapping) {
+    MonoId mono, std::map<VarId, MonoId> const& mapping) {
 
 	mono = ll_find(mono);
 	NodeHeader header = ll_node_header[mono];
 
 	if (header.tag == Tag::Var) {
-		auto it = mapping.find(mono);
+		auto it = mapping.find(get_var_id(mono));
 		return it == mapping.end() ? mono : it->second;
 	} else {
 		TermId term = header.data_idx;
@@ -46,7 +48,7 @@ MonoId TypeSystemCore::inst_with(PolyId poly, std::vector<MonoId> const& vals) {
 
 	assert(data.vars.size() == vals.size());
 
-	std::unordered_map<MonoId, MonoId> old_to_new;
+	std::map<VarId, MonoId> old_to_new;
 	for (int i {0}; i != data.vars.size(); ++i) {
 		old_to_new[data.vars[i]] = vals[i];
 	}

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -13,14 +13,6 @@ MonoId TypeSystemCore::new_term(
 	return ll_new_term(tf, std::move(args), tag);
 }
 
-
-PolyId TypeSystemCore::new_poly(MonoId mono, std::vector<MonoId> vars) {
-	// TODO: check that the given vars are actually vars
-	std::vector<VarId> actual_vars;
-	for (MonoId ty : vars) actual_vars.push_back(get_var_id(ty));
-	return forall(std::move(actual_vars), mono);
-}
-
 PolyId TypeSystemCore::forall(std::vector<VarId> vars, MonoId ty) {
 	PolyId poly = poly_data.size();
 	poly_data.push_back({ty, std::move(vars)});

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -110,10 +110,11 @@ struct TypeSystemCore {
 		    {std::move(structure), Constraint::Shape::Record});
 	}
 
-	// qualifies all unbound variables in the given monotype
-	void gather_free_vars(MonoId mono, std::unordered_set<VarId>& free_vars);
+	std::unordered_set<VarId> free_vars(MonoId);
 
 private:
+	void gather_free_vars(MonoId, std::unordered_set<VarId>&);
+
 	MonoId inst_impl(MonoId mono, std::unordered_map<VarId, MonoId> const& mapping);
 	MonoId inst_with(PolyId poly, std::vector<MonoId> const& vals);
 public:

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -160,6 +160,7 @@ private:
 	void unify_vars_left_to_right(VarId vi, VarId vj);
 	void combine_constraints_left_to_right(VarId vi, VarId vj);
 	bool satisfies(MonoId t, Constraint const& c);
+public:
 	VarId get_var_id(MonoId i);
 
 private:

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -9,6 +10,14 @@
 #include "typechecker_types.hpp"
 
 enum class VarId {};
+
+inline bool operator<(VarId a, VarId b) {
+	return static_cast<int>(a) < static_cast<int>(b);
+}
+
+inline bool operator==(VarId a, VarId b) {
+	return static_cast<int>(a) == static_cast<int>(b);
+}
 
 enum class TypeFunctionTag { Builtin, Variant, Record };
 // Concrete type function. If it's a built-in, we use argument_count
@@ -31,7 +40,7 @@ struct TypeFunctionData {
 // any value, and still give a valid typing.
 struct PolyData {
 	MonoId base;
-	std::vector<MonoId> vars;
+	std::vector<VarId> vars;
 };
 
 struct Constraint {
@@ -100,8 +109,10 @@ struct TypeSystemCore {
 	// qualifies all unbound variables in the given monotype
 	void gather_free_vars(MonoId mono, std::unordered_set<MonoId>& free_vars);
 
-	MonoId inst_impl(MonoId mono, std::unordered_map<MonoId, MonoId> const& mapping);
+private:
+	MonoId inst_impl(MonoId mono, std::map<VarId, MonoId> const& mapping);
 	MonoId inst_with(PolyId poly, std::vector<MonoId> const& vals);
+public:
 	MonoId inst_fresh(PolyId poly);
 
 	TypeFunctionData& type_function_data_of(MonoId);

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -65,7 +65,6 @@ struct TypeSystemCore {
 	    char const* tag = nullptr);
 
 	PolyId forall(std::vector<VarId>, MonoId);
-	PolyId new_poly(MonoId mono, std::vector<MonoId> vars);
 
 	TypeFunctionId new_builtin_type_function(int arguments);
 	TypeFunctionId new_type_function(

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "../algorithms/union_find.hpp"
@@ -107,7 +107,7 @@ struct TypeSystemCore {
 	}
 
 	// qualifies all unbound variables in the given monotype
-	void gather_free_vars(MonoId mono, std::unordered_set<MonoId>& free_vars);
+	void gather_free_vars(MonoId mono, std::set<VarId>& free_vars);
 
 private:
 	MonoId inst_impl(MonoId mono, std::map<VarId, MonoId> const& mapping);

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -64,6 +64,7 @@ struct TypeSystemCore {
 	    std::vector<MonoId> args,
 	    char const* tag = nullptr);
 
+	PolyId forall(std::vector<VarId>, MonoId);
 	PolyId new_poly(MonoId mono, std::vector<MonoId> vars);
 
 	TypeFunctionId new_builtin_type_function(int arguments);

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <map>
-#include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "../algorithms/union_find.hpp"
@@ -11,13 +10,18 @@
 
 enum class VarId {};
 
-inline bool operator<(VarId a, VarId b) {
-	return static_cast<int>(a) < static_cast<int>(b);
-}
-
 inline bool operator==(VarId a, VarId b) {
 	return static_cast<int>(a) == static_cast<int>(b);
 }
+
+template<>
+struct std::hash<VarId> {
+	size_t operator()(VarId v) const {
+		return std::hash<int>{}(static_cast<int>(v));
+	}
+};
+
+
 
 enum class TypeFunctionTag { Builtin, Variant, Record };
 // Concrete type function. If it's a built-in, we use argument_count
@@ -107,10 +111,10 @@ struct TypeSystemCore {
 	}
 
 	// qualifies all unbound variables in the given monotype
-	void gather_free_vars(MonoId mono, std::set<VarId>& free_vars);
+	void gather_free_vars(MonoId mono, std::unordered_set<VarId>& free_vars);
 
 private:
-	MonoId inst_impl(MonoId mono, std::map<VarId, MonoId> const& mapping);
+	MonoId inst_impl(MonoId mono, std::unordered_map<VarId, MonoId> const& mapping);
 	MonoId inst_with(PolyId poly, std::vector<MonoId> const& vals);
 public:
 	MonoId inst_fresh(PolyId poly);


### PR DESCRIPTION
Use `VarId` instead of `MonoId` where appropriate (`PolyData` and `gather_free_vars`, mainly)

I had to define comparison operators to make it work with `std::set` and `std::map`

Also, I renamed `new_poly` to `forall`