### PR TITLE
Typechecker core refactor

### DIFF
--- a/src/typechecker/core.cpp
+++ b/src/typechecker/core.cpp
@@ -151,7 +151,7 @@ void TypeSystemCore::unify_type_function(TypeFunc i, TypeFunc j) {
 bool TypeSystemCore::occurs(VarId v, Type i) {
 
 	if (ll_is_var(i))
-		return equals_var(i, v);
+		return get_var_id(i) == v;
 
 	int ti = data(i).data_idx;
 	for (Type c : ll_term_data[ti].argument_idx)
@@ -277,11 +277,6 @@ TypeSystemCore::NodeHeader& TypeSystemCore::data(Type ty) {
 TypeSystemCore::TypeFunctionData& TypeSystemCore::data(TypeFunc tf) {
 	return m_type_functions[int(tf)];
 }
-
-bool TypeSystemCore::equals_var(Type t, VarId v) {
-	return ll_is_var(t) && get_var_id(t) == v;
-}
-
 
 void TypeSystemCore::add_record_constraint(VarId v) {
 	int i = static_cast<int>(v);

--- a/src/typechecker/core.hpp
+++ b/src/typechecker/core.hpp
@@ -132,7 +132,6 @@ private:
 	void gather_free_vars(Type, std::unordered_set<VarId>&);
 
 	Type inst_impl(Type mono, std::unordered_map<VarId, Type> const& mapping);
-	Type inst_with(PolyId poly, std::vector<Type> const& vals);
 	void unify_type_function(TypeFunc, TypeFunc);
 
 	bool ll_is_var(Type i);
@@ -148,11 +147,13 @@ private:
 
 	void establish_substitution(VarId var_id, Type type_id);
 
+	VarId get_representative_var_id(Type i);
 	bool occurs(VarId v, Type i);
 	bool equals_var(Type t, VarId v);
-	void unify_vars_left_to_right(VarId vi, VarId vj);
 	void combine_constraints_left_to_right(VarId vi, VarId vj);
 	bool satisfies(Type t, Constraint const& c);
+
+
 	// per-func data
 	std::vector<TypeFunctionData> m_type_functions;
 

--- a/src/typechecker/core.hpp
+++ b/src/typechecker/core.hpp
@@ -26,6 +26,8 @@ struct TypeSystemCore {
 
 	// types
 
+	Type apply_substitution(Type);
+
 	std::unordered_set<VarId> free_vars(Type);
 	void ll_unify(Type i, Type j);
 	TypeFunc type_function_of(Type);
@@ -132,8 +134,6 @@ private:
 	Type inst_impl(Type mono, std::unordered_map<VarId, Type> const& mapping);
 	Type inst_with(PolyId poly, std::vector<Type> const& vals);
 	void unify_type_function(TypeFunc, TypeFunc);
-
-	Type ll_find(Type i);
 
 	bool ll_is_var(Type i);
 	bool ll_is_term(Type i);

--- a/src/typechecker/core.hpp
+++ b/src/typechecker/core.hpp
@@ -149,7 +149,6 @@ private:
 
 	VarId get_representative_var_id(Type i);
 	bool occurs(VarId v, Type i);
-	bool equals_var(Type t, VarId v);
 	void combine_constraints_left_to_right(VarId vi, VarId vj);
 	bool satisfies(Type t, Constraint const& c);
 

--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -344,13 +344,10 @@ void typecheck_stmt(AST::IfElseStatement* ast) {
 }
 
 void typecheck_stmt(AST::WhileStatement* ast) {
-	// TODO: Why do while statements create a new scope?
-	new_nested_scope();
 	infer(ast->m_condition);
 	unify(ast->m_condition->m_value_type, boolean());
 
 	typecheck_stmt(ast->m_body);
-	end_scope();
 }
 
 void typecheck_stmt(AST::ReturnStatement* ast) {


### PR DESCRIPTION
Offline we talked about a new design for the typechecker core, and how it would require a rewrite, but it appears that the main difference is not necessarily reflected deeply in the implementation, but is rather a matter of perspective.

This perspective is that types are immutable data which must be brought up to date by `apply_substitution` before being examined, which returns a new type with all substitutions applied. The substitutions are decided through unification.

This is in contrast to the previous approach, where the abstraction was that `ll_unify` replaces every instance of a variable with its substitution, and `occurs`, `free_vars`, etc. all implicitly work on the most up to date version of a type.

(plus there is the stuff about how constraints are represented, but that can probably be changed later)

This also parallels the old implementation:

As an optimization, `ll_unify` would not replace the instances of a variable, but just write the substitution on a table, and all the other functions would have to apply pending substitutions on the fly (by calling `ll_find`, which is a shallow version of `apply_substitution`). This substitution table is now brought forward as a central piece of the algorithm.

`apply_substitution` will mutate types internally, but only as an optimization. This is possible because applying substitutions to a type which already has some substitutions applied yields the same result as applying them all in one go.

------------------

I got a bit greedy and also did some work in `typecheck.cpp`