### PR TITLE
Jan 8 refactor

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -233,13 +233,19 @@ struct MatchExpression : public Expr {
 	    : Expr {ExprTag::MatchExpression} {}
 };
 
-struct Constructor;
+struct Constructor {
+	MonoId m_mono;
+	InternedString m_id;
+	// points to the ast node this one was made from
+
+	Constructor() {}
+};
 
 struct ConstructorExpression : public Expr {
 	Expr* m_constructor;
 	std::vector<Expr*> m_args;
 
-	Constructor* m_evaluated_constructor {nullptr};
+	Constructor m_evaluated_constructor;
 
 	ConstructorExpression()
 	    : Expr {ExprTag::ConstructorExpression} {}
@@ -329,14 +335,6 @@ struct BuiltinTypeFunction : public Expr {
 
 	BuiltinTypeFunction()
 	    : Expr {ExprTag::BuiltinTypeFunction} {}
-};
-
-struct Constructor : public AST {
-	MonoId m_mono;
-	InternedString m_id;
-	// points to the ast node this one was made from
-
-	Constructor() {}
 };
 
 } // namespace AST

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -335,7 +335,6 @@ struct Constructor : public AST {
 	MonoId m_mono;
 	InternedString m_id;
 	// points to the ast node this one was made from
-	Expr* m_syntax;
 
 	Constructor() {}
 };

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -236,7 +236,6 @@ struct MatchExpression : public Expr {
 struct Constructor {
 	MonoId m_mono;
 	InternedString m_id;
-	// points to the ast node this one was made from
 
 	Constructor() {}
 };

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -330,10 +330,6 @@ void eval(AST::BuiltinTypeFunction* ast, Interpreter& e) {
 	return eval(ast->m_syntax, e);
 }
 
-void eval(AST::Constructor* ast, Interpreter& e) {
-	return eval(ast->m_syntax, e);
-}
-
 void eval(AST::TypeTerm* ast, Interpreter& e) {
 	eval(ast->m_callee, e);
 }

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -64,7 +64,7 @@ ExitStatus execute(
 
 	if (settings.typecheck) {
 		TypeChecker::metacheck_program(ast);
-		TypeChecker::reify_types(ast, tc, ast_allocator);
+		TypeChecker::reify_types(ast, tc);
 		TypeChecker::typecheck_program(ast, tc);
 	}
 

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -302,7 +302,7 @@ static void stub_monotype_id(AST::Expr* ast, TypeChecker& tc) {
 	case ExprTag::TypeTerm:
 		return void(static_cast<AST::TypeTerm*>(ast)->m_value = tc.new_var());
 	case ExprTag::Identifier:
-		return void(stub_monotype_id(static_cast<AST::Identifier*>(ast)->m_declaration->m_value, tc));
+		return;
 	default: assert(0);
 	}
 }

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -26,7 +26,7 @@ void reify_types(AST::Program* ast, TypeChecker& tc, AST::Allocator& alloc) {
 static void ct_eval(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc);
 static void ct_visit(AST::Block* ast, TypeChecker& tc, AST::Allocator& alloc);
 
-static AST::Constructor* constructor_from_ast(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc);
+static AST::Constructor constructor_from_ast(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc);
 
 static MonoId compute_mono(AST::Expr*, TypeChecker&);
 static TypeFunctionId compute_type_func(AST::Expr*, TypeChecker&);
@@ -102,9 +102,7 @@ static void ct_eval(AST::MatchExpression* ast, TypeChecker& tc, AST::Allocator& 
 
 static void ct_eval(
     AST::ConstructorExpression* ast, TypeChecker& tc, AST::Allocator& alloc) {
-
 	ast->m_evaluated_constructor = constructor_from_ast(ast->m_constructor, tc, alloc);
-
 	for (auto& arg : ast->m_args)
 		ct_eval(arg, tc, alloc);
 }
@@ -122,13 +120,13 @@ static void ct_eval(AST::UnionExpression* ast, TypeChecker& tc, AST::Allocator& 
 	ast->m_value = compute_type_func(ast, tc);
 }
 
-static AST::Constructor* constructor_from_ast(
+static AST::Constructor constructor_from_ast(
     AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	MetaType meta = ast->m_meta_type;
-	auto constructor = alloc.make<AST::Constructor>();
+	auto constructor = AST::Constructor{};
 
 	if (meta == MetaType::Type) {
-		constructor->m_mono = compute_mono(ast, tc);
+		constructor.m_mono = compute_mono(ast, tc);
 	} else if (meta == MetaType::Constructor) {
 		assert(ast->type() == ExprTag::AccessExpression);
 
@@ -143,8 +141,8 @@ static AST::Constructor* constructor_from_ast(
 		tc.core().add_field_constraint(v, access->m_member, tc.core().ll_new_var());
 		tc.core().ll_unify(expected_ty, actual_ty);
 
-		constructor->m_mono = actual_ty;
-		constructor->m_id = access->m_member;
+		constructor.m_mono = actual_ty;
+		constructor.m_id = access->m_member;
 	} else {
 		Log::fatal() << "Constructor invokation on a non-constructor -- MetaType(" << int(meta) << ")";
 	}

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -262,33 +262,29 @@ static void complete_type_function(AST::Expr* ast, TypeChecker& tc) {
 	}
 }
 
+std::vector<MonoId> make_vars(int count, TypeChecker& tc) {
+	std::vector<MonoId> vars(count);
+	for (int i = 0; i < count; ++i) {
+		vars[i] = tc.core().ll_new_var();
+	}
+	return vars;
+}
+
 static void stub_type_function(AST::Expr* ast, TypeChecker& tc) {
 	switch (ast->type()) {
 
 	case ExprTag::StructExpression: {
 		auto struct_expression = static_cast<AST::StructExpression*>(ast);
-
-		int n = struct_expression->m_fields.size();
-		std::vector<MonoId> ty_stubs(n);
-		for (int i = 0; i < n; ++i) {
-			ty_stubs[i] = tc.core().ll_new_var();
-		}
-
-		struct_expression->m_value =
-		    tc.core().new_record(struct_expression->m_fields, ty_stubs);
+		struct_expression->m_value = tc.core().new_record(
+		    struct_expression->m_fields,
+		    make_vars(struct_expression->m_fields.size(), tc));
 	} break;
 
 	case ExprTag::UnionExpression: {
 		auto union_expression = static_cast<AST::UnionExpression*>(ast);
-
-		int n = union_expression->m_constructors.size();
-		std::vector<MonoId> ty_stubs(n);
-		for (int i = 0; i < n; ++i) {
-			ty_stubs[i] = tc.core().ll_new_var();
-		}
-
-		union_expression->m_value =
-		    tc.core().new_variant(union_expression->m_constructors, ty_stubs);
+		union_expression->m_value = tc.core().new_variant(
+		    union_expression->m_constructors,
+		    make_vars(union_expression->m_constructors.size(), tc));
 		break;
 	}
 

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -17,12 +17,6 @@ using AST::StmtTag;
 
 static void ct_visit(AST::Stmt*& ast, TypeChecker& tc);
 
-static void do_the_thing(AST::Program* ast, TypeChecker& tc);
-
-void reify_types(AST::Program* ast, TypeChecker& tc) {
-	do_the_thing(ast, tc);
-}
-
 static void ct_eval(AST::Expr* ast, TypeChecker& tc);
 static void ct_visit(AST::Block* ast, TypeChecker& tc);
 
@@ -312,7 +306,7 @@ static MonoId get_monotype_id(AST::Expr* ast) {
 	}
 }
 
-static void do_the_thing(AST::Program* ast, TypeChecker& tc) {
+void reify_types(AST::Program* ast, TypeChecker& tc) {
 
 	for (auto& decl : ast->m_declarations) {
 		MetaType meta_type = decl.m_meta_type;

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -335,13 +335,6 @@ static void do_the_thing(AST::Program* ast, TypeChecker& tc, AST::Allocator& all
 		for (auto decl : decls) {
 			MetaType meta_type = decl->m_meta_type;
 
-#if 0
-			std::cerr << "[ Pass 2 ] top level \"" << decl->m_identifier << "\"\n";
-			std::cerr << "           metatype tag is: Tag(" << int(meta_type) << ")\n";
-#endif
-
-			assert(meta_type != MetaType::Undefined);
-
 			if (meta_type == MetaType::TypeFunction) {
 				if (decl->m_type_hint)
 					Log::fatal() << "type hint not allowed in typefunc declaration";

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -126,7 +126,6 @@ static AST::Constructor* constructor_from_ast(
     AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc) {
 	MetaType meta = ast->m_meta_type;
 	auto constructor = alloc.make<AST::Constructor>();
-	constructor->m_syntax = ast;
 
 	if (meta == MetaType::Type) {
 		constructor->m_mono = compute_mono(ast, tc);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -437,34 +437,10 @@ static void ct_eval(AST::Expr* ast, TypeChecker& tc, AST::Allocator& alloc) {
 #undef RETURN
 }
 
-static TypeFunctionId compute_type_func(AST::Identifier* ast, TypeChecker& tc) {
-	assert(ast->m_declaration);
-	assert(ast->m_meta_type == MetaType::TypeFunction);
-	auto decl = ast->m_declaration;
-	return get_type_function_id(decl->m_value);
-}
-
-static TypeFunctionId compute_type_func(AST::StructExpression* ast, TypeChecker& tc) {
-	return tc.core().new_record(ast->m_fields, compute_monos(ast->m_types, tc));
-}
-
-static TypeFunctionId compute_type_func(AST::UnionExpression* ast, TypeChecker& tc) {
-	return tc.core().new_variant(ast->m_constructors, compute_monos(ast->m_types, tc));
-}
-
 static TypeFunctionId compute_type_func(AST::Expr* ast, TypeChecker& tc) {
-	assert(
-	    ast->type() == ExprTag::Identifier ||
-	    ast->type() == ExprTag::UnionExpression ||
-	    ast->type() == ExprTag::StructExpression);
-
-	if (ast->type() == ExprTag::UnionExpression) {
-		return compute_type_func(static_cast<AST::UnionExpression*>(ast), tc);
-	} else if (ast->type() == ExprTag::StructExpression) {
-		return compute_type_func(static_cast<AST::StructExpression*>(ast), tc);
-	} else {
-		return compute_type_func(static_cast<AST::Identifier*>(ast), tc);
-	}
+	stub_type_function(ast, tc);
+	complete_type_function(ast, tc);
+	return get_type_function_id(ast);
 }
 
 static MonoId compute_mono(AST::Identifier* ast, TypeChecker& tc) {

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -322,13 +322,6 @@ static void do_the_thing(AST::Program* ast, TypeChecker& tc, AST::Allocator& all
 	for (auto& decl : ast->m_declarations) {
 		MetaType meta_type = decl.m_meta_type;
 
-#if 0
-		std::cerr << "[ Pass 1 ] top level \"" << decl.m_identifier << "\"\n";
-		std::cerr << "           metatype tag is: Tag(" << int(meta_type) << ")\n";
-#endif
-
-		assert(meta_type != MetaType::Undefined);
-
 		// put a dummy var where required.
 		if (meta_type == MetaType::TypeFunction) {
 			stub_type_function(decl.m_value, tc);
@@ -447,13 +440,7 @@ static MonoId compute_mono(AST::Identifier* ast, TypeChecker& tc) {
 
 static MonoId compute_mono(AST::TypeTerm* ast, TypeChecker& tc) {
 	TypeFunctionId type_function = compute_type_func(ast->m_callee, tc);
-
-	std::vector<MonoId> args;
-	for (auto& arg : ast->m_args) {
-		args.push_back(compute_mono(arg, tc));
-	}
-
-	return tc.core().new_term(type_function, std::move(args));
+	return tc.core().new_term(type_function, compute_monos(ast->m_args, tc));
 }
 
 static MonoId compute_mono(AST::Expr* ast, TypeChecker& tc) {

--- a/src/typechecker/ct_eval.hpp
+++ b/src/typechecker/ct_eval.hpp
@@ -2,14 +2,12 @@
 
 namespace AST {
 struct Program;
-struct Expr;
-struct Allocator;
 }
 
 namespace TypeChecker {
 
 struct TypeChecker;
 
-void reify_types(AST::Program*, TypeChecker& tc, AST::Allocator& alloc);
+void reify_types(AST::Program*, TypeChecker& tc);
 
 } // namespace TypeChecker

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -37,9 +37,6 @@ struct TypecheckHelper {
 
 	void unify(MonoId i, MonoId j) { core().ll_unify(i, j); }
 
-	bool is_type(MetaType i) { return i == MetaType::TypeFunction || i == MetaType::Type; }
-	bool is_term(MetaType i) { return i == MetaType::Term; }
-
 	MonoId inst_fresh(PolyId i) { return tc.core().inst_fresh(i); }
 
 	MonoId new_term(TypeFunctionId type_function, std::vector<MonoId> arguments) {
@@ -134,7 +131,7 @@ static void infer(AST::Identifier* ast, TypecheckHelper& tc) {
 	AST::Declaration* declaration = ast->m_declaration;
 	assert(declaration);
 
-	assert(tc.is_term(declaration->m_meta_type));
+	assert(declaration->m_meta_type == MetaType::Term);
 
 	ast->m_value_type = declaration->m_is_polymorphic
 		? tc.inst_fresh(declaration->m_decl_type)

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -453,38 +453,17 @@ void typecheck_program(AST::Program* ast, TypeChecker& tc_) {
 
 	auto const& comps = tc.declaration_order();
 
-	std::vector<std::vector<AST::Declaration*>> value_components;
-
+	// This loop implements the [Rec] rule
 	for (auto const& component : comps) {
 
-		bool type_in_component = false;
-		bool non_type_in_component = false;
+		bool terms_only = true;
 		for (auto decl : component) {
-
-			if (tc.is_type(decl->m_meta_type)) {
-				type_in_component = true;
-			}
-
-			if (tc.is_term(decl->m_meta_type)) {
-				non_type_in_component = true;
+			if (decl->m_meta_type != MetaType::Term) {
+				terms_only = false;
 			}
 		}
 
-		// We don't deal with types and non-types in the same component.
-		//
-		// TODO: maybe we should be even more strict and reject
-		//       non-values in components of size > 1.
-		if (type_in_component && non_type_in_component) {
-			Log::fatal() << "found reference cycle with types and values";
-		}
-
-		if (!type_in_component) {
-			value_components.push_back(component);
-		}
-	}
-
-	// This loop implements the [Rec] rule
-	for (auto const& component : value_components) {
+		if (!terms_only) continue;
 
 		tc.new_nested_scope();
 

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -252,10 +252,9 @@ static void infer(AST::MatchExpression* ast, TypecheckHelper& tc) {
 
 static void infer(AST::ConstructorExpression* ast, TypecheckHelper& tc) {
 
-	auto constructor = ast->m_evaluated_constructor;
-	assert(constructor);
+	auto& constructor = ast->m_evaluated_constructor;
 
-	TypeFunctionData& tf_data = tc.core().type_function_data_of(constructor->m_mono);
+	TypeFunctionData& tf_data = tc.core().type_function_data_of(constructor.m_mono);
 
 	// match value arguments
 	if (tf_data.tag == TypeFunctionTag::Record) {
@@ -270,13 +269,13 @@ static void infer(AST::ConstructorExpression* ast, TypecheckHelper& tc) {
 		assert(ast->m_args.size() == 1);
 
 		infer(ast->m_args[0], tc);
-		InternedString id = constructor->m_id;
+		InternedString id = constructor.m_id;
 		MonoId constructor_type = tf_data.structure[id];
 
 		tc.unify(constructor_type, ast->m_args[0]->m_value_type);
 	}
 
-	ast->m_value_type = constructor->m_mono;
+	ast->m_value_type = constructor.m_mono;
 }
 
 // this function implements 'the value restriction', a technique

--- a/src/typechecker/typechecker_types.hpp
+++ b/src/typechecker/typechecker_types.hpp
@@ -7,8 +7,6 @@ using MonoId = int;
 using PolyId = int;
 using TypeVarId = int;
 
-using MetaTypeId = int;
-
 enum class MetaType { Term, Type, TypeFunction, Constructor, Undefined };
 
 namespace TypeChecker {


### PR DESCRIPTION
Summary:

- store `ConstructorExpression::m_evaluated_constructor` by value
- `ct_eval` no longer uses the AST allocator, so remove it as an argument
- move some misplaced code into `metacheck`
- a bunch of "low level" refactors, like replacing duped code with function calls

These changes get `ct_eval.cpp` well below the 500LOC mark :tada:, and I think we can get it sub-400LOC while simplifying and cleaning up even further

At this point, it feels like `ct_eval` doesn't do all that much, and it could even be merged right into `typecheck` after a few more simplifications :thinking: ...