### PR TITLE
Assignment refactor

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -194,6 +194,14 @@ struct CallExpression : public Expr {
 	    : Expr {ExprTag::CallExpression} {}
 };
 
+struct AssignmentExpression : public Expr {
+	Expr* m_target;
+	Expr* m_value;
+
+	AssignmentExpression()
+		: Expr {ExprTag::AssignmentExpression} {}
+};
+
 struct IndexExpression : public Expr {
 	Expr* m_callee;
 	Expr* m_index;

--- a/src/ast_tag.hpp
+++ b/src/ast_tag.hpp
@@ -11,6 +11,7 @@
 	/* All before this point are literals */                                   \
 	X(Identifier)                                                              \
 	X(CallExpression)                                                          \
+	X(AssignmentExpression)                                                    \
 	X(IndexExpression)                                                         \
 	X(AccessExpression)                                                        \
 	X(MatchExpression)                                                         \

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -31,6 +31,12 @@ void compute_offsets(AST::CallExpression* ast, int frame_offset) {
 		compute_offsets(arg, frame_offset++);
 }
 
+void compute_offsets(AST::AssignmentExpression* ast, int frame_offset) {
+	frame_offset++; // TODO: delete
+	compute_offsets(ast->m_target, frame_offset++);
+	compute_offsets(ast->m_value, frame_offset++);
+}
+
 void compute_offsets(AST::FunctionLiteral* ast, int frame_offset) {
 	// functions start a new frame
 	frame_offset = 0;
@@ -199,6 +205,7 @@ void compute_offsets(AST::Expr* ast, int frame_offset) {
 		DISPATCH(Identifier);
 		DISPATCH(IndexExpression);
 		DISPATCH(CallExpression);
+		DISPATCH(AssignmentExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(AccessExpression);
 		DISPATCH(MatchExpression);

--- a/src/compute_offsets.cpp
+++ b/src/compute_offsets.cpp
@@ -32,7 +32,6 @@ void compute_offsets(AST::CallExpression* ast, int frame_offset) {
 }
 
 void compute_offsets(AST::AssignmentExpression* ast, int frame_offset) {
-	frame_offset++; // TODO: delete
 	compute_offsets(ast->m_target, frame_offset++);
 	compute_offsets(ast->m_value, frame_offset++);
 }

--- a/src/convert_ast.cpp
+++ b/src/convert_ast.cpp
@@ -106,13 +106,20 @@ static CallExpression* convert_pizza(CST::BinaryExpression* cst, Allocator& allo
 }
 
 // convert binary operators into calls
-static CallExpression* convert(CST::BinaryExpression* cst, Allocator& alloc) {
+static Expr* convert(CST::BinaryExpression* cst, Allocator& alloc) {
 	if (cst->m_op_token->m_type == TokenTag::PIZZA)
 		return convert_pizza(cst, alloc);
 
 	if (cst->m_op_token->m_type == TokenTag::DOT)
 		Log::fatal("found '.' used as a binary operator");
 	
+	if (cst->m_op_token->m_type == TokenTag::ASSIGN) {
+		auto ast = alloc.make<AssignmentExpression>();
+		ast->m_target = convert_expr(cst->m_lhs, alloc);
+		ast->m_value = convert_expr(cst->m_rhs, alloc);
+		return ast;
+	}
+
 	auto ast = alloc.make<CallExpression>();
 
 	auto identifier = alloc.make<Identifier>();

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -119,27 +119,15 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 }
 
 void eval(AST::AssignmentExpression* ast, Interpreter& e) {
-
-	e.m_stack.push(e.null());
-
-	auto callee = e.global_access("=")->m_value;
-	assert(is_callable_type(callee.type()));
-
 	eval(ast->m_target, e);
 	eval(ast->m_value, e);
 
-	e.m_stack.start_frame(2);
+	auto value = e.m_stack.pop_unsafe();
+	auto target = e.m_stack.pop_unsafe();
 
-	auto callee_fn = callee.get_native_func();
-	auto args = e.m_stack.frame_range(0, 2);
+	e.assign(target, value);
 
-	auto result = callee_fn(args, e);
-
-	e.m_stack.push(result);
-
-	e.m_stack.frame_at(-1) = e.m_stack.pop_unsafe();
-
-	e.m_stack.end_frame();
+	e.m_stack.push(e.null());
 }
 
 void eval(AST::IndexExpression* ast, Interpreter& e) {

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -258,11 +258,6 @@ Value value_less_or_equal(ArgsType v, Interpreter& e) {
 	return Value {bool(!b)};
 }
 
-Value value_assign(ArgsType v, Interpreter& e) {
-	e.assign(v[0], v[1]);
-	return e.null();
-}
-
 Value read_integer(ArgsType v, Interpreter& e) {
 	// TODO: error handling
 	int result;
@@ -310,7 +305,6 @@ void declare_native_functions(Interpreter& env) {
 	declare(">=", value_greater_or_equal);
 	declare(">", value_greater);
 	declare("<=", value_less_or_equal);
-	declare("=", value_assign);
 	declare("==", value_equals);
 	declare("!=", value_not_equals);
 	declare("^^", value_logicxor);

--- a/src/symbol_resolution.cpp
+++ b/src/symbol_resolution.cpp
@@ -139,6 +139,12 @@ private:
 		return {};
 	}
 
+	[[nodiscard]] ErrorReport resolve(AST::AssignmentExpression* ast) {
+		CHECK_AND_RETURN(resolve(ast->m_target));
+		CHECK_AND_RETURN(resolve(ast->m_value));
+		return {};
+	}
+
 	[[nodiscard]] ErrorReport resolve(AST::FunctionLiteral* ast) {
 
 		ast->m_surrounding_function = functions.current();
@@ -346,6 +352,7 @@ private:
 			DISPATCH(Identifier);
 			DISPATCH(IndexExpression);
 			DISPATCH(CallExpression);
+			DISPATCH(AssignmentExpression);
 			DISPATCH(TernaryExpression);
 			DISPATCH(AccessExpression);
 			DISPATCH(MatchExpression);

--- a/src/typechecker/ct_eval.cpp
+++ b/src/typechecker/ct_eval.cpp
@@ -55,6 +55,12 @@ static void ct_eval(AST::CallExpression* ast, TypeChecker& tc) {
 		ct_eval(arg, tc);
 }
 
+static void ct_eval(AST::AssignmentExpression* ast, TypeChecker& tc) {
+	ct_eval(ast->m_target, tc);
+	ct_eval(ast->m_value, tc);
+}
+
+
 static void ct_eval(AST::IndexExpression* ast, TypeChecker& tc) {
 	ct_eval(ast->m_callee, tc);
 	ct_eval(ast->m_index, tc);
@@ -388,6 +394,7 @@ static void ct_eval(AST::Expr* ast, TypeChecker& tc) {
 		DISPATCH(Identifier);
 		DISPATCH(FunctionLiteral);
 		DISPATCH(CallExpression);
+		DISPATCH(AssignmentExpression);
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(AccessExpression);

--- a/src/typechecker/metacheck.cpp
+++ b/src/typechecker/metacheck.cpp
@@ -85,6 +85,7 @@ static MetaType infer_shallow(AST::Expr* ast) {
 	case ExprTag::NullLiteral:
 	case ExprTag::FunctionLiteral:
 	case ExprTag::CallExpression:
+	case ExprTag::AssignmentExpression:
 	case ExprTag::IndexExpression:
 	case ExprTag::MatchExpression:
 	case ExprTag::TernaryExpression:
@@ -167,6 +168,12 @@ static MetaType infer(AST::CallExpression* ast) {
 	for (auto arg : ast->m_args) {
 		check(arg, MetaType::Term);
 	}
+	return ast->m_meta_type = infer_shallow(ast);
+}
+
+static MetaType infer(AST::AssignmentExpression* ast) {
+	check(ast->m_target, MetaType::Term);
+	check(ast->m_value, MetaType::Term);
 	return ast->m_meta_type = infer_shallow(ast);
 }
 
@@ -301,6 +308,7 @@ static MetaType infer(AST::Expr* ast) {
 	case ExprTag::NullLiteral: return infer(static_cast<AST::NullLiteral*>(ast));
 	case ExprTag::FunctionLiteral: return infer(static_cast<AST::FunctionLiteral*>(ast));
 	case ExprTag::CallExpression: return infer(static_cast<AST::CallExpression*>(ast));
+	case ExprTag::AssignmentExpression: return infer(static_cast<AST::AssignmentExpression*>(ast));
 	case ExprTag::IndexExpression: return infer(static_cast<AST::IndexExpression*>(ast));
 	case ExprTag::MatchExpression: return infer(static_cast<AST::MatchExpression*>(ast));
 	case ExprTag::TernaryExpression: return infer(static_cast<AST::TernaryExpression*>(ast));
@@ -312,7 +320,7 @@ static MetaType infer(AST::Expr* ast) {
 	case ExprTag::AccessExpression: return infer(static_cast<AST::AccessExpression*>(ast));
 	case ExprTag::Identifier: return infer(static_cast<AST::Identifier*>(ast));
 	case ExprTag::BuiltinTypeFunction:
-		Log::fatal() << "unexpected AST type in infer_shallow ("
+		Log::fatal() << "unexpected AST type in infer ("
 		             << AST::expr_string[int(ast->type())] << ") during infer";
 	}
 }

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -156,6 +156,16 @@ static void infer(AST::CallExpression* ast, TypecheckHelper& tc) {
 	ast->m_value_type = result_type;
 }
 
+
+static void infer(AST::AssignmentExpression* ast, TypecheckHelper& tc) {
+	infer(ast->m_target, tc);
+	infer(ast->m_value, tc);
+
+	tc.unify(ast->m_target->m_value_type, ast->m_value->m_value_type);
+
+	ast->m_value_type = ast->m_value->m_value_type;
+}
+
 // Implements [Abs] rule, extended for functions with multiple arguments
 static void infer(AST::FunctionLiteral* ast, TypecheckHelper& tc) {
 	tc.new_nested_scope();
@@ -425,6 +435,7 @@ static void infer(AST::Expr* ast, TypecheckHelper& tc) {
 
 		DISPATCH(Identifier);
 		DISPATCH(CallExpression);
+		DISPATCH(AssignmentExpression);
 		DISPATCH(IndexExpression);
 		DISPATCH(TernaryExpression);
 		DISPATCH(AccessExpression);

--- a/src/typechecker/typechecker.cpp
+++ b/src/typechecker/typechecker.cpp
@@ -61,7 +61,6 @@ TypeChecker::TypeChecker(AST::Allocator& allocator)
 	declare_builtin_value("*", forall_a(fun({a, a}, a)));
 	declare_builtin_value("/", forall_a(fun({a, a}, a)));
 	declare_builtin_value(".", forall_a(fun({a, a}, a)));
-	declare_builtin_value("=", forall_a(fun({a, a}, a)));
 
 	declare_builtin_value("<",  forall_a(fun({a, a}, boolean())));
 	declare_builtin_value(">=", forall_a(fun({a, a}, boolean())));


### PR DESCRIPTION
This change lays the groundwork to stop using `Reference`s to implement assignments. `References` should only be necessary for local variables that are captured by a lambda (but using them for all local variables, to avoid the complexity of handling two different cases, would be reasonable), using them to store array elements is a total hack.

I implemented this by just copy-pasting the original `CallExpression` code path that assignments currently use, inlining a bunch of stuff, replacing lookups and intermediate data structures for things that we can know statically and then applying some general simplifications.

So, the goal was to make the interpreter simpler in the future, but assignment-heavy code also got faster as a side-effect. The base10 counter microbenchmark (see below) goes from 2.92s to 2.45s (16% less) and the base2 counter (see below) goes from 1.22s to 1.08s (11% less).

base10 counter (7 nested loops):

```
fn __invoke() {
	cnt := 0;
	for (i1 := 0; i1 < 10; i1 = i1 + 1) {
		// ... etc ...
		for (i7 := 0; i7 < 10; i7 = i7 + 1) {
			cnt = cnt + 1;
		}
		// ... etc ...
	}
	return cnt; // returns 10^7
};
```

base2 counter (21 nested loops):

```
fn __invoke() {
	cnt := 0;
	for (i1 := 0; i1 < 2; i1 = i1 + 1) {
		// ... etc ...
		for (i21 := 0; i21 < 2; i21 = i21 + 1) {
			cnt = cnt + 1;
		}
		// ... etc ...
	}
	return cnt; // returns 2^21
};
```