### PR TITLE
Remove references from arrays

### DIFF
--- a/src/interpreter/bytecode.cpp
+++ b/src/interpreter/bytecode.cpp
@@ -86,14 +86,14 @@ static int decode(char const* stream, Interpreter::Interpreter& e) {
 	}
 	case Instruction::Tag::GetGlobal: {
 		auto op = static_cast<GetGlobal const*>(punned);
-		e.m_stack.push(Interpreter::Value{e.global_access(op->m_name)});
+		e.m_stack.push(value_of(Interpreter::Value{e.global_access(op->m_name)}));
 		return sizeof(*op);
 	}
 	case Instruction::Tag::Call: {
 		auto op = static_cast<Call const*>(punned);
 		int argument_count = op->m_argument_count;
 
-		auto callee = value_of(e.m_stack.access(argument_count));
+		auto callee = e.m_stack.access(argument_count);
 
 		e.m_stack.start_frame(argument_count);
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -82,9 +82,9 @@ void eval(AST::Identifier* ast, Interpreter& e) {
 	    ast->m_origin == AST::Identifier::Origin::Capture) {
 		if (ast->m_frame_offset == INT_MIN)
 			Log::fatal() << "missing layout for identifier '" << ast->text() << "'";
-		e.m_stack.push(e.m_stack.frame_at(ast->m_frame_offset));
+		e.m_stack.push(value_of(e.m_stack.frame_at(ast->m_frame_offset)));
 	} else {
-		e.m_stack.push(Value{e.global_access(ast->text())});
+		e.m_stack.push(value_of(Value{e.global_access(ast->text())}));
 	}
 };
 

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -119,15 +119,29 @@ void eval(AST::CallExpression* ast, Interpreter& e) {
 }
 
 void eval(AST::AssignmentExpression* ast, Interpreter& e) {
-	eval(ast->m_target, e);
-	eval(ast->m_value, e);
+	if (ast->m_target->type() == ExprTag::Identifier) {
+		eval(ast->m_target, e);
+		eval(ast->m_value, e);
 
-	auto value = e.m_stack.pop_unsafe();
-	auto target = e.m_stack.pop_unsafe();
+		auto value = e.m_stack.pop_unsafe();
+		auto target = e.m_stack.pop_unsafe();
 
-	e.assign(target, value);
+		e.assign(target, value);
 
-	e.m_stack.push(e.null());
+		e.m_stack.push(e.null());
+	} else if (ast->m_target->type() == ExprTag::IndexExpression) {
+		eval(ast->m_target, e);
+		eval(ast->m_value, e);
+
+		auto value = e.m_stack.pop_unsafe();
+		auto target = e.m_stack.pop_unsafe();
+
+		e.assign(target, value);
+
+		e.m_stack.push(e.null());
+	} else {
+		assert(0);
+	}
 }
 
 void eval(AST::IndexExpression* ast, Interpreter& e) {

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -134,7 +134,7 @@ void eval(AST::AssignmentExpression* ast, Interpreter& e) {
 		eval(ast->m_value, e);
 		auto value = e.m_stack.pop_unsafe();
 
-		e.assign(target, value);
+		target.get_cast<Reference>()->m_value = value_of(value);
 
 		e.m_stack.push(e.null());
 	} else if (ast->m_target->type() == ExprTag::IndexExpression) {

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -61,9 +61,7 @@ void eval(AST::ArrayLiteral* ast, Interpreter& e) {
 	result->m_value.reserve(ast->m_elements.size());
 	for (auto& element : ast->m_elements) {
 		eval(element, e);
-		auto ref = e.new_reference(Value {nullptr});
-		ref->m_value = value_of(e.m_stack.pop_unsafe());
-		result->append(ref.get());
+		result->append(e.m_stack.pop_unsafe());
 	}
 	e.m_stack.push(result.as_value());
 }
@@ -154,8 +152,7 @@ void eval(AST::AssignmentExpression* ast, Interpreter& e) {
 		auto callee_ptr = e.m_stack.pop_unsafe();
 		auto* callee = value_as<Array>(callee_ptr);
 
-		auto ref = e.new_reference(value);
-		callee->m_value[index] = ref.get();
+		callee->m_value[index] = value;
 
 		e.m_stack.push(e.null());
 	} else {
@@ -174,7 +171,7 @@ void eval(AST::IndexExpression* ast, Interpreter& e) {
 	auto callee_ptr = e.m_stack.pop_unsafe();
 	auto* callee = value_as<Array>(callee_ptr);
 
-	e.m_stack.push(Value{callee->at(index)});
+	e.m_stack.push(callee->at(index));
 };
 
 void eval(AST::TernaryExpression* ast, Interpreter& e) {

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -144,21 +144,18 @@ void eval(AST::AssignmentExpression* ast, Interpreter& e) {
 		auto target_ast = static_cast<AST::IndexExpression*>(ast->m_target);
 
 		eval(target_ast->m_callee, e);
+
 		eval(target_ast->m_index, e);
-
 		auto index = value_of(e.m_stack.pop_unsafe()).get_integer();
-
-		auto callee_ptr = e.m_stack.pop_unsafe();
-		auto* callee = value_as<Array>(callee_ptr);
-
-		e.m_stack.push(Value{callee->at(index)});
 
 		eval(ast->m_value, e);
 
 		auto value = e.m_stack.pop_unsafe();
-		auto target = e.m_stack.pop_unsafe();
+		auto callee_ptr = e.m_stack.pop_unsafe();
+		auto* callee = value_as<Array>(callee_ptr);
 
-		e.assign(target, value);
+		auto ref = e.new_reference(value);
+		callee->m_value[index] = ref.get();
 
 		e.m_stack.push(e.null());
 	} else {

--- a/src/interpreter/execute.cpp
+++ b/src/interpreter/execute.cpp
@@ -113,7 +113,7 @@ Value eval_expression(
 	// TODO?: return a gc_ptr
 	eval(ast, env);
 	auto value = env.m_stack.pop_unsafe();
-	return value_of(value);
+	return value;
 }
 
 } // namespace Interpreter

--- a/src/interpreter/gc_cell.cpp
+++ b/src/interpreter/gc_cell.cpp
@@ -30,7 +30,7 @@ static void gc_visit(Array* l) {
 		return;
 
 	l->m_visited = true;
-	for (auto* child : l->m_value) {
+	for (auto child : l->m_value) {
 		gc_visit(child);
 	}
 }

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -56,12 +56,6 @@ Value Interpreter::fetch_return_value() {
 	return rv;
 }
 
-void Interpreter::assign(Value dst, Value src) {
-	// NOTE: copied by reference, matters if rhs is actually a reference
-	// TODO: change in another pr, perhaps adding Interpreter::copy_value?
-	dst.get_cast<Reference>()->m_value = value_of(src);
-}
-
 
 void Interpreter::run_gc() {
 	m_gc->unmark_all();

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -51,7 +51,6 @@ struct Interpreter {
 	void global_declare_direct(const Identifier& i, Reference* v);
 	void global_declare(const Identifier& i, Value v);
 	Reference* global_access(const Identifier& i);
-	void assign(Value dst, Value src);
 
 	auto null() -> Value;
 	void push_integer(int);

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -33,7 +33,7 @@ Value array_append(ArgsType v, Interpreter& e) {
 	assert(v.size() > 0);
 	Array* array = value_as<Array>(v[0]);
 	for (unsigned int i = 1; i < v.size(); i++) {
-		array->append(value_of(v[i]));
+		array->append(v[i]);
 	}
 	return Value {array};
 }
@@ -87,8 +87,8 @@ Value array_at(ArgsType v, Interpreter& e) {
 }
 
 Value value_add(ArgsType v, Interpreter& e) {
-	auto lhs = value_of(v[0]);
-	auto rhs = value_of(v[1]);
+	auto lhs = v[0];
+	auto rhs = v[1];
 
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
@@ -106,8 +106,8 @@ Value value_add(ArgsType v, Interpreter& e) {
 }
 
 Value value_sub(ArgsType v, Interpreter& e) {
-	auto lhs = value_of(v[0]);
-	auto rhs = value_of(v[1]);
+	auto lhs = v[0];
+	auto rhs = v[1];
 
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
@@ -123,8 +123,8 @@ Value value_sub(ArgsType v, Interpreter& e) {
 }
 
 Value value_mul(ArgsType v, Interpreter& e) {
-	auto lhs = value_of(v[0]);
-	auto rhs = value_of(v[1]);
+	auto lhs = v[0];
+	auto rhs = v[1];
 
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
@@ -140,8 +140,8 @@ Value value_mul(ArgsType v, Interpreter& e) {
 }
 
 Value value_div(ArgsType v, Interpreter& e) {
-	auto lhs = value_of(v[0]);
-	auto rhs = value_of(v[1]);
+	auto lhs = v[0];
+	auto rhs = v[1];
 
 	assert(lhs.type() == rhs.type());
 	switch (lhs.type()) {
@@ -157,8 +157,8 @@ Value value_div(ArgsType v, Interpreter& e) {
 }
 
 Value value_logicand(ArgsType v, Interpreter& e) {
-	auto lhs = value_of(v[0]);
-	auto rhs = value_of(v[1]);
+	auto lhs = v[0];
+	auto rhs = v[1];
 
 	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
 		return OP_(as_boolean, lhs, &&, rhs);
@@ -169,8 +169,8 @@ Value value_logicand(ArgsType v, Interpreter& e) {
 }
 
 Value value_logicor(ArgsType v, Interpreter& e) {
-	auto lhs = value_of(v[0]);
-	auto rhs = value_of(v[1]);
+	auto lhs = v[0];
+	auto rhs = v[1];
 
 	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
 		return OP_(as_boolean, lhs, ||, rhs);
@@ -181,8 +181,8 @@ Value value_logicor(ArgsType v, Interpreter& e) {
 }
 
 Value value_logicxor(ArgsType v, Interpreter& e) {
-	auto lhs = value_of(v[0]);
-	auto rhs = value_of(v[1]);
+	auto lhs = v[0];
+	auto rhs = v[1];
 
 	if (lhs.type() == ValueTag::Boolean and rhs.type() == ValueTag::Boolean)
 		return OP_(as_boolean, lhs, !=, rhs);
@@ -193,8 +193,8 @@ Value value_logicxor(ArgsType v, Interpreter& e) {
 }
 
 Value value_equals(ArgsType v, Interpreter& e) {
-	auto lhs = value_of(v[0]);
-	auto rhs = value_of(v[1]);
+	auto lhs = v[0];
+	auto rhs = v[1];
 
 	assert(lhs.type() == rhs.type());
 
@@ -224,8 +224,8 @@ Value value_not_equals(ArgsType v, Interpreter& e) {
 }
 
 Value value_less(ArgsType v, Interpreter& e) {
-	auto lhs = value_of(v[0]);
-	auto rhs = value_of(v[1]);
+	auto lhs = v[0];
+	auto rhs = v[1];
 
 	assert(lhs.type() == rhs.type());
 

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -33,7 +33,7 @@ Value array_append(ArgsType v, Interpreter& e) {
 	assert(v.size() > 0);
 	Array* array = value_as<Array>(v[0]);
 	for (unsigned int i = 1; i < v.size(); i++) {
-		array->append(e.new_reference(value_of(v[i])).get());
+		array->append(value_of(v[i]));
 	}
 	return Value {array};
 }
@@ -70,7 +70,7 @@ Value array_join(ArgsType v, Interpreter& e) {
 	std::stringstream result;
 	for (unsigned int i = 0; i < array->m_value.size(); i++) {
 		if (i > 0) result << sep->m_value;
-		result << array->m_value[i]->m_value.get_integer();
+		result << array->m_value[i].get_integer();
 	}
 	return Value{e.m_gc->new_string_raw(result.str())};
 }

--- a/src/interpreter/utils.cpp
+++ b/src/interpreter/utils.cpp
@@ -25,7 +25,7 @@ void eval_call_function(Function* callee, int arg_count, Interpreter& e) {
 
 	for (int i = 0; i < arg_count; ++i) {
 		auto ref = e.new_reference(Value {nullptr});
-		ref->m_value = value_of(e.m_stack.access(i));
+		ref->m_value = e.m_stack.access(i);
 		e.m_stack.access(i) = ref.as_value();
 	}
 

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -18,14 +18,14 @@ Array::Array(ArrayType l)
     : GcCell(ValueTag::Array)
     , m_value(std::move(l)) {}
 
-void Array::append(Reference* v) {
+void Array::append(Value v) {
 	m_value.push_back(v);
 }
 
-Reference* Array::at(int position) {
+Value Array::at(int position) {
 	if (position < 0 or position >= int(m_value.size())) {
 		// TODO: return RangeError
-		return nullptr;
+		return Value{nullptr};
 	} else {
 		return m_value[position];
 	}
@@ -147,7 +147,7 @@ static void print(NativeFunction* f, int d) {
 static void print(Array* l, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(l->type())] << '\n';
-	for (auto* child : l->m_value) {
+	for (auto child : l->m_value) {
 		print(child, d + 1);
 	}
 }

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -22,7 +22,7 @@ struct Value;
 using Identifier = InternedString;
 using StringType = std::string;
 using RecordType = std::unordered_map<Identifier, Value>;
-using ArrayType = std::vector<Reference*>;
+using ArrayType = std::vector<Value>;
 using FunctionType = AST::FunctionLiteral*;
 using NativeFunction = auto(Span<Value>, Interpreter&) -> Value;
 using CapturesType = std::vector<Reference*>;
@@ -128,8 +128,8 @@ struct Array : GcCell {
 	Array();
 	Array(ArrayType l);
 
-	void append(Reference* v);
-	Reference* at(int position);
+	void append(Value v);
+	Value at(int position);
 };
 
 struct Record : GcCell {


### PR DESCRIPTION
After special-casing assignment expressions, we no longer need to store array elements through a reference. The data structure and interacting with it became simpler, and that makes me happy.

To implement this, I inlined `eval(Identifier)` and `eval(IndexExpression)` into `eval(AssignmentExpression)` and touched them up by hand. I admit it is a bit ugly, but they really are doing different things.

As a bonus, this makes some things even faster. This fibonacci benchmark goes from 1.41s before #333, to 1.34s after #333, to 1.03s now.

```
fn __invoke() {
	dp := array{};
	array_append(dp, 0);
	array_append(dp, 1);
	for (i := 0; i < 3000000; i = i+1) {
		array_append(dp, dp[i] + dp[i+1]);
	}
	return dp[3000001];
};
```

The base10 counter benchmark also got slightly faster (I'm guessing due to inlining). From 2.92s to 2.45s to 2.34s now.

```
fn __invoke() {
	cnt := 0;
	for (i1 := 0; i1 < 10; i1 = i1 + 1) {
		// ... etc ...
		for (i7 := 0; i7 < 10; i7 = i7 + 1) {
			cnt = cnt + 1;
		}
		// ... etc ...
	}
	return cnt; // returns 10^7
};
```

----------------

UPDATE: after special-casing assignment, we no longer use `Reference`s anywhere else in the interpreter, so we can have `eval(Identifier)` unwrap the reference itself instead of pushing it onto the stack.

This actually ensures an invariant: there are no temporary references on the stack, ever.

And we can exploit the invariant by removing all the `value_of` calls that were sprinkled throughout the codebase after reading a value from the stack.

Note that there are no _temporary_ references on the stack, but there are still some references. They store local variables and variables captured by lambdas.

-------------------

These changes tell me that `Reference` should really be named `Variable`, and that variables should live in a separate stack from temporaries. This would probably simplify the calling convention and `compute_offsets`.