### PR TITLE
Dont rewrite nodes in ct_eval

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -233,9 +233,13 @@ struct MatchExpression : public Expr {
 	    : Expr {ExprTag::MatchExpression} {}
 };
 
+struct Constructor;
+
 struct ConstructorExpression : public Expr {
 	Expr* m_constructor;
 	std::vector<Expr*> m_args;
+
+	Constructor* m_evaluated_constructor {nullptr};
 
 	ConstructorExpression()
 	    : Expr {ExprTag::ConstructorExpression} {}

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -331,14 +331,13 @@ struct BuiltinTypeFunction : public Expr {
 	    : Expr {ExprTag::BuiltinTypeFunction} {}
 };
 
-struct Constructor : public Expr {
+struct Constructor : public AST {
 	MonoId m_mono;
 	InternedString m_id;
 	// points to the ast node this one was made from
 	Expr* m_syntax;
 
-	Constructor()
-	    : Expr {ExprTag::Constructor} {}
+	Constructor() {}
 };
 
 } // namespace AST

--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -22,7 +22,6 @@
 	X(StructExpression)                                                        \
 	X(TypeTerm)                                                                \
 	X(BuiltinTypeFunction)                                                     \
-	X(Constructor)
 
 #define AST_STMT_TAGS                                                          \
 	X(Block)                                                                   \

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -210,7 +210,6 @@ void compute_offsets(AST::Expr* ast, int frame_offset) {
 		DISPATCH(TypeTerm);
 
 		DO_NOTHING(BuiltinTypeFunction);
-		DO_NOTHING(Constructor);
 	}
 
 #undef DO_NOTHING

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -388,7 +388,6 @@ void eval(AST::Expr* ast, Interpreter& e) {
 		DISPATCH(StructExpression);
 		DISPATCH(UnionExpression);
 		DISPATCH(BuiltinTypeFunction);
-		DISPATCH(Constructor);
 	}
 
 	Log::fatal() << "(internal) unhandled case in eval: "

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -35,16 +35,14 @@ static std::vector<MonoId> compute_monos(std::vector<AST::Expr*> const&, TypeChe
 
 // literals
 
-static void ct_eval(
-    AST::ArrayLiteral* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::ArrayLiteral* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	for (auto& element : ast->m_elements)
 		ct_eval(element, tc, alloc);
 }
 
 // expressions
 
-static void ct_eval(
-    AST::FunctionLiteral* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::FunctionLiteral* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	for (auto& arg : ast->m_args)
 		if (arg.m_type_hint)
 			ct_eval(arg.m_type_hint, tc, alloc);
@@ -52,12 +50,10 @@ static void ct_eval(
 	ct_eval(ast->m_body, tc, alloc);
 }
 
-static void ct_eval(
-    AST::Identifier* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::Identifier* ast, TypeChecker& tc, AST::Allocator& alloc) {
 }
 
-static void ct_eval(
-    AST::CallExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::CallExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 
 	ct_eval(ast->m_callee, tc, alloc);
 
@@ -65,21 +61,18 @@ static void ct_eval(
 		ct_eval(arg, tc, alloc);
 }
 
-static void ct_eval(
-    AST::IndexExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::IndexExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	ct_eval(ast->m_callee, tc, alloc);
 	ct_eval(ast->m_index, tc, alloc);
 }
 
-static void ct_eval(
-    AST::TernaryExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::TernaryExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	ct_eval(ast->m_condition, tc, alloc);
 	ct_eval(ast->m_then_expr, tc, alloc);
 	ct_eval(ast->m_else_expr, tc, alloc);
 }
 
-static void ct_eval(
-    AST::AccessExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::AccessExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 
 	MetaType meta_type = ast->m_meta_type;
 
@@ -89,11 +82,7 @@ static void ct_eval(
 	ct_eval(ast->m_target, tc, alloc);
 }
 
-static void ct_eval(
-    AST::MatchExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
-
-	// NOTE: no need to ct_eval the identifier, because it is guaranteed
-	// to be of metatype value, thus nothing needs to be done
+static void ct_eval(AST::MatchExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 
 	if (ast->m_type_hint) {
 		ct_eval(ast->m_type_hint, tc, alloc);
@@ -120,19 +109,16 @@ static void ct_eval(
 		ct_eval(arg, tc, alloc);
 }
 
-static void ct_eval(
-    AST::SequenceExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::SequenceExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	ct_visit(ast->m_body, tc, alloc);
 }
 // types
 
-static void ct_eval(
-    AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::StructExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	ast->m_value = compute_type_func(ast, tc);
 }
 
-static void ct_eval(
-    AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
+static void ct_eval(AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	ast->m_value = compute_type_func(ast, tc);
 }
 

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -57,25 +57,6 @@ static AST::FunctionLiteral* ct_eval(
 
 static AST::Expr* ct_eval(
     AST::Identifier* ast, TypeChecker& tc, AST::Allocator& alloc) {
-	// This does something very similar to what ct_eval(Program) does.
-	// Maybe it can be de-duplicated?
-
-	assert(ast);
-	assert(ast->m_declaration);
-
-	MetaType meta_type = ast->m_declaration->m_meta_type;
-
-	assert(meta_type != MetaType::Undefined);
-
-	if (meta_type == MetaType::Term) {
-		return ast;
-	} else if (meta_type == MetaType::Type) {
-		return ast->m_declaration->m_value;
-	} else if (meta_type == MetaType::TypeFunction) {
-		return ast->m_declaration->m_value;
-	}
-
-	assert(0 && "UNREACHABLE");
 }
 
 static AST::CallExpression* ct_eval(

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -111,7 +111,7 @@ static AST::Expr* ct_eval(
 	MetaType meta_type = ast->m_meta_type;
 
 	if (meta_type == MetaType::Constructor)
-		return constructor_from_ast(ast, tc, alloc);
+		return ast;
 
 	ast->m_target = ct_eval(ast->m_target, tc, alloc);
 	return ast;
@@ -144,7 +144,8 @@ static AST::Expr* ct_eval(
 
 static AST::ConstructorExpression* ct_eval(
     AST::ConstructorExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
-	ast->m_constructor = constructor_from_ast(ast->m_constructor, tc, alloc);
+
+	ast->m_evaluated_constructor = constructor_from_ast(ast->m_constructor, tc, alloc);
 
 	for (auto& arg : ast->m_args)
 		arg = ct_eval(arg, tc, alloc);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -442,7 +442,6 @@ static void ct_eval(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc) {
 		DISPATCH(StructExpression);
 		DISPATCH(UnionExpression);
 		REJECT(BuiltinTypeFunction);
-		REJECT(Constructor);
 	}
 
 	Log::fatal() << "(internal) Unhandled case in ct_eval : "

--- a/src/typechecker/metacheck.cpp
+++ b/src/typechecker/metacheck.cpp
@@ -104,7 +104,6 @@ static MetaType infer_shallow(AST::Expr* ast) {
 		return MetaType::Undefined;
 
 	case ExprTag::BuiltinTypeFunction:
-	case ExprTag::Constructor:
 		Log::fatal() << "unexpected AST type in infer_shallow ("
 		             << AST::expr_string[int(ast->type())] << ") during infer";
 	}
@@ -313,7 +312,6 @@ static MetaType infer(AST::Expr* ast) {
 	case ExprTag::AccessExpression: return infer(static_cast<AST::AccessExpression*>(ast));
 	case ExprTag::Identifier: return infer(static_cast<AST::Identifier*>(ast));
 	case ExprTag::BuiltinTypeFunction:
-	case ExprTag::Constructor:
 		Log::fatal() << "unexpected AST type in infer_shallow ("
 		             << AST::expr_string[int(ast->type())] << ") during infer";
 	}

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -435,7 +435,6 @@ static void infer(AST::Expr* ast, TypecheckHelper& tc) {
 		DISPATCH(SequenceExpression);
 
 		IGNORE(BuiltinTypeFunction);
-		IGNORE(Constructor);
 	}
 
 	Log::fatal() << "(internal) CST type not handled in infer: "

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -254,10 +254,9 @@ static void infer(AST::MatchExpression* ast, TypecheckHelper& tc) {
 }
 
 static void infer(AST::ConstructorExpression* ast, TypecheckHelper& tc) {
-	infer(ast->m_constructor, tc);
 
-	auto constructor = static_cast<AST::Constructor*>(ast->m_constructor);
-	assert(constructor->type() == ExprTag::Constructor);
+	auto constructor = ast->m_evaluated_constructor;
+	assert(constructor);
 
 	TypeFunctionData& tf_data = tc.core().type_function_data_of(constructor->m_mono);
 

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -92,8 +92,8 @@ static void process_type_hint(AST::Declaration* ast, TypecheckHelper& tc);
 
 static MonoId get_monotype_id(AST::Expr* ast) {
 	switch(ast->type()) {
-	case ExprTag::TypeTerm:
-		return static_cast<AST::TypeTerm*>(ast)->m_value;
+	case ExprTag::TypeTerm: return static_cast<AST::TypeTerm*>(ast)->m_value;
+	case ExprTag::Identifier: return get_monotype_id(static_cast<AST::Identifier*>(ast)->m_declaration->m_value);
 	default: assert(0);
 	}
 }


### PR DESCRIPTION
The only remaining instances of AST rewriting were rewriting access expressions into constructor nodes and non-term identifiers into whatever they referenced.

Instead, we now compute them on-demand. Instead of rewriting access expressions into constructors when we find them, we now store the constructor in the ConstructorExpression that actually uses it.

This means that **there is no AST rewriting in ct_eval**, a sentence I've wanted to say for a long time but getting there seemed really hard lol.

I hope this change enables further simplifications.