### PR TITLE
Type constraint api

### DIFF
--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -184,16 +184,16 @@ static AST::Constructor* constructor_from_ast(
 
 		auto access = static_cast<AST::AccessExpression*>(ast);
 
-		MonoId dummy_monotype = tc.core().ll_new_var();
-		auto v = tc.core().get_var_id(dummy_monotype);
+		MonoId actual_ty = compute_mono(access->m_target, tc);
+
+		// constraint target type
+		MonoId expected_ty = tc.core().ll_new_var();
+		auto v = tc.core().get_var_id(expected_ty);
 		tc.core().add_variant_constraint(v);
 		tc.core().add_field_constraint(v, access->m_member, tc.core().ll_new_var());
+		tc.core().ll_unify(expected_ty, actual_ty);
 
-		MonoId monotype = compute_mono(access->m_target, tc);
-
-		tc.core().ll_unify(dummy_monotype, monotype);
-
-		constructor->m_mono = monotype;
+		constructor->m_mono = actual_ty;
 		constructor->m_id = access->m_member;
 	} else {
 		Log::fatal() << "Constructor invokation on a non-constructor -- MetaType(" << int(meta) << ")";

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -184,7 +184,10 @@ static AST::Constructor* constructor_from_ast(
 
 		auto access = static_cast<AST::AccessExpression*>(ast);
 
-		MonoId dummy_monotype = tc.core().new_dummy_for_ct_eval(access->m_member);
+		MonoId dummy_monotype = tc.core().ll_new_var();
+		auto v = tc.core().get_var_id(dummy_monotype);
+		tc.core().add_variant_constraint(v);
+		tc.core().add_field_constraint(v, access->m_member, tc.core().ll_new_var());
 
 		MonoId monotype = compute_mono(access->m_target, tc);
 

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -202,23 +202,12 @@ void TypeSystemCore::ll_unify(int i, int j) {
 }
 
 int TypeSystemCore::ll_new_var() {
-	return new_constrained_var({});
-}
-
-int TypeSystemCore::new_constrained_var(Constraint c) {
 	int var_id = m_var_counter++;
-	int uf_node = m_type_var_uf.new_node();
-
-	assert(uf_node == var_id);
-	assert(m_substitution.size() == var_id);
-	assert(m_constraints.size() == var_id);
+	m_type_var_uf.new_node();
 	m_substitution.push_back(-1);
-	m_constraints.push_back(std::move(c));
-
+	m_constraints.push_back({});
 	int type_id = m_type_counter++;
-	assert(ll_node_header.size() == type_id);
 	ll_node_header.push_back({Tag::Var, var_id});
-
 	return type_id;
 }
 

--- a/src/typechecker/typesystem.cpp
+++ b/src/typechecker/typesystem.cpp
@@ -262,3 +262,31 @@ TypeFunctionData& TypeSystemCore::get_type_function_data(TypeFunctionId tf) {
 bool TypeSystemCore::equals_var(MonoId t, VarId v) {
 	return ll_is_var(t) && static_cast<VarId>(ll_node_header[t].data_idx) == v;
 }
+
+
+void TypeSystemCore::add_record_constraint(VarId v) {
+	int i = static_cast<int>(v);
+	if (m_constraints[i].shape == Constraint::Shape::Unknown) {
+		m_constraints[i].shape = Constraint::Shape::Record;
+	} else if (m_constraints[i].shape != Constraint::Shape::Record) {
+		Log::fatal() << "object used both as record and variant";
+	}
+}
+
+void TypeSystemCore::add_variant_constraint(VarId v) {
+	int i = static_cast<int>(v);
+	if (m_constraints[i].shape == Constraint::Shape::Unknown) {
+		m_constraints[i].shape = Constraint::Shape::Variant;
+	} else if (m_constraints[i].shape != Constraint::Shape::Variant) {
+		Log::fatal() << "object used both as record and variant";
+	}
+}
+
+void TypeSystemCore::add_field_constraint(VarId v, InternedString name, MonoId ty) {
+	int i = static_cast<int>(v);
+	if (m_constraints[i].structure.count(name)) {
+		ll_unify(m_constraints[i].structure[name], ty);
+	} else {
+		m_constraints[i].structure[name] = ty;
+	}
+}

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -104,37 +104,6 @@ struct TypeSystemCore {
 
 	void add_field_constraint(VarId, InternedString name, MonoId ty);
 
-	// dummy with one constructor, the one used
-	MonoId new_dummy_for_ct_eval(InternedString member) {
-		auto result = ll_new_var();
-		auto v = get_var_id(result);
-		add_variant_constraint(v);
-		add_field_constraint(v, member, ll_new_var());
-		return result;
-	}
-
-	MonoId new_dummy_for_typecheck1(
-		std::unordered_map<InternedString, MonoId> structure) {
-		auto result = ll_new_var();
-		auto v = get_var_id(result);
-		add_variant_constraint(v);
-		for (auto& kv : structure) {
-			add_field_constraint(v, kv.first, kv.second);
-		}
-		return result;
-	}
-
-	MonoId new_dummy_for_typecheck2(
-		std::unordered_map<InternedString, MonoId> structure) {
-		auto result = ll_new_var();
-		auto v = get_var_id(result);
-		add_record_constraint(v);
-		for (auto& kv : structure) {
-			add_field_constraint(v, kv.first, kv.second);
-		}
-		return result;
-	}
-
 	std::unordered_set<VarId> free_vars(MonoId);
 
 private:

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -60,9 +60,14 @@ struct TypeSystemCore {
 
 	TypeSystemCore();
 
-	int ll_new_var();
-	void ll_unify(int i, int j);
+	// types
 
+	std::unordered_set<VarId> free_vars(MonoId);
+	void ll_unify(MonoId i, MonoId j);
+	TypeFunctionData& type_function_data_of(MonoId);
+	VarId get_var_id(MonoId i);
+
+	MonoId ll_new_var();
 	MonoId new_term(TypeFunctionId type_function, std::vector<MonoId> args);
 
 	MonoId fun(std::vector<MonoId> arg_tys, MonoId res_ty) {
@@ -74,14 +79,21 @@ struct TypeSystemCore {
 		return new_term(TypeChecker::BuiltinType::Array, {elem_ty});
 	}
 
+	// typevars
 
+	void add_record_constraint(VarId);
+	void add_variant_constraint(VarId);
+	void add_field_constraint(VarId, InternedString name, MonoId ty);
+
+	// polytypes
+
+	MonoId inst_fresh(PolyId poly);
 	PolyId forall(std::vector<VarId>, MonoId);
 
+	// typefuncs
+
+	TypeFunctionData& get_type_function_data(TypeFunctionId);
 	TypeFunctionId new_builtin_type_function(int arguments);
-	TypeFunctionId new_type_function(
-	    TypeFunctionTag type,
-	    std::vector<InternedString> fields,
-	    std::unordered_map<InternedString, MonoId> structure);
 
 	TypeFunctionId new_record(std::vector<InternedString> fields, std::vector<MonoId> const& types) {
 		std::unordered_map<InternedString, MonoId> structure;
@@ -98,25 +110,17 @@ struct TypeSystemCore {
 		return new_type_function(TypeFunctionTag::Variant, {}, std::move(structure));
 	}
 
-	void add_record_constraint(VarId);
-
-	void add_variant_constraint(VarId);
-
-	void add_field_constraint(VarId, InternedString name, MonoId ty);
-
-	std::unordered_set<VarId> free_vars(MonoId);
-
 private:
+
+	TypeFunctionId new_type_function(
+	    TypeFunctionTag type,
+	    std::vector<InternedString> fields,
+	    std::unordered_map<InternedString, MonoId> structure);
 	void gather_free_vars(MonoId, std::unordered_set<VarId>&);
 
 	MonoId inst_impl(MonoId mono, std::unordered_map<VarId, MonoId> const& mapping);
 	MonoId inst_with(PolyId poly, std::vector<MonoId> const& vals);
-public:
-	MonoId inst_fresh(PolyId poly);
-
-	TypeFunctionData& type_function_data_of(MonoId);
 	void unify_type_function(TypeFunctionId, TypeFunctionId);
-private:
 
 	enum class Tag { Var, Term, };
 
@@ -138,9 +142,6 @@ private:
 	bool ll_is_term(int i);
 
 	int ll_new_term(int f, std::vector<int> args = {});
-public:
-	TypeFunctionData& get_type_function_data(TypeFunctionId);
-private:
 
 	TypeFunctionId create_type_function(
 	    TypeFunctionTag tag,
@@ -155,10 +156,6 @@ private:
 	void unify_vars_left_to_right(VarId vi, VarId vj);
 	void combine_constraints_left_to_right(VarId vi, VarId vj);
 	bool satisfies(MonoId t, Constraint const& c);
-public:
-	VarId get_var_id(MonoId i);
-
-private:
 	// per-func data
 	std::vector<TypeFunctionData> m_type_functions;
 

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -106,20 +106,33 @@ struct TypeSystemCore {
 
 	// dummy with one constructor, the one used
 	MonoId new_dummy_for_ct_eval(InternedString member) {
-		return new_constrained_var(
-		    {{{member, ll_new_var()}}, Constraint::Shape::Variant});
+		auto result = ll_new_var();
+		auto v = get_var_id(result);
+		add_variant_constraint(v);
+		add_field_constraint(v, member, ll_new_var());
+		return result;
 	}
 
 	MonoId new_dummy_for_typecheck1(
 		std::unordered_map<InternedString, MonoId> structure) {
-		return new_constrained_var(
-		    {std::move(structure), Constraint::Shape::Variant});
+		auto result = ll_new_var();
+		auto v = get_var_id(result);
+		add_variant_constraint(v);
+		for (auto& kv : structure) {
+			add_field_constraint(v, kv.first, kv.second);
+		}
+		return result;
 	}
 
 	MonoId new_dummy_for_typecheck2(
 		std::unordered_map<InternedString, MonoId> structure) {
-		return new_constrained_var(
-		    {std::move(structure), Constraint::Shape::Record});
+		auto result = ll_new_var();
+		auto v = get_var_id(result);
+		add_record_constraint(v);
+		for (auto& kv : structure) {
+			add_field_constraint(v, kv.first, kv.second);
+		}
+		return result;
 	}
 
 	std::unordered_set<VarId> free_vars(MonoId);

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -98,6 +98,12 @@ struct TypeSystemCore {
 		return new_type_function(TypeFunctionTag::Variant, {}, std::move(structure));
 	}
 
+	void add_record_constraint(VarId);
+
+	void add_variant_constraint(VarId);
+
+	void add_field_constraint(VarId, InternedString name, MonoId ty);
+
 	// dummy with one constructor, the one used
 	MonoId new_dummy_for_ct_eval(InternedString member) {
 		return new_constrained_var(

--- a/src/typechecker/typesystem.hpp
+++ b/src/typechecker/typesystem.hpp
@@ -118,8 +118,6 @@ public:
 	void unify_type_function(TypeFunctionId, TypeFunctionId);
 private:
 
-	int new_constrained_var(Constraint c);
-
 	enum class Tag { Var, Term, };
 
 	struct NodeHeader {


### PR DESCRIPTION
I created a builder-pattern-style API for adding constraints to typevars, replacing the old idea of dummies. I think this communicates the intent a lot better when reading the code.

Also took the opportunity to reorganize TypeSystemCore's public interface... side note, I feel like it's becoming pretty cohesive thanks to the last few commits :D.

This PR actually adds more code than it removes D: (but still has negative delta due to some shenanigans :D), but I feel like the improved quality justifies it