### PR TITLE
Simplify type creation

### DIFF
--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -20,11 +20,11 @@ struct TypecheckHelper {
 
 	PolyId generalize(Type mono);
 
-	Type mono_int() { return tc.mono_int(); }
-	Type mono_float() { return tc.mono_float(); }
-	Type mono_string() { return tc.mono_string(); }
-	Type mono_boolean() { return tc.mono_boolean(); }
-	Type mono_unit() { return tc.mono_unit(); }
+	Type integer() { return tc.integer(); }
+	Type number() { return tc.number(); }
+	Type string() { return tc.string(); }
+	Type boolean() { return tc.boolean(); }
+	Type unit() { return tc.unit(); }
 
 	TypeSystemCore& core() { return tc.core(); }
 	std::vector<std::vector<AST::Declaration*>> const& declaration_order() const { return tc.declaration_order(); }
@@ -97,23 +97,23 @@ static Type get_monotype_id(AST::Expr* ast) {
 
 // Literals
 static void infer(AST::NumberLiteral* ast, TypecheckHelper& tc) {
-	ast->m_value_type = tc.mono_float();
+	ast->m_value_type = tc.number();
 }
 
 static void infer(AST::IntegerLiteral* ast, TypecheckHelper& tc) {
-	ast->m_value_type = tc.mono_int();
+	ast->m_value_type = tc.integer();
 }
 
 static void infer(AST::StringLiteral* ast, TypecheckHelper& tc) {
-	ast->m_value_type = tc.mono_string();
+	ast->m_value_type = tc.string();
 }
 
 static void infer(AST::BooleanLiteral* ast, TypecheckHelper& tc) {
-	ast->m_value_type = tc.mono_boolean();
+	ast->m_value_type = tc.boolean();
 }
 
 static void infer(AST::NullLiteral* ast, TypecheckHelper& tc) {
-	ast->m_value_type = tc.mono_unit();
+	ast->m_value_type = tc.unit();
 }
 
 static void infer(AST::ArrayLiteral* ast, TypecheckHelper& tc) {
@@ -186,14 +186,14 @@ static void infer(AST::IndexExpression* ast, TypecheckHelper& tc) {
 	auto arr = tc.core().array(var);
 	tc.unify(arr, ast->m_callee->m_value_type);
 
-	tc.unify(tc.mono_int(), ast->m_index->m_value_type);
+	tc.unify(tc.integer(), ast->m_index->m_value_type);
 
 	ast->m_value_type = var;
 }
 
 static void infer(AST::TernaryExpression* ast, TypecheckHelper& tc) {
 	infer(ast->m_condition, tc);
-	tc.unify(ast->m_condition->m_value_type, tc.mono_boolean());
+	tc.unify(ast->m_condition->m_value_type, tc.boolean());
 
 	infer(ast->m_then_expr, tc);
 	infer(ast->m_else_expr, tc);
@@ -342,7 +342,7 @@ static void typecheck_stmt(AST::Block* ast, TypecheckHelper& tc) {
 
 static void typecheck_stmt(AST::IfElseStatement* ast, TypecheckHelper& tc) {
 	infer(ast->m_condition, tc);
-	tc.unify(ast->m_condition->m_value_type, tc.mono_boolean());
+	tc.unify(ast->m_condition->m_value_type, tc.boolean());
 
 	typecheck_stmt(ast->m_body, tc);
 
@@ -354,7 +354,7 @@ static void typecheck_stmt(AST::WhileStatement* ast, TypecheckHelper& tc) {
 	// TODO: Why do while statements create a new scope?
 	tc.new_nested_scope();
 	infer(ast->m_condition, tc);
-	tc.unify(ast->m_condition->m_value_type, tc.mono_boolean());
+	tc.unify(ast->m_condition->m_value_type, tc.boolean());
 
 	typecheck_stmt(ast->m_body, tc);
 	tc.end_scope();

--- a/src/typechecker/typechecker.cpp
+++ b/src/typechecker/typechecker.cpp
@@ -45,7 +45,7 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 	};
 
 	auto fun = [&](std::vector<Type> args, Type res) {
-		return this->core().fun(args, res);
+		return this->core().fun(std::move(args), res);
 	};
 
 	declare_builtin_value("print", forall_a(a));

--- a/src/typechecker/typechecker.cpp
+++ b/src/typechecker/typechecker.cpp
@@ -34,7 +34,7 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 
 	auto array_a = core().array(a);
 
-	auto array_int = core().array(mono_int());
+	auto array_int = core().array(integer());
 
 	auto forall_a = [&](Type t) {
 		return this->core().forall({aid}, t);
@@ -50,11 +50,11 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 
 	declare_builtin_value("print", forall_a(a));
 
-	declare_builtin_value("array_append", forall_a(fun({array_a, a}, mono_unit())));
+	declare_builtin_value("array_append", forall_a(fun({array_a, a}, unit())));
 	declare_builtin_value("array_extend", forall_a(fun({array_a, array_a}, array_a)));
-	declare_builtin_value("array_join",   mono(fun({array_int, mono_string()}, mono_string())));
-	declare_builtin_value("array_at",     forall_a(fun({array_a, mono_int()}, a)));
-	declare_builtin_value("size",         forall_a(fun({array_a}, mono_int())));
+	declare_builtin_value("array_join",   mono(fun({array_int, string()}, string())));
+	declare_builtin_value("array_at",     forall_a(fun({array_a, integer()}, a)));
+	declare_builtin_value("size",         forall_a(fun({array_a}, integer())));
 
 	declare_builtin_value("+", forall_a(fun({a, a}, a)));
 	declare_builtin_value("-", forall_a(fun({a, a}, a)));
@@ -63,20 +63,20 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 	declare_builtin_value(".", forall_a(fun({a, a}, a)));
 	declare_builtin_value("=", forall_a(fun({a, a}, a)));
 
-	declare_builtin_value("<",  forall_a(fun({a, a}, mono_boolean())));
-	declare_builtin_value(">=", forall_a(fun({a, a}, mono_boolean())));
-	declare_builtin_value(">",  forall_a(fun({a, a}, mono_boolean())));
-	declare_builtin_value("<=", forall_a(fun({a, a}, mono_boolean())));
-	declare_builtin_value("==", forall_a(fun({a, a}, mono_boolean())));
-	declare_builtin_value("!=", forall_a(fun({a, a}, mono_boolean())));
+	declare_builtin_value("<",  forall_a(fun({a, a}, boolean())));
+	declare_builtin_value(">=", forall_a(fun({a, a}, boolean())));
+	declare_builtin_value(">",  forall_a(fun({a, a}, boolean())));
+	declare_builtin_value("<=", forall_a(fun({a, a}, boolean())));
+	declare_builtin_value("==", forall_a(fun({a, a}, boolean())));
+	declare_builtin_value("!=", forall_a(fun({a, a}, boolean())));
 
-	declare_builtin_value("&&", mono(fun({mono_boolean(), mono_boolean()}, mono_boolean())));
-	declare_builtin_value("||", mono(fun({mono_boolean(), mono_boolean()}, mono_boolean())));
+	declare_builtin_value("&&", mono(fun({boolean(), boolean()}, boolean())));
+	declare_builtin_value("||", mono(fun({boolean(), boolean()}, boolean())));
 
-	declare_builtin_value("read_integer", mono(fun({}, mono_int())));
-	declare_builtin_value("read_number",  mono(fun({}, mono_float())));
-	declare_builtin_value("read_string",  mono(fun({}, mono_string())));
-	declare_builtin_value("read_line",    mono(fun({}, mono_string())));
+	declare_builtin_value("read_integer", mono(fun({}, integer())));
+	declare_builtin_value("read_number",  mono(fun({}, number())));
+	declare_builtin_value("read_string",  mono(fun({}, string())));
+	declare_builtin_value("read_line",    mono(fun({}, string())));
 
 	declare_builtin_typefunc("int",     BuiltinType::Int);
 	declare_builtin_typefunc("float",   BuiltinType::Float);
@@ -113,23 +113,23 @@ void TypeChecker::declare_builtin_value(InternedString const& name, PolyId poly_
 	decl->m_meta_type = MetaType::Term;
 }
 
-Type TypeChecker::mono_int() {
+Type TypeChecker::integer() {
 	return Type(0);
 }
 
-Type TypeChecker::mono_float() {
+Type TypeChecker::number() {
 	return Type(1);
 }
 
-Type TypeChecker::mono_string() {
+Type TypeChecker::string() {
 	return Type(2);
 }
 
-Type TypeChecker::mono_boolean() {
+Type TypeChecker::boolean() {
 	return Type(3);
 }
 
-Type TypeChecker::mono_unit() {
+Type TypeChecker::unit() {
 	return Type(4);
 }
 

--- a/src/typechecker/typechecker.hpp
+++ b/src/typechecker/typechecker.hpp
@@ -27,11 +27,11 @@ struct TypeChecker {
 
 	Type new_var();
 
-	Type mono_int();
-	Type mono_float();
-	Type mono_string();
-	Type mono_boolean();
-	Type mono_unit();
+	Type integer();
+	Type number();
+	Type string();
+	Type boolean();
+	Type unit();
 
 	TypeSystemCore& core() { return m_core; }
 


### PR DESCRIPTION
This is only a proposal, I was thinking about creating a custom micro-language to write things like `\/a. a`, because a class manage this may be too much for our use case... so this is just a simplification of what we already have.

Edit: further changes can be made to the idea, I was just experimenting.