### PR TITLE
Interpreter renamings

### DIFF
--- a/src/interpreter/bytecode.cpp
+++ b/src/interpreter/bytecode.cpp
@@ -86,7 +86,7 @@ static int decode(char const* stream, Interpreter::Interpreter& e) {
 	}
 	case Instruction::Tag::GetGlobal: {
 		auto op = static_cast<GetGlobal const*>(punned);
-		e.m_stack.push(value_of(Interpreter::Value{e.global_access(op->m_name)}));
+		e.m_stack.push(e.global_access(op->m_name)->m_value);
 		return sizeof(*op);
 	}
 	case Instruction::Tag::Call: {

--- a/src/interpreter/eval.cpp
+++ b/src/interpreter/eval.cpp
@@ -27,7 +27,7 @@ void run(AST::Program* ast, Interpreter& e) {
 	auto const& comps = *e.m_declaration_order;
 	for (auto const& comp : comps) {
 		for (auto decl : comp) {
-			auto ref = e.new_reference(e.null());
+			auto ref = e.new_variable(e.null());
 			e.global_declare_direct(decl->identifier_text(), ref.get());
 			eval(decl->m_value, e);
 			auto value = e.m_stack.pop_unsafe();
@@ -134,7 +134,7 @@ void eval(AST::AssignmentExpression* ast, Interpreter& e) {
 		eval(ast->m_value, e);
 		auto value = e.m_stack.pop_unsafe();
 
-		target.get_cast<Reference>()->m_value = value;
+		target.get_cast<Variable>()->m_value = value;
 
 		e.m_stack.push(e.null());
 	} else if (ast->m_target->type() == ExprTag::IndexExpression) {
@@ -194,7 +194,7 @@ void eval(AST::FunctionLiteral* ast, Interpreter& e) {
 		assert(capture.second.outer_frame_offset != INT_MIN);
 		auto value = e.m_stack.frame_at(capture.second.outer_frame_offset);
 		auto offset = capture.second.inner_frame_offset - ast->m_args.size();
-		captures[offset] = value.get_cast<Reference>();
+		captures[offset] = value.get_cast<Variable>();
 	}
 
 	auto result = e.new_function(ast, std::move(captures));
@@ -219,8 +219,8 @@ void eval(AST::MatchExpression* ast, Interpreter& e) {
 
 	// We won't pop it, because it is already lined up for the later
 	// expressions. Instead, replace the variant with its inner value.
-	// We also wrap it in a reference so it can be captured
-	auto ref = e.new_reference(Value {nullptr});
+	// We also wrap it in a variable so it can be captured
+	auto ref = e.new_variable(Value {nullptr});
 	ref->m_value = variant_value;
 	e.m_stack.access(0) = ref.as_value();
 	
@@ -295,7 +295,7 @@ void eval(AST::SequenceExpression* ast, Interpreter& e) {
 }
 
 static void exec(AST::Declaration* ast, Interpreter& e) {
-	auto ref = e.new_reference(Value {nullptr});
+	auto ref = e.new_variable(Value {nullptr});
 	e.m_stack.push(ref.as_value());
 	if (ast->m_value) {
 		eval(ast->m_value, e);

--- a/src/interpreter/garbage_collector.cpp
+++ b/src/interpreter/garbage_collector.cpp
@@ -94,8 +94,8 @@ gc_ptr<Error> GC::new_error(std::string s) {
 	return result;
 }
 
-gc_ptr<Reference> GC::new_reference(Value v) {
-	auto result = new Reference(std::move(v));
+gc_ptr<Variable> GC::new_variable(Value v) {
+	auto result = new Variable(std::move(v));
 	m_blocks.push_back(result);
 	return result;
 }

--- a/src/interpreter/garbage_collector.hpp
+++ b/src/interpreter/garbage_collector.hpp
@@ -31,7 +31,7 @@ struct GC {
 	auto new_string(std::string) -> gc_ptr<String>;
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
 	auto new_error(std::string) -> gc_ptr<Error>;
-	auto new_reference(Value) -> gc_ptr<Reference>;
+	auto new_variable(Value) -> gc_ptr<Variable>;
 
 	auto new_string_raw(std::string) -> String*;
 	auto new_variant_constructor_raw(InternedString) -> VariantConstructor*;

--- a/src/interpreter/gc_cell.cpp
+++ b/src/interpreter/gc_cell.cpp
@@ -61,7 +61,7 @@ static void gc_visit(Function* f) {
 		gc_visit(capture);
 }
 
-static void gc_visit(Reference* r) {
+static void gc_visit(Variable* r) {
 	if (r->m_visited)
 		return;
 
@@ -83,8 +83,8 @@ static void gc_visit(GcCell* v) {
 		return gc_visit(static_cast<Variant*>(v));
 	case ValueTag::Function:
 		return gc_visit(static_cast<Function*>(v));
-	case ValueTag::Reference:
-		return gc_visit(static_cast<Reference*>(v));
+	case ValueTag::Variable:
+		return gc_visit(static_cast<Variable*>(v));
 	case ValueTag::VariantConstructor:
 		return gc_visit(static_cast<VariantConstructor*>(v));
 	case ValueTag::RecordConstructor:

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -8,12 +8,12 @@
 
 namespace Interpreter {
 
-void Scope::declare(const Identifier& i, Reference* v) {
+void GlobalScope::declare(const Identifier& i, Variable* v) {
 	auto insertion_result = m_declarations.insert({i, v});
 	assert(insertion_result.second);
 }
 
-Reference* Scope::access(const Identifier& i) {
+Variable* GlobalScope::access(const Identifier& i) {
 	auto v = m_declarations.find(i);
 
 	if (v == m_declarations.end()) {
@@ -24,18 +24,17 @@ Reference* Scope::access(const Identifier& i) {
 	return v->second;
 }
 
-void Interpreter::global_declare_direct(const Identifier& i, Reference* r) {
+void Interpreter::global_declare_direct(const Identifier& i, Variable* r) {
 	m_global_scope.declare(i, r);
 }
 
 void Interpreter::global_declare(const Identifier& i, Value v) {
-	if (v.type() == ValueTag::Reference)
-		assert(0 && "declared a reference!");
-	auto r = new_reference(v);
+	assert(v.type() != ValueTag::Variable);
+	auto r = new_variable(v);
 	global_declare_direct(i, r.get());
 }
 
-Reference* Interpreter::global_access(const Identifier& i) {
+Variable* Interpreter::global_access(const Identifier& i) {
 	return m_global_scope.access(i);
 }
 
@@ -139,11 +138,9 @@ gc_ptr<Error> Interpreter::new_error(std::string e) {
 	return result;
 }
 
-gc_ptr<Reference> Interpreter::new_reference(Value v) {
-	assert(
-	    v.type() != ValueTag::Reference &&
-	    "References to references are not allowed.");
-	auto result = m_gc->new_reference(v);
+gc_ptr<Variable> Interpreter::new_variable(Value v) {
+	assert(v.type() != ValueTag::Variable);
+	auto result = m_gc->new_variable(v);
 	run_gc_if_needed();
 	return result;
 }

--- a/src/interpreter/interpreter.hpp
+++ b/src/interpreter/interpreter.hpp
@@ -19,11 +19,11 @@ namespace Interpreter {
 struct GC;
 struct Error;
 
-struct Scope {
-	std::map<InternedString, Reference*> m_declarations;
+struct GlobalScope {
+	std::map<InternedString, Variable*> m_declarations;
 
-	void declare(const Identifier& i, Reference* v);
-	Reference* access(const Identifier& i);
+	void declare(const Identifier& i, Variable* v);
+	Variable* access(const Identifier& i);
 };
 
 struct Interpreter {
@@ -33,7 +33,7 @@ struct Interpreter {
 	int m_gc_size_on_last_pass {64};
 	bool m_returning{false};
 	Value m_return_value {nullptr};
-	Scope m_global_scope;
+	GlobalScope m_global_scope;
 
 	Interpreter(
 	    GC* gc,
@@ -47,10 +47,10 @@ struct Interpreter {
 	void run_gc();
 	void run_gc_if_needed();
 
-	// Binds a global name to the given reference
-	void global_declare_direct(const Identifier& i, Reference* v);
+	// Binds a global name to the given variable
+	void global_declare_direct(const Identifier& i, Variable* v);
 	void global_declare(const Identifier& i, Value v);
-	Reference* global_access(const Identifier& i);
+	Variable* global_access(const Identifier& i);
 
 	auto null() -> Value;
 	void push_integer(int);
@@ -63,7 +63,7 @@ struct Interpreter {
 	auto new_record(RecordType) -> gc_ptr<Record>;
 	auto new_function(FunctionType, CapturesType) -> gc_ptr<Function>;
 	auto new_error(std::string) -> gc_ptr<Error>;
-	auto new_reference(Value) -> gc_ptr<Reference>;
+	auto new_variable(Value) -> gc_ptr<Variable>;
 };
 
 } // namespace Interpreter

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -31,7 +31,7 @@ Value print(ArgsType v, Interpreter& e) {
 Value array_append(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() > 0);
-	Array* array = value_as<Array>(v[0]);
+	Array* array = v[0].get_cast<Array>();
 	for (unsigned int i = 1; i < v.size(); i++) {
 		array->append(v[i]);
 	}
@@ -43,8 +43,8 @@ Value array_append(ArgsType v, Interpreter& e) {
 Value array_extend(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 2);
-	Array* arr1 = value_as<Array>(v[0]);
-	Array* arr2 = value_as<Array>(v[1]);
+	Array* arr1 = v[0].get_cast<Array>();
+	Array* arr2 = v[1].get_cast<Array>();
 	arr1->m_value.insert(
 	    arr1->m_value.end(), arr2->m_value.begin(), arr2->m_value.end());
 	return Value {arr1};
@@ -54,7 +54,7 @@ Value array_extend(ArgsType v, Interpreter& e) {
 Value size(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 1);
-	Array* array = value_as<Array>(v[0]);
+	Array* array = v[0].get_cast<Array>();
 
 	return Value {int(array->m_value.size())};
 }
@@ -65,8 +65,8 @@ Value array_join(ArgsType v, Interpreter& e) {
 	// TODO make it more general
 	// TODO proper error handling
 	assert(v.size() == 2);
-	Array* array = value_as<Array>(v[0]);
-	String* sep = value_as<String>(v[1]);
+	Array* array = v[0].get_cast<Array>();
+	String* sep = v[1].get_cast<String>();
 	std::stringstream result;
 	for (unsigned int i = 0; i < array->m_value.size(); i++) {
 		if (i > 0) result << sep->m_value;
@@ -79,7 +79,7 @@ Value array_join(ArgsType v, Interpreter& e) {
 Value array_at(ArgsType v, Interpreter& e) {
 	// TODO proper error handling
 	assert(v.size() == 2);
-	Array* array = value_as<Array>(v[0]);
+	Array* array = v[0].get_cast<Array>();
 	int index = v[1].get_integer();
 	assert(index >= 0);
 	assert(index < array->m_value.size());
@@ -290,6 +290,9 @@ void declare_native_functions(Interpreter& env) {
 	auto declare = [&](char const* name, NativeFunction* func) {
 		env.global_declare(name, Value {func});
 	};
+
+	env.global_declare("int", env.null());
+	env.global_declare("float", env.null());
 
 	declare("print", print);
 	declare("array_append", array_append);

--- a/src/interpreter/native.cpp
+++ b/src/interpreter/native.cpp
@@ -20,7 +20,7 @@ namespace Interpreter {
 
 using ArgsType = Span<Value>;
 
-// print(vals...) prints the values or references in vals
+// print(vals...) prints the values in vals
 Value print(ArgsType v, Interpreter& e) {
 	for (auto value : v)
 		print(value);

--- a/src/interpreter/utils.cpp
+++ b/src/interpreter/utils.cpp
@@ -8,19 +8,6 @@
 
 namespace Interpreter {
 
-Value value_of(Value h) {
-	if (!is_heap_type(h.type()))
-		return h;
-
-	if (h.type() != ValueTag::Variable)
-		return h;
-
-	// try unboxing recursively?
-	auto ref = h.get_cast<Variable>();
-	return ref->m_value;
-}
-
-
 void eval_call_function(Function* callee, int arg_count, Interpreter& e) {
 
 	for (int i = 0; i < arg_count; ++i) {

--- a/src/interpreter/utils.cpp
+++ b/src/interpreter/utils.cpp
@@ -12,11 +12,11 @@ Value value_of(Value h) {
 	if (!is_heap_type(h.type()))
 		return h;
 
-	if (h.type() != ValueTag::Reference)
+	if (h.type() != ValueTag::Variable)
 		return h;
 
 	// try unboxing recursively?
-	auto ref = h.get_cast<Reference>();
+	auto ref = h.get_cast<Variable>();
 	return ref->m_value;
 }
 
@@ -24,7 +24,7 @@ Value value_of(Value h) {
 void eval_call_function(Function* callee, int arg_count, Interpreter& e) {
 
 	for (int i = 0; i < arg_count; ++i) {
-		auto ref = e.new_reference(Value {nullptr});
+		auto ref = e.new_variable(Value {nullptr});
 		ref->m_value = e.m_stack.access(i);
 		e.m_stack.access(i) = ref.as_value();
 	}

--- a/src/interpreter/utils.hpp
+++ b/src/interpreter/utils.hpp
@@ -6,14 +6,6 @@
 
 namespace Interpreter {
 
-Value value_of(Value value);
-
-template<typename T>
-T* value_as(Value h) {
-	static_assert(std::is_base_of<GcCell, T>::value, "T is not a subclass of GcCell");
-	return value_of(h).get_cast<T>();
-}
-
 void eval_call_callable(Value callee, int arg_count, Interpreter&);
 
 } // namespace Interpreter

--- a/src/interpreter/value.cpp
+++ b/src/interpreter/value.cpp
@@ -65,8 +65,8 @@ Function::Function(FunctionType def, CapturesType captures)
     , m_def(def)
     , m_captures(std::move(captures)) {}
 
-Reference::Reference(Value value)
-    : GcCell {ValueTag::Reference}
+Variable::Variable(Value value)
+    : GcCell {ValueTag::Variable}
     , m_value {value} {}
 
 VariantConstructor::VariantConstructor(InternedString constructor)
@@ -152,7 +152,7 @@ static void print(Array* l, int d) {
 	}
 }
 
-static void print(Reference* l, int d) {
+static void print(Variable* l, int d) {
 	print_spaces(d);
 	std::cout << value_string[int(l->type())] << '\n';
 	print(l->m_value, d + 1);
@@ -183,8 +183,8 @@ static void print(GcCell* v, int d) {
 		return print(static_cast<Variant*>(v), d);
 	case ValueTag::Function:
 		return print(static_cast<Function*>(v), d);
-	case ValueTag::Reference:
-		return print(static_cast<Reference*>(v), d);
+	case ValueTag::Variable:
+		return print(static_cast<Variable*>(v), d);
 	case ValueTag::VariantConstructor:
 		return print(static_cast<VariantConstructor*>(v), d);
 	case ValueTag::RecordConstructor:

--- a/src/interpreter/value.hpp
+++ b/src/interpreter/value.hpp
@@ -16,7 +16,7 @@ struct FunctionLiteral;
 namespace Interpreter {
 
 struct Interpreter;
-struct Reference;
+struct Variable;
 struct Value;
 
 using Identifier = InternedString;
@@ -25,7 +25,7 @@ using RecordType = std::unordered_map<Identifier, Value>;
 using ArrayType = std::vector<Value>;
 using FunctionType = AST::FunctionLiteral*;
 using NativeFunction = auto(Span<Value>, Interpreter&) -> Value;
-using CapturesType = std::vector<Reference*>;
+using CapturesType = std::vector<Variable*>;
 
 inline bool is_heap_type(ValueTag tag) {
 	return tag != ValueTag::Null && tag != ValueTag::Boolean &&
@@ -157,10 +157,10 @@ struct Function : GcCell {
 	Function(FunctionType, CapturesType);
 };
 
-struct Reference : GcCell {
+struct Variable : GcCell {
 	Value m_value;
 
-	Reference(Value value);
+	Variable(Value value);
 };
 
 struct VariantConstructor : GcCell {
@@ -183,7 +183,7 @@ template<> struct type_data<Array> { static constexpr auto tag = ValueTag::Array
 template<> struct type_data<Record> { static constexpr auto tag = ValueTag::Record; };
 template<> struct type_data<Variant> { static constexpr auto tag = ValueTag::Variant; };
 template<> struct type_data<Function> { static constexpr auto tag = ValueTag::Function; };
-template<> struct type_data<Reference> { static constexpr auto tag = ValueTag::Reference; };
+template<> struct type_data<Variable> { static constexpr auto tag = ValueTag::Variable; };
 template<> struct type_data<VariantConstructor> { static constexpr auto tag = ValueTag::VariantConstructor; };
 template<> struct type_data<RecordConstructor> { static constexpr auto tag = ValueTag::RecordConstructor; };
 

--- a/src/interpreter/value_tag.hpp
+++ b/src/interpreter/value_tag.hpp
@@ -16,7 +16,7 @@
 	X(Function)                                                                \
 	X(NativeFunction)                                                          \
                                                                                \
-	X(Reference)                                                               \
+	X(Variable)                                                                \
                                                                                \
 	X(VariantConstructor)                                                      \
 	X(RecordConstructor)


### PR DESCRIPTION
I renamed `Reference` to `Variable` because now it's only used to store variables, and also `Scope` to `GlobalScope` for an analogous reason.

Then, I removed all usages of `value_of` and `value_as`, and deleted them from the codebase. This was possible because after #333 and #334, we statically know where unrapping is necessary and where it isn't.

I also tried to put variables and temporaries in different stacks but it turned out complicated, so I rolled it back. I think it can be done simply but I haven't figured out the right way.