### PR TITLE
Don't generalize local variables

### DIFF
--- a/src/typechecker/typecheck.cpp
+++ b/src/typechecker/typecheck.cpp
@@ -343,7 +343,6 @@ void typecheck_stmt(AST::Declaration* ast) {
 	// put a typevar in the decl to allow recursive definitions
 	ast->m_value_type = new_var();
 	process_contents(ast);
-	generalize(ast);
 	declare(ast);
 }
 
@@ -467,8 +466,6 @@ private:
 
 	Frontend::SymbolTable symbol_table;
 	TypeChecker& tc;
-
-
 };
 
 void typecheck_program(AST::Program* ast, TypeChecker& tc) {


### PR DESCRIPTION
Earlier today I read [Let Should not be Generalised, Vytiniotis et al, 2010](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tldi10-vytiniotis.pdf). This paper outlines a bunch of bugs that can crop up if you try to generalize local variables in languages with type constraints (like field constraints in Jasper).

Aparently, this can be fixed by either capturing ALL available constraints during generalization (even if the generalized variables don't occur in them) or by lots of annoying ad-hoc work. The alternative is to not generalize locals, which eliminates this problem with some loss of expressiveness, but doesn't matter too much in practice.

In the spirit of having a working type checker that runs decently fast somewhat soon, I have decided to go with the alternative. So as of now Jasper no longer has polymorphic local variables.